### PR TITLE
documentation: update component status table to show shadow only when 'stickied'

### DIFF
--- a/.changeset/spicy-cats-knock.md
+++ b/.changeset/spicy-cats-knock.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+update component status table header to only show drop shadow when stickied
+

--- a/packages/pharos-site/src/components/statics/component-status/StatusTable.module.css
+++ b/packages/pharos-site/src/components/statics/component-status/StatusTable.module.css
@@ -17,11 +17,16 @@
     var(--pharos-spacing-three-quarters-x) 0;
   text-align: left;
   position: sticky;
-  top: 0;
+  top: -1px;
   background: var(--pharos-color-white);
   min-width: 11rem;
-  box-shadow: 0 12px 19px rgba(229, 229, 229, 0.4);
   white-space: nowrap;
+  box-shadow: 0 0 0 rgba(229, 229, 229, 0);
+  transition: box-shadow var(--pharos-transition-duration-short) ease-in-out;
+}
+
+.stuck {
+  box-shadow: 0 12px 19px rgba(229, 229, 229, 0.4);
 }
 
 .status__description {

--- a/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
+++ b/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
@@ -79,6 +79,7 @@ const StatusTable: FC = () => {
     });
 
     setStateTable(allComponentStatuses);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [setStateTable, Pharos]);
 
   return (

--- a/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
+++ b/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
@@ -30,10 +30,6 @@ const StatusTable: FC = () => {
   const ref = createRef<HTMLTableCellElement>();
 
   useEffect(() => {
-    console.log(IsStuck);
-  }, [IsStuck]);
-
-  useEffect(() => {
     const { PharosLink } = Pharos;
 
     const cachedRef = ref.current;
@@ -47,7 +43,6 @@ const StatusTable: FC = () => {
       }
     );
     if (cachedRef) {
-      console.log('observing');
       observer.observe(cachedRef);
     }
 

--- a/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
+++ b/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, createRef } from 'react';
 import type { FC, ReactElement } from 'react';
 import StatusIcon from './StatusIcon';
 import {
@@ -7,6 +7,7 @@ import {
   status__description,
   table,
   table__header,
+  stuck,
 } from './StatusTable.module.css';
 import legend from '../../../pages/components/component-status/legend.json';
 import statuses from '../../../pages/components/component-status/status.json';
@@ -19,14 +20,36 @@ const toCamelCase = (str: string) => {
 
 const StatusTable: FC = () => {
   const [StateTable, setStateTable] = useState<ReactElement[] | null>(null);
+  const [IsStuck, setIsStuck] = useState(false);
 
   const columns = ['Component', 'Design', 'Development', 'Tests', 'Documentation', 'Released In'];
 
   const Pharos =
     typeof window !== `undefined` ? require('@ithaka/pharos/lib/react-components') : null;
 
+  const ref = createRef<HTMLTableCellElement>();
+
+  useEffect(() => {
+    console.log(IsStuck);
+  }, [IsStuck]);
+
   useEffect(() => {
     const { PharosLink } = Pharos;
+
+    const cachedRef = ref.current;
+    const observer = new IntersectionObserver(
+      ([e]) => {
+        const tBool = e.intersectionRatio < 1;
+        return setIsStuck(tBool);
+      },
+      {
+        threshold: [1],
+      }
+    );
+    if (cachedRef) {
+      console.log('observing');
+      observer.observe(cachedRef);
+    }
 
     const allComponentStatuses = Object.keys(statuses).map((key, i) => {
       const name = key.charAt(0).toUpperCase() + key.slice(1);
@@ -69,7 +92,7 @@ const StatusTable: FC = () => {
         <tr>
           {columns.map((column, id) => {
             return (
-              <th key={id} className={table__header}>
+              <th key={id} className={`${table__header} ${IsStuck ? stuck : null}`} ref={ref}>
                 {column}
               </th>
             );


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
The design for the table intended to show that the drop shadow used for the table header on the component status page should only be visible when it's stickied.

**How does this change work?**
Using `IntersectionObserver`, combined with css `top: -1px`, we're able to detect whether the header is stickied or not. We then apply the style as intended.