### PR TITLE
fix(pharos): increase max-height of sidenav menu

### DIFF
--- a/.changeset/purple-beans-cross.md
+++ b/.changeset/purple-beans-cross.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+increase max-height of sidenav menu
+

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-menu.scss
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-menu.scss
@@ -46,7 +46,7 @@
 }
 
 .menu__container--show {
-  max-height: 50rem;
+  max-height: 100rem;
   transition: max-height var(--pharos-transition-duration-long) ease-in;
   visibility: visible;
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
The sidenav on the site was not showing the last component link for `Textarea` because the expanded menu's max-height of 50rem had been reached.

**How does this change work?**

- Increase max-height of sidenav menu