### PR TITLE
documentation: revert text input and textarea storybook examples

### DIFF
--- a/.changeset/purple-ligers-dance.md
+++ b/.changeset/purple-ligers-dance.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+revert textarea and textinput examples to show multiple variants on state stories
+

--- a/packages/pharos/src/components/text-input/PharosTextInput.react.stories.mdx
+++ b/packages/pharos/src/components/text-input/PharosTextInput.react.stories.mdx
@@ -74,21 +74,36 @@ export const Template = (args) => (
 # States
 
 <Canvas withToolbar>
-  <Story
-    name="States"
-    argTypes={{
-      type: { table: { disable: true }, defaultValue: 'text' },
-    }}
-    args={{
-      placeholder: 'Enter some text',
-      disabled: false,
-      readonly: false,
-      value: '',
-      hideLabel: false,
-      label: 'Edit attributes via control panel',
-    }}
-  >
-    {Template.bind({})}
+  <Story name="States">
+    <div
+      style={{
+        display: 'grid',
+        gridGap: '1rem',
+        gridTemplateColumns: 'repeat(2, 300px)',
+      }}
+    >
+      <PharosTextInput>
+        <span slot="label">Empty input</span>
+      </PharosTextInput>
+      <PharosTextInput disabled>
+        <span slot="label">Disabled input</span>
+      </PharosTextInput>
+      <PharosTextInput readonly value="Example text">
+        <span slot="label">Read only input</span>
+      </PharosTextInput>
+      <PharosTextInput placeholder="example placeholder text">
+        <span slot="label">Placeholder for input</span>
+      </PharosTextInput>
+      <PharosTextInput value="This value was provided">
+        <span slot="label">Value provided</span>
+      </PharosTextInput>
+      <PharosTextInput hideLabel value="Hidden label input">
+        <span slot="label">Hidden label</span>
+      </PharosTextInput>
+      <PharosTextInput value="A validated value" validated>
+        <span slot="label">Validated input</span>
+      </PharosTextInput>
+    </div>
   </Story>
 </Canvas>
 

--- a/packages/pharos/src/components/text-input/pharos-text-input.wc.stories.mdx
+++ b/packages/pharos/src/components/text-input/pharos-text-input.wc.stories.mdx
@@ -52,7 +52,7 @@ export const Template = (args) =>
         },
       },
     }}
-    args={{ hideLabel: false, label: 'I am a label' }}
+    args={{ hideLabel: false, label: 'I am a label', placeholder: 'placeholder', value: '' }}
   >
     {Template.bind({})}
   </Story>
@@ -65,21 +65,37 @@ export const Template = (args) =>
 # States
 
 <Canvas withToolbar>
-  <Story
-    name="States"
-    argTypes={{
-      type: { table: { disable: true }, defaultValue: 'text' },
-    }}
-    args={{
-      placeholder: 'Enter some text',
-      disabled: false,
-      readonly: false,
-      value: '',
-      hideLabel: false,
-      label: 'Edit attributes via control panel',
-    }}
-  >
-    {Template.bind({})}
+  <Story name="States">
+    {html`
+      <div
+        style="display: grid; display: -ms-grid; grid-gap: 1rem; grid-template-columns: repeat(2, 300px); -ms-grid-columns: 300px 1rem 300px"
+      >
+        <pharos-text-input><span slot="label">Empty input</span></pharos-text-input>
+        <pharos-text-input disabled style="-ms-grid-column: 3"
+          ><span slot="label">Disabled input</span></pharos-text-input
+        >
+        <pharos-text-input readonly value="Example text" style="-ms-grid-row: 2"
+          ><span slot="label">Read only input</span></pharos-text-input
+        >
+        <pharos-text-input
+          placeholder="example placeholder text"
+          style="-ms-grid-column: 3; -ms-grid-row: 2"
+          ><span slot="label">Placeholder for input</span></pharos-text-input
+        >
+        <pharos-text-input value="This value was provided" style="-ms-grid-row: 3"
+          ><span slot="label">Value provided</span></pharos-text-input
+        >
+        <pharos-text-input
+          hide-label
+          style="-ms-grid-column: 3; -ms-grid-row: 3"
+          value="Hidden label input"
+          ><span slot="label">Hidden label</span></pharos-text-input
+        >
+        <pharos-text-input value="A validated value" validated style="-ms-grid-row: 3"
+          ><span slot="label">Validated input</span></pharos-text-input
+        >
+      </div>
+    `}
   </Story>
 </Canvas>
 

--- a/packages/pharos/src/components/textarea/PharosTextarea.react.stories.mdx
+++ b/packages/pharos/src/components/textarea/PharosTextarea.react.stories.mdx
@@ -70,24 +70,27 @@ export const Template = (args) => (
 <ArgsTable of={PharosTextarea} />
 
 <Canvas withToolbar>
-  <Story
-    name="States"
-    argTypes={{
-      type: { table: { disable: true }, defaultValue: 'text' },
-      resize: { control: { type: 'select', options: ['none', 'vertical', 'horizontal', 'both'] } },
-    }}
-    args={{
-      placeholder: 'Enter some text',
-      disabled: false,
-      readonly: false,
-      value: '',
-      resize: ['none', 'vertical', 'horizontal', 'both'],
-      hideLabel: false,
-      invalidated: false,
-      label: 'Edit via control panel',
-    }}
-  >
-    {Template.bind({})}
+  <Story name="States">
+    <div style={{ display: 'grid', gridGap: '1rem', gridTemplateColumns: 'repeat(2, 250px)' }}>
+      <PharosTextarea>
+        <span slot="label">Empty textarea</span>
+      </PharosTextarea>
+      <PharosTextarea disabled>
+        <span slot="label">Disabled textarea</span>
+      </PharosTextarea>
+      <PharosTextarea readonly value="Example text">
+        <span slot="label">Read only textarea</span>
+      </PharosTextarea>
+      <PharosTextarea placeholder="Placeholder text">
+        <span slot="label">Placeholder for textarea</span>
+      </PharosTextarea>
+      <PharosTextarea value="This value is provided">
+        <span slot="label">Value provided textarea</span>
+      </PharosTextarea>
+      <PharosTextarea resize="none">
+        <span slot="label">non-resizeable textarea</span>
+      </PharosTextarea>
+    </div>
   </Story>
 </Canvas>
 

--- a/packages/pharos/src/components/textarea/pharos-textarea.wc.stories.mdx
+++ b/packages/pharos/src/components/textarea/pharos-textarea.wc.stories.mdx
@@ -65,24 +65,29 @@ export const Template = (args) =>
 # States
 
 <Canvas withToolbar>
-  <Story
-    name="States"
-    argTypes={{
-      type: { table: { disable: true }, defaultValue: 'text' },
-      resize: { control: { type: 'select', options: ['none', 'vertical', 'horizontal', 'both'] } },
-    }}
-    args={{
-      placeholder: 'Enter some text',
-      disabled: false,
-      readonly: false,
-      value: '',
-      resize: ['none', 'vertical', 'horizontal', 'both'],
-      hideLabel: false,
-      invalidated: false,
-      label: 'Edit via control panel',
-    }}
-  >
-    {Template.bind({})}
+  <Story name="States">
+    {html`
+      <div
+        style="display: grid; display: -ms-grid; grid-gap: 1rem; grid-template-columns: repeat(2, 250px); -ms-grid-columns: 250px 1rem 250px"
+      >
+        <pharos-textarea><span slot="label">Empty textarea</span></pharos-textarea>
+        <pharos-textarea disabled style="-ms-grid-column: 3"
+          ><span slot="label">Disabled textarea</span></pharos-textarea
+        >
+        <pharos-textarea readonly value="Example text" style="-ms-grid-row: 2"
+          ><span slot="label">Read only textarea</span></pharos-textarea
+        >
+        <pharos-textarea placeholder="Placeholder text" style="-ms-grid-column: 3; -ms-grid-row: 2"
+          ><span slot="label">Placeholder for textarea</span></pharos-textarea
+        >
+        <pharos-textarea value="This value is provided" style="-ms-grid-row: 3"
+          ><span slot="label">Value provided textarea</span></pharos-textarea
+        >
+        <pharos-textarea resize="none" style="-ms-grid-column: 3; -ms-grid-row: 3"
+          ><span slot="label">non-resizeable textarea</span></pharos-textarea
+        >
+      </div>
+    `}
   </Story>
 </Canvas>
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
There has been a recent change to storybook examples which changed the "states" stories for the textarea and text-input components to use the control add-on for storybook, removing the need for multiple instances of different variants to be displayed. In doing so, a couple of tests were failing.

**How does this change work?**
This change reverts the examples for the 2 components' "states" stories to display multiple variants at once, while keeping the desired change in verbiage.
