### PR TITLE
ci: instruct yarn to give cache priority and cache node_modules

### DIFF
--- a/.changeset/seven-cherries-try.md
+++ b/.changeset/seven-cherries-try.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+fix inconsistent unit test
+

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --prefer-offline --frozen-lockfile
 
       - name: Setup Storybook
         run: yarn storybook:setup

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -33,7 +33,9 @@ jobs:
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --prefer-offline --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm # Pushes to main will create/update the release PR. Merging the PR will publish the packages.
         id: changesets

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --prefer-offline --frozen-lockfile
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,6 +32,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Use Yarn Cache
+        if: steps.yarn-cache.outputs.cache-hit == 'true'
+        run: yarn --prefer-offline
+
       - name: Install Dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: yarn --frozen-lockfile

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache Browsers
         uses: actions/cache@v2
-        id: browser-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: browser-cache # use this to check for `cache-hit` (`steps.browser-cache.outputs.cache-hit != 'true'`)
         with:
           path: '~/.cache/ms-playwright'
           key: ${{ runner.os }}-browsers-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,13 +32,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Use Yarn Cache
-        if: steps.yarn-cache.outputs.cache-hit == 'true'
-        run: yarn --prefer-offline
-
       - name: Install Dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn --frozen-lockfile
+        run: yarn --prefer-offline --frozen-lockfile
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,8 +7,39 @@ on:
       - develop
 
 jobs:
-  verify:
-    name: Verify changes
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        run: yarn --prefer-offline --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,9 +76,6 @@ jobs:
 
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile
-
-      - name: Lint
-        run: yarn lint
 
       - name: Test
         run: yarn test

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,6 +32,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Cache Browsers
+        uses: actions/cache@v2
+        id: browser-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: '~/.cache/ms-playwright'
+          key: ${{ runner.os }}-browsers-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-browsers-
+
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            **/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,7 +33,8 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        run: yarn --prefer-offline --frozen-lockfile
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn --frozen-lockfile
 
       - name: Lint
         run: yarn lint

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache Browsers
         uses: actions/cache@v2
-        id: browser-cache # use this to check for `cache-hit` (`steps.browser-cache.outputs.cache-hit != 'true'`)
+        id: browsers-cache # use this to check for `cache-hit` (`steps.browsers-cache.outputs.cache-hit != 'true'`)
         with:
           path: '~/.cache/ms-playwright'
           key: ${{ runner.os }}-browsers-${{ hashFiles('**/yarn.lock') }}

--- a/.yarnrc
+++ b/.yarnrc
@@ -3,4 +3,3 @@
 
 
 registry "https://registry.yarnpkg.com"
---install.prefer-offline true

--- a/.yarnrc
+++ b/.yarnrc
@@ -3,3 +3,4 @@
 
 
 registry "https://registry.yarnpkg.com"
+--install.prefer-offline true

--- a/docs/development/conventions/creating-a-release.md
+++ b/docs/development/conventions/creating-a-release.md
@@ -26,7 +26,15 @@ This brings the set of changes onto the `main` branch for a stable release. If t
 
 ## Publishing a release
 
-After pushing the commits to `main`, the [Changesets action](https://github.com/changesets/action) will create a pull request, titled `Version Packages`, with all of the package versions updated and changelogs updated. This pull request will automatically update whenever new changesets are pushed to `main`. When you're ready, you can merge the pull request and the action will publish the new version to NPM for you.
+After pushing the commits to `main`, the [Changesets action](https://github.com/changesets/action) will create a pull request, titled `Version Packages`, with all of the package versions updated and changelogs updated. This pull request will automatically update whenever new changesets are pushed to `main`. When you're ready, you can merge the pull request and the action will publish the new versions to NPM for you. Lastly, the `main` branch's latest changes must be merged into the `develop` branch. It's important to do a fast-forward merge to avoid additional merge commits:
+
+```shell
+$ git checkout main
+$ git pull origin main
+$ git checkout develop
+$ git merge main --ff
+$ git push origin develop
+```
 
 ## Manually publishing a release
 
@@ -58,4 +66,4 @@ This publishes the newly-versioned packages to [npm](https://www.npmjs.com/) and
 $ git push --follow-tags
 ```
 
-The last step is to open a pull request from `main` to `develop` to pull in the updated version strings.
+The last step is to merge and push changes from `main` to `develop` to pull in the updated version strings.

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^6.0.0",
-    "lint-staged": "^10.5.3",
+    "lint-staged": "^11.0.0",
     "lit-analyzer": "^1.2.1",
     "markdown-toc": "^1.2.0",
     "postcss": "^8.2.4",

--- a/packages/pharos/src/components/sidenav/pharos-sidenav.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav.test.ts
@@ -1,4 +1,4 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import { html, fixture, expect, nextFrame } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import './pharos-sidenav';
 import './pharos-sidenav-section';
@@ -127,6 +127,7 @@ describe('pharos-sidenav', () => {
 
     await setViewport({ width: 1056, height: 768 });
     await component.updateComplete;
+    await nextFrame();
     expect(component.slide).to.be.false;
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6917,12 +6917,12 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
-commander@^6.1.0, commander@^6.2.0, commander@^6.2.1:
+commander@^6.1.0, commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
-commander@^7.0.0, commander@^7.1.0:
+commander@^7.0.0, commander@^7.1.0, commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
@@ -7350,7 +7350,7 @@ cross-fetch@3.1.4:
   dependencies:
     node-fetch "2.6.1"
 
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -7859,7 +7859,7 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@~4.3.1:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -9292,7 +9292,7 @@ execa@^3.4.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@^4.0.0, execa@^4.0.2, execa@^4.0.3, execa@^4.1.0:
+execa@^4.0.0, execa@^4.0.2, execa@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -9305,6 +9305,21 @@ execa@^4.0.0, execa@^4.0.2, execa@^4.0.3, execa@^4.1.0:
     npm-run-path "^4.0.0"
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
+execa@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
 execall@^2.0.0:
@@ -11984,6 +11999,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
 husky@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
@@ -13968,22 +13988,22 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.5.3:
-  version "10.5.4"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.4.tgz#cd153b5f0987d2371fc1d2847a409a2fe705b665"
-  integrity sha512-EechC3DdFic/TdOPgj/RB3FicqE6932LTHCUm0Y2fsD9KGlLB+RwJl2q1IYBIvEsKzDOgn0D4gll+YxG5RsrKg==
+lint-staged@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.0.0.tgz#24d0a95aa316ba28e257f5c4613369a75a10c712"
+  integrity sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==
   dependencies:
-    chalk "^4.1.0"
+    chalk "^4.1.1"
     cli-truncate "^2.1.0"
-    commander "^6.2.0"
+    commander "^7.2.0"
     cosmiconfig "^7.0.0"
-    debug "^4.2.0"
+    debug "^4.3.1"
     dedent "^0.7.0"
     enquirer "^2.3.6"
-    execa "^4.1.0"
-    listr2 "^3.2.2"
-    log-symbols "^4.0.0"
-    micromatch "^4.0.2"
+    execa "^5.0.0"
+    listr2 "^3.8.2"
+    log-symbols "^4.1.0"
+    micromatch "^4.0.4"
     normalize-path "^3.0.0"
     please-upgrade-node "^3.2.0"
     string-argv "0.3.1"
@@ -13999,10 +14019,10 @@ list-item@^1.1.1:
     is-number "^2.1.0"
     repeat-string "^1.5.2"
 
-listr2@^3.2.2:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.8.1.tgz#0237a8211962249db97828e5d704633f7c26c965"
-  integrity sha512-75vMLokDIEoZIXp3FE3P7U4yi7BRroZb7Az9+XBq+wGGnvq70QPT+BX41aSrROUMLuVan9l3aAjdeXWgaFyFEw==
+listr2@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.8.2.tgz#99b138ad1cfb08f1b0aacd422972e49b2d814b99"
+  integrity sha512-E28Fw7Zd3HQlCJKzb9a8C8M0HtFWQeucE+S8YrSrqZObuCLPRHMRrR8gNmYt65cU9orXYHwvN5agXC36lYt7VQ==
   dependencies:
     chalk "^4.1.1"
     cli-truncate "^2.1.0"
@@ -14314,7 +14334,7 @@ log-symbols@2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-log-symbols@^4.0.0, log-symbols@^4.1.0:
+log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -15615,7 +15635,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run-path@^4.0.0:
+npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
@@ -15849,7 +15869,7 @@ once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
By default, `yarn` always fetches dependencies from the network first before checking the cache. As a result we have not seen the full benefits of caching dependencies in our Github Actions builds. We can use `--prefer-offline` to tell Yarn to use the cache and only make network requests for anything missing from it. We should also cache `node_modules` to ensure Yarn does not fetch packages. This in combination with running linting and tests in parallel results in a reduction of one minute in average job duration.

**How does this change work?**

- Add `--prefer-offline` for yarn installs in our workflows
- Cache `node_modules`
- Cache Playwright browsers for test job
- Fix inconsistent unit test
- Run linting and tests in parallel