### PR TITLE
feat(pharos): add image card component

### DIFF
--- a/.changeset/fair-steaks-tan.md
+++ b/.changeset/fair-steaks-tan.md
@@ -1,0 +1,12 @@
+---
+'@ithaka/pharos': minor
+'@ithaka/pharos-site': minor
+---
+add image card component:
+
+* Add card component with `error` and `subtle` states
+* Add `action-menu` attribute to render an action button to act as the trigger for the menu
+* Add `collection` variant to present collection in 4:3 aspect ratio
+* Add `tag` prop to `pharos-layout` to specify the HTML tag to use for the inner grid
+* Update `playwright`
+

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@types/react": "17.0.1",
     "lit-element": "^2.5.1",
     "lit-html": "^1.4.1",
-    "playwright": "^1.10.0",
+    "playwright": "^1.11.0",
     "webpack": "^5.35.0",
     "dotenv-webpack": "^6.0.0",
     "html-webpack-plugin": "^5.0.0",

--- a/packages/pharos-site/src/pages/components/component-status/status.json
+++ b/packages/pharos-site/src/pages/components/component-status/status.json
@@ -307,6 +307,28 @@
       "description": ""
     }
   },
+  "image-card": {
+    "design": {
+      "status": "released",
+      "description": ""
+    },
+    "development": {
+      "status": "released",
+      "description": ""
+    },
+    "tests": {
+      "status": "planned",
+      "description": ""
+    },
+    "documentation": {
+      "status": "planned",
+      "description": ""
+    },
+    "released": {
+      "status": "na",
+      "description": ""
+    }
+  },
   "input-group": {
     "design": {
       "status": "released",

--- a/packages/pharos-site/static/styles/global.scss
+++ b/packages/pharos-site/static/styles/global.scss
@@ -258,3 +258,13 @@ p.alert-example__content + p.alert-example__content {
     grid-column: span 4;
   }
 }
+
+.image-card-example__card--collection {
+  grid-column: span 3;
+}
+
+@include pharos.until(medium) {
+  .image-card-example__card--collection {
+    grid-column: span 4;
+  }
+}

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -58,7 +58,7 @@
     "@web/dev-server-esbuild": "^0.2.12",
     "@web/test-runner": "^0.13.4",
     "@web/test-runner-commands": "^0.4.5",
-    "@web/test-runner-playwright": "^0.8.5",
+    "@web/test-runner-playwright": "^0.8.6",
     "autoprefixer": "^10.2.1",
     "gulp": "^4.0.2",
     "gulp-debug": "^4.0.0",

--- a/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
+++ b/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
@@ -1,22 +1,186 @@
 import { Meta, Canvas, ArgsTable, Story } from '@storybook/addon-docs/blocks';
+import { Fragment } from 'react';
+import { viewports } from '../../pages/shared/viewports';
 
 import { PharosImageCard } from '../../react-components/image-card/pharos-image-card';
+import { PharosLayout } from '../../react-components/layout/pharos-layout';
+import { PharosLink } from '../../react-components/link/pharos-link';
+import { PharosDropdownMenu } from '../../react-components/dropdown-menu/pharos-dropdown-menu';
+import { PharosDropdownMenuItem } from '../../react-components/dropdown-menu/pharos-dropdown-menu-item';
+
+import { items, collections } from '../../pages/item-detail/mocks';
 
 <Meta
   title="Components/Image Card"
   parameters={{
     component: PharosImageCard,
+    viewport: {
+      viewports,
+    },
   }}
 />
 
-# ImageCard
+export const Template = (args) => (
+  <PharosLayout style={{ margin: '1rem 0' }}>
+    <PharosImageCard
+      title="South Hall"
+      link="https://www.jstor.org/stable/10.2307/community.26220188"
+      error={args.error}
+      subtle={args.subtle}
+      style={{ gridColumn: 'span 2' }}
+    >
+      <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+      <div id="creator" slot="metadata">
+        Tubby, William Bunker (American architect,...
+      </div>
+      <div id="item-date" slot="metadata">
+        1889-1892 (creation)
+      </div>
+      <div id="collection" slot="metadata">
+        Part of
+        <PharosLink
+          href="https://www.jstor.org/site/pratt/buildings-image"
+          onBackground={args.subtle}
+        >
+          Pratt Institute Buildings Image Collection
+        </PharosLink>
+      </div>
+    </PharosImageCard>
+  </PharosLayout>
+);
 
-<Canvas withToolbar>
-  <Story name="Base">
-    <PharosImageCard />
-  </Story>
+export const MultipleTemplate = () => (
+  <PharosLayout style={{ margin: '1rem 0' }}>
+    {items.map((item, index) => {
+      return (
+        <PharosImageCard
+          id={`card-${index}`}
+          key={index}
+          title="Card Title"
+          link="#"
+          style={{ gridColumn: 'span 2' }}
+        >
+          <img
+            id={`image-${index}`}
+            src="./images/item-detail/{item.image}"
+            alt={`Card Title ${index}`}
+            slot="image"
+          />
+          <div id={`creator-${index}`} slot="metadata">
+            Creator of the item
+          </div>
+          <div id={`item-date-${index}`} slot="metadata">
+            1990-2000
+          </div>
+          <div id={`collection-${index}`} slot="metadata">
+            Part of
+            <PharosLink href="https://www.jstor.org/site/pratt/buildings-image">
+              An Example Collection
+            </PharosLink>
+          </div>
+        </PharosImageCard>
+      );
+    })}
+  </PharosLayout>
+);
+
+export const CollectionsTemplate = () => (
+  <PharosLayout style={{ margin: '1rem 0' }}>
+    {collections.map((collection, index) => {
+      return (
+        <PharosImageCard
+          id={`card-${index}`}
+          key={index}
+          title={collection.title}
+          link="#"
+          variant="collection"
+          class="image-card-example__card--collection"
+        >
+          <img
+            id={`image-${index}`}
+            src="./images/item-detail/{collection.image}"
+            alt={collection.title}
+            slot="image"
+          />
+          <div id={`items-${index}`} slot="metadata">
+            <strong>{collection.items} items</strong>
+          </div>
+          <div id={`description-${index}`} slot="metadata">
+            Selections from the global permanent collection.
+          </div>
+        </PharosImageCard>
+      );
+    })}
+  </PharosLayout>
+);
+
+<Canvas>
+  <Story name="Base">{MultipleTemplate.bind({})}</Story>
 </Canvas>
 
 ## API
 
 <ArgsTable of={PharosImageCard} />
+
+# Error State
+
+<Canvas>
+  <Story name="Error State" args={{ error: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+# Subtle State
+
+<Canvas>
+  <Story name="Subtle State" args={{ subtle: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+# With Action Menu
+
+<Canvas>
+  <Story name="With Action Menu">
+    <Fragment>
+      <PharosLayout style={{ margin: '1rem 0' }}>
+        <PharosImageCard
+          title="South Hall"
+          link="https://www.jstor.org/stable/10.2307/community.26220188"
+          actionMenu="my-dropdown-menu"
+          style={{ gridColumn: 'span 2' }}
+        >
+          <img
+            id="image"
+            src="./images/item-detail/collection_5.png"
+            alt="south hall"
+            slot="image"
+          />
+          <div id="creator" slot="metadata">
+            Tubby, William Bunker (American architect,...
+          </div>
+          <div id="item-date" slot="metadata">
+            1889-1892 (creation)
+          </div>
+          <div id="collection" slot="metadata">
+            Part of
+            <PharosLink href="https://www.jstor.org/site/pratt/buildings-image">
+              Pratt Institute Buildings Image Collection
+            </PharosLink>
+          </div>
+        </PharosImageCard>
+      </PharosLayout>
+      <PharosDropdownMenu id="my-dropdown-menu">
+        <PharosDropdownMenuItem>Item 1</PharosDropdownMenuItem>
+        <PharosDropdownMenuItem>Item 2</PharosDropdownMenuItem>
+        <PharosDropdownMenuItem>Item 3</PharosDropdownMenuItem>
+      </PharosDropdownMenu>
+    </Fragment>
+  </Story>
+</Canvas>
+
+# Collection
+
+<Canvas>
+  <Story name="Collection">{CollectionsTemplate.bind({})}</Story>
+</Canvas>

--- a/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
+++ b/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
@@ -50,65 +50,61 @@ export const Template = (args) => (
 );
 
 export const MultipleTemplate = () => (
-  <PharosLayout style={{ margin: '1rem 0' }}>
+  <PharosLayout tag="ol" style={{ margin: '1rem 0' }}>
     {items.map((item, index) => {
       return (
-        <PharosImageCard
-          id={`card-${index}`}
-          key={index}
-          title="Card Title"
-          link="#"
-          style={{ gridColumn: 'span 2' }}
-        >
-          <img
-            id={`image-${index}`}
-            src="./images/item-detail/{item.image}"
-            alt={`Card Title ${index}`}
-            slot="image"
-          />
-          <div id={`creator-${index}`} slot="metadata">
-            Creator of the item
-          </div>
-          <div id={`item-date-${index}`} slot="metadata">
-            1990-2000
-          </div>
-          <div id={`collection-${index}`} slot="metadata">
-            Part of
-            <PharosLink href="https://www.jstor.org/site/pratt/buildings-image">
-              An Example Collection
-            </PharosLink>
-          </div>
-        </PharosImageCard>
+        <li style={{ gridColumn: 'span 2' }} key={index}>
+          <PharosImageCard id={`card-${index}`} title="Card Title" link="#">
+            <img
+              id={`image-${index}`}
+              src="./images/item-detail/{item.image}"
+              alt={`Card Title ${index}`}
+              slot="image"
+            />
+            <div id={`creator-${index}`} slot="metadata">
+              Creator of the item
+            </div>
+            <div id={`item-date-${index}`} slot="metadata">
+              1990-2000
+            </div>
+            <div id={`collection-${index}`} slot="metadata">
+              Part of
+              <PharosLink href="https://www.jstor.org/site/pratt/buildings-image">
+                An Example Collection
+              </PharosLink>
+            </div>
+          </PharosImageCard>
+        </li>
       );
     })}
   </PharosLayout>
 );
 
 export const CollectionsTemplate = () => (
-  <PharosLayout style={{ margin: '1rem 0' }}>
+  <PharosLayout tag="ol" style={{ margin: '1rem 0' }}>
     {collections.map((collection, index) => {
       return (
-        <PharosImageCard
-          id={`card-${index}`}
-          key={index}
-          title={collection.title}
-          link="#"
-          variant="collection"
-          class="image-card-example__card--collection"
-        >
-          <img
-            id={`image-${index}`}
-            src="./images/item-detail/{collection.image}"
-            alt={collection.title}
-            slot="image"
-          />
-          <div id={`items-${index}`} slot="metadata">
-            <strong>{collection.items} items</strong>
-          </div>
-          <div id={`description-${index}`} slot="metadata">
-            Selections from the global permanent collection.
-          </div>
-        </PharosImageCard>
+        <li className="image-card-example__card--collection" key={index}>
+          <PharosImageCard
+            id={`card-${index}`}
+            title={collection.title}
+            link="#"
+            variant="collection"
+          >
+            <img
+              id={`image-${index}`}
+              src="./images/item-detail/{collection.image}"
+              alt={collection.title}
+              slot="image"
+            />
+            <div id={`items-${index}`} slot="metadata">
+              <strong>{collection.items} items</strong>
+            </div>
+            <div id={`description-${index}`} slot="metadata">
+              Selections from the global permanent collection.
+            </div>
+          </PharosImageCard>
+        </li>
       );
     })}
   </PharosLayout>

--- a/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
+++ b/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
@@ -1,0 +1,22 @@
+import { Meta, Canvas, ArgsTable, Story } from '@storybook/addon-docs/blocks';
+
+import { PharosImageCard } from '../../react-components/image-card/pharos-image-card';
+
+<Meta
+  title="Components/Image Card"
+  parameters={{
+    component: PharosImageCard,
+  }}
+/>
+
+# ImageCard
+
+<Canvas withToolbar>
+  <Story name="Base">
+    <PharosImageCard />
+  </Story>
+</Canvas>
+
+## API
+
+<ArgsTable of={PharosImageCard} />

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  contain: layout;
+}

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -50,9 +50,9 @@
   pointer-events: none;
   opacity: 0;
   transform: translate3d(0, 0, 0);
-  transition: visibility var(--pharos-transition-duration-long) ease-in-out,
-    opacity var(--pharos-transition-duration-long) ease-in-out,
-    background-color var(--pharos-transition-duration-long) ease-in-out;
+  transition: visibility var(--pharos-transition-duration-default) ease-in-out,
+    opacity var(--pharos-transition-duration-default) ease-in-out,
+    background-color var(--pharos-transition-duration-default) ease-in-out;
 }
 
 .card__container--error {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -69,16 +69,16 @@
   row-gap: var(--pharos-spacing-1-x);
 }
 
-.card__container--title {
+.card__title {
   display: flex;
   align-items: center;
 }
 
-.card__container--base-title {
+.card__title--base {
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
-.card__container--collection-title {
+.card__title--collection {
   margin-bottom: var(--pharos-spacing-1-x);
 }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -30,17 +30,24 @@
 }
 
 .card__metadata--hover {
+  @include mixins.font-base(
+    $font-size: var(--pharos-font-size-small),
+    $line-height: var(--pharos-line-height-small)
+  );
+
   height: 100%;
   box-sizing: border-box;
   color: var(--pharos-color-text-white);
-  padding: var(--pharos-spacing-one-half-x);
+  background-color: rgba(0, 0, 0, 0);
+  padding: var(--pharos-spacing-three-quarters-x);
   position: absolute;
   visibility: hidden;
   pointer-events: none;
   opacity: 0;
   transform: translate3d(0, 0, 0);
-  transition: visibility 0s var(--pharos-transition-duration-short),
-    opacity var(--pharos-transition-duration-default) linear;
+  transition: visibility var(--pharos-transition-duration-long) ease-in-out,
+    opacity var(--pharos-transition-duration-long) ease-in-out,
+    background-color var(--pharos-transition-duration-long) ease-in-out;
 }
 
 .card__container--error {
@@ -63,15 +70,21 @@
   margin-left: auto;
 }
 
+.card__title--hover {
+  @include mixins.font-base($font-weight: var(--pharos-font-weight-bold));
+
+  display: block;
+  margin-bottom: var(--pharos-spacing-one-half-x);
+}
+
 :host([subtle]) .card__image {
   position: relative;
 
   &:hover {
     .card__metadata--hover {
-      background-color: rgba(0, 0, 0, 0.5);
+      background-color: rgba(0, 0, 0, 0.75);
       visibility: visible;
       opacity: 1;
-      transition-delay: 0ms;
       pointer-events: auto;
     }
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -1,4 +1,37 @@
+@use '../../utils/scss/mixins';
+
 :host {
-  display: block;
+  display: inline-flex;
   contain: layout;
+}
+
+.card {
+  display: inline-flex;
+  flex-direction: column;
+}
+
+.card__image,
+.card__title {
+  display: inline-flex;
+}
+
+.card__image {
+  margin-bottom: var(--pharos-spacing-1-x);
+}
+
+.card__title {
+  margin-bottom: var(--pharos-spacing-one-half-x);
+}
+
+.card__metadata {
+  @include mixins.font-base(
+    $font-size: var(--pharos-font-size-small),
+    $line-height: var(--pharos-line-height-small)
+  );
+
+  color: var(--pharos-color-text-40);
+}
+
+slot[name='metadata']::slotted(*:not(:last-child)) {
+  margin-bottom: var(--pharos-spacing-one-half-x);
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -31,6 +31,7 @@
 
 .card__metadata--hover {
   height: 100%;
+  box-sizing: border-box;
   color: var(--pharos-color-text-white);
   padding: var(--pharos-spacing-one-half-x);
   position: absolute;

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -10,6 +10,10 @@
   flex-direction: column;
 }
 
+.card__link--image {
+  height: 15.625rem;
+}
+
 .card__link--image,
 .card__link--title {
   display: inline-flex;
@@ -21,19 +25,13 @@
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
-.card__metadata--base {
+.card__metadata {
   @include mixins.font-base(
     $font-size: var(--pharos-font-size-small),
     $line-height: var(--pharos-line-height-small)
   );
 
   color: var(--pharos-color-text-40);
-}
-
-.card__metadata--collection {
-  @include mixins.font-base;
-
-  color: var(--pharos-color-text-20);
 }
 
 .card__metadata--hover {
@@ -58,9 +56,8 @@
 }
 
 .card__container--error {
-  min-width: 11rem;
   border: 1px solid var(--pharos-color-ui-40);
-  height: 14.625rem;
+  height: 12.5rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -72,14 +69,7 @@
 .card__title {
   display: flex;
   align-items: center;
-}
-
-.card__title--base {
   margin-bottom: var(--pharos-spacing-one-half-x);
-}
-
-.card__title--collection {
-  margin-bottom: var(--pharos-spacing-1-x);
 }
 
 .card__container--collection-image {
@@ -100,6 +90,11 @@
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
+.card__heading,
+.card__title--hover {
+  @include mixins.truncate-text($lines: 2);
+}
+
 :host([subtle]) .card__link--image {
   position: relative;
 
@@ -113,8 +108,25 @@
   }
 }
 
+slot[name='image']::slotted(img) {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
+  object-position: bottom;
+}
+
 slot[name='metadata']::slotted(*:not(:last-child)) {
   margin-bottom: var(--pharos-spacing-one-half-x);
+}
+
+:host([variant='collection']) .card__title {
+  margin-bottom: var(--pharos-spacing-1-x);
+}
+
+:host([variant='collection']) .card__metadata {
+  @include mixins.font-base;
+
+  color: var(--pharos-color-text-20);
 }
 
 :host([variant='collection']) slot[name='metadata']::slotted(*:not(:last-child)) {
@@ -124,7 +136,5 @@ slot[name='metadata']::slotted(*:not(:last-child)) {
 :host([variant='collection']) slot[name='image']::slotted(img) {
   position: absolute;
   object-fit: cover;
-  height: 100%;
-  width: 100%;
   object-position: 50% 30%;
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -20,10 +20,6 @@
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
-.card__title {
-  margin-bottom: var(--pharos-spacing-one-half-x);
-}
-
 .card__metadata {
   @include mixins.font-base(
     $font-size: var(--pharos-font-size-small),
@@ -46,6 +42,26 @@
     opacity var(--pharos-transition-duration-default) linear;
 }
 
+.card__container--error {
+  border: 1px solid var(--pharos-color-ui-40);
+  height: 14.625rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  row-gap: var(--pharos-spacing-1-x);
+}
+
+.card__container--title {
+  margin-bottom: var(--pharos-spacing-one-half-x);
+  display: flex;
+  align-items: center;
+}
+
+.card__button {
+  margin-left: auto;
+}
+
 :host([subtle]) .card__image {
   position: relative;
 
@@ -62,14 +78,4 @@
 
 slot[name='metadata']::slotted(*:not(:last-child)) {
   margin-bottom: var(--pharos-spacing-one-half-x);
-}
-
-.card__container--error {
-  border: 1px solid var(--pharos-color-ui-40);
-  height: 14.625rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  row-gap: var(--pharos-spacing-1-x);
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -21,7 +21,7 @@
 
 .card__link--image,
 .card__container--error,
-.card__container--collection-image {
+.card__container--collection {
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
@@ -72,7 +72,7 @@
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
-.card__container--collection-image {
+.card__container--collection {
   display: grid;
   overflow: hidden;
   position: relative;

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -15,7 +15,8 @@
   display: inline-flex;
 }
 
-.card__image {
+.card__image,
+.card__container--error {
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
@@ -32,6 +33,43 @@
   color: var(--pharos-color-text-40);
 }
 
+.card__metadata--hover {
+  height: 100%;
+  color: var(--pharos-color-text-white);
+  padding: var(--pharos-spacing-one-half-x);
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate3d(0, 0, 0);
+  transition: visibility 0s var(--pharos-transition-duration-short),
+    opacity var(--pharos-transition-duration-default) linear;
+}
+
+:host([subtle]) .card__image {
+  position: relative;
+
+  &:hover {
+    .card__metadata--hover {
+      background-color: rgba(0, 0, 0, 0.5);
+      visibility: visible;
+      opacity: 1;
+      transition-delay: 0ms;
+      pointer-events: auto;
+    }
+  }
+}
+
 slot[name='metadata']::slotted(*:not(:last-child)) {
   margin-bottom: var(--pharos-spacing-one-half-x);
+}
+
+.card__container--error {
+  border: 1px solid var(--pharos-color-ui-40);
+  height: 14.625rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  row-gap: var(--pharos-spacing-1-x);
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -10,23 +10,30 @@
   flex-direction: column;
 }
 
-.card__image,
-.card__title {
+.card__link--image,
+.card__link--title {
   display: inline-flex;
 }
 
-.card__image,
-.card__container--error {
+.card__link--image,
+.card__container--error,
+.card__container--collection-image {
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
-.card__metadata {
+.card__metadata--base {
   @include mixins.font-base(
     $font-size: var(--pharos-font-size-small),
     $line-height: var(--pharos-line-height-small)
   );
 
   color: var(--pharos-color-text-40);
+}
+
+.card__metadata--collection {
+  @include mixins.font-base;
+
+  color: var(--pharos-color-text-20);
 }
 
 .card__metadata--hover {
@@ -51,19 +58,35 @@
 }
 
 .card__container--error {
+  min-width: 11rem;
   border: 1px solid var(--pharos-color-ui-40);
   height: 14.625rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-align: center;
   row-gap: var(--pharos-spacing-1-x);
 }
 
 .card__container--title {
-  margin-bottom: var(--pharos-spacing-one-half-x);
   display: flex;
   align-items: center;
+}
+
+.card__container--base-title {
+  margin-bottom: var(--pharos-spacing-one-half-x);
+}
+
+.card__container--collection-title {
+  margin-bottom: var(--pharos-spacing-1-x);
+}
+
+.card__container--collection-image {
+  display: grid;
+  overflow: hidden;
+  position: relative;
+  height: auto;
 }
 
 .card__button {
@@ -77,7 +100,7 @@
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
-:host([subtle]) .card__image {
+:host([subtle]) .card__link--image {
   position: relative;
 
   &:hover {
@@ -92,4 +115,16 @@
 
 slot[name='metadata']::slotted(*:not(:last-child)) {
   margin-bottom: var(--pharos-spacing-one-half-x);
+}
+
+:host([variant='collection']) slot[name='metadata']::slotted(*:not(:last-child)) {
+  margin-bottom: var(--pharos-spacing-1-x);
+}
+
+:host([variant='collection']) slot[name='image']::slotted(img) {
+  position: absolute;
+  object-fit: cover;
+  height: 100%;
+  width: 100%;
+  object-position: 50% 30%;
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -1,0 +1,15 @@
+import { html, fixture, expect } from '@open-wc/testing';
+import './pharos-image-card';
+import type { PharosImageCard } from './pharos-image-card';
+
+describe('pharos-image-card', () => {
+  let component: PharosImageCard;
+
+  beforeEach(async () => {
+    component = await fixture(html` <pharos-image-card> Shell ImageCard </pharos-image-card> `);
+  });
+
+  it('is accessible', async () => {
+    await expect(component).to.be.accessible();
+  });
+});

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -1,15 +1,152 @@
-import { html, fixture, expect } from '@open-wc/testing';
+import { html, fixture, expect, aTimeout, elementUpdated } from '@open-wc/testing';
 import './pharos-image-card';
+import '../dropdown-menu/pharos-dropdown-menu';
+import '../dropdown-menu/pharos-dropdown-menu-item';
 import type { PharosImageCard } from './pharos-image-card';
+import type { PharosButton } from '../button/pharos-button';
 
 describe('pharos-image-card', () => {
   let component: PharosImageCard;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-image-card> Shell ImageCard </pharos-image-card> `);
+    component = await fixture(html`<pharos-image-card title="Card Title" link="#">
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="metadata">Creator of the item</div>
+      <div slot="metadata">1990-2000</div>
+      <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
+    </pharos-image-card>`);
   });
 
   it('is accessible', async () => {
     await expect(component).to.be.accessible();
+  });
+
+  it('is accessible in the error state', async () => {
+    component.error = true;
+    await component.updateComplete;
+    await expect(component).to.be.accessible();
+  });
+
+  it('is accessible in the subtle state', async () => {
+    component.subtle = true;
+    await component.updateComplete;
+    await expect(component).to.be.accessible();
+  });
+
+  it('is accessible as the collection variant', async () => {
+    component = await fixture(html`<pharos-image-card
+      title="Card Title"
+      link="#"
+      variant="collection"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="metadata"><strong>100 items</strong></div>
+      <div slot="metadata">Description of collection.</div>
+    </pharos-image-card>`);
+    await expect(component).to.be.accessible();
+  });
+
+  it('throws an error for an invalid variant value', async () => {
+    component = await fixture(html`
+      <pharos-image-card title="Card Title" link="#" variant="fake"></pharos-image-card>
+    `).catch((e) => e);
+    expect('fake is not a valid variant. Valid variants are: base, collection').to.be.thrown;
+  });
+
+  it('opens the provided dropdown menu when the action button is clicked', async () => {
+    component.actionMenu = 'menu-id';
+    await component.updateComplete;
+
+    const menu = document.createElement('pharos-dropdown-menu');
+    menu.id = 'menu-id';
+    const item = document.createElement('pharos-dropdown-menu-item');
+    item.textContent = 'Menu Item';
+    menu.appendChild(item);
+    document.body.appendChild(menu);
+
+    const button: PharosButton | null = component.renderRoot.querySelector(
+      'pharos-button[icon="ellipses-vertical"]'
+    );
+    button?.click();
+    await aTimeout(100);
+    await elementUpdated(menu);
+
+    expect(menu.open).to.be.true;
+  });
+
+  it('sets title link hover state when the card image link is hovered', async () => {
+    const imageLink = component.renderRoot.querySelector('.card__link--image');
+    imageLink?.dispatchEvent(new Event('mouseenter'));
+    await component.updateComplete;
+
+    expect(component['_title']['_hover']).to.be.true;
+  });
+
+  it('renders an action button when an action menu id is provided', async () => {
+    component.actionMenu = 'menu-id';
+    await component.updateComplete;
+
+    const button = component.renderRoot.querySelector('pharos-button[icon="ellipses-vertical"]');
+    expect(button).not.to.be.null;
+  });
+
+  it('does not render an action button when an action menu id is not provided', async () => {
+    const button = component.renderRoot.querySelector('pharos-button[icon="ellipses-vertical"]');
+    expect(button).to.be.null;
+  });
+
+  it('renders a heading with preset "1--bold" for the base variant', async () => {
+    const heading = component.renderRoot.querySelector('pharos-heading.card__heading');
+    expect(heading?.getAttribute('preset')).to.equal('1--bold');
+  });
+
+  it('renders a heading with preset "2" for the collection variant', async () => {
+    component.variant = 'collection';
+    await component.updateComplete;
+
+    const heading = component.renderRoot.querySelector('pharos-heading.card__heading');
+    expect(heading?.getAttribute('preset')).to.equal('2');
+  });
+
+  it('renders an exclamation icon in the error state', async () => {
+    component.error = true;
+    await component.updateComplete;
+
+    const icon = component.renderRoot.querySelector('pharos-icon[name="exclamation-inverse"]');
+    expect(icon).not.to.be.null;
+  });
+
+  it('renders a container for the metadata', async () => {
+    const metadata = component.renderRoot.querySelector('.card__metadata');
+    expect(metadata).not.to.be.null;
+  });
+
+  it('renders a hoverable version of the metadata in the subtle state', async () => {
+    component.subtle = true;
+    await component.updateComplete;
+
+    const metadataHover = component.renderRoot.querySelector('.card__metadata--hover');
+    expect(metadataHover).not.to.be.null;
+  });
+
+  it('renders a link around the image for the base variant', async () => {
+    const link = component.renderRoot.querySelector('pharos-link.card__link--image');
+    expect(link).not.to.be.null;
+  });
+
+  it('renders a container around the image for the collection variant', async () => {
+    component.variant = 'collection';
+    await component.updateComplete;
+
+    const container = component.renderRoot.querySelector('.card__container--collection');
+    expect(container).not.to.be.null;
   });
 });

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -101,7 +101,7 @@ export class PharosImageCard extends LitElement {
   }
 
   private _renderCollectionImage(): TemplateResult {
-    return html`<div class="card__container--collection-image">
+    return html`<div class="card__container--collection">
       <svg role="presentation" viewBox="0 0 4 3"></svg>
       <slot name="image"></slot>
     </div>`;

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -88,6 +88,7 @@ export class PharosImageCard extends LitElement {
           icon="ellipses-vertical"
           variant="subtle"
           icon-condensed
+          label="More actions"
           @click=${this._handleClick}
         ></pharos-button>`
       : nothing;

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -1,12 +1,14 @@
-import { html, LitElement, property } from 'lit-element';
+import { html, LitElement, property, query } from 'lit-element';
 import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit-element';
 import { nothing } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { imageCardStyles } from './pharos-image-card.css';
 import { designTokens } from '../../styles/variables.css';
 import { customElement } from '../../utils/decorators';
+
 import type { PharosButton } from '../button/pharos-button';
 import type { PharosDropdownMenu } from '../dropdown-menu/pharos-dropdown-menu';
+import type { PharosLink } from '../link/pharos-link';
 
 import '../heading/pharos-heading';
 import '../link/pharos-link';
@@ -70,6 +72,9 @@ export class PharosImageCard extends LitElement {
   @property({ type: String, reflect: true })
   public variant: ImageCardVariant = 'base';
 
+  @query('.card__link--title')
+  private _title!: PharosLink;
+
   public static get styles(): CSSResultArray {
     return [designTokens, imageCardStyles];
   }
@@ -92,6 +97,10 @@ export class PharosImageCard extends LitElement {
     menu?.openWithTrigger(trigger);
   }
 
+  private _handleImageHover(event: Event): void {
+    this._title['_hover'] = event.type === 'mouseenter';
+  }
+
   private _renderCollectionImage(): TemplateResult {
     return html`<div class="card__container--collection-image">
       <svg role="presentation" viewBox="0 0 4 3"></svg>
@@ -104,7 +113,13 @@ export class PharosImageCard extends LitElement {
       ? html`<div class="card__container--error">
           <pharos-icon name="exclamation-inverse"></pharos-icon>Preview not available
         </div>`
-      : html`<pharos-link class="card__link--image" href="${this.link}" subtle flex
+      : html`<pharos-link
+          class="card__link--image"
+          href="${this.link}"
+          subtle
+          flex
+          @mouseenter=${this._handleImageHover}
+          @mouseleave=${this._handleImageHover}
           ><slot name="image"></slot>${this.subtle
             ? html`<div class="card__metadata--hover">
                 <strong class="card__title--hover">${this.title}</strong
@@ -160,8 +175,8 @@ export class PharosImageCard extends LitElement {
       ${this._renderImage()}
       <div
         class="${classMap({
-          [`card__container--title`]: true,
-          [`card__container--${this.variant}-title`]: this.variant,
+          [`card__title`]: true,
+          [`card__title--${this.variant}`]: this.variant,
         })}"
       >
         ${this.renderTitle} ${this._renderActionButton()}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -1,0 +1,46 @@
+import { html, LitElement, property } from 'lit-element';
+import type { TemplateResult, CSSResultArray } from 'lit-element';
+import { imageCardStyles } from './pharos-image-card.css';
+import { designTokens } from '../../styles/variables.css';
+import { customElement } from '../../utils/decorators';
+
+import '../heading/pharos-heading';
+import '../link/pharos-link';
+
+@customElement('pharos-image-card')
+export class PharosImageCard extends LitElement {
+  /**
+   * Indicates the title of the item presented in the card.
+   * @attr title
+   */
+  @property({ type: String, reflect: true })
+  public title = '';
+
+  /**
+   * Indicates the link to apply to the title and image.
+   * @attr link
+   */
+  @property({ type: String, reflect: true })
+  public link = '';
+
+  public static get styles(): CSSResultArray {
+    return [designTokens, imageCardStyles];
+  }
+
+  protected render(): TemplateResult {
+    return html`<div>
+      <slot name="image"></slot>
+      <pharos-link href="${this.link}" subtle flex
+        ><pharos-heading preset="1--bold" level="3" no-margin
+          >${this.title}</pharos-heading
+        ></pharos-link
+      ><slot name="metadata"></slot>
+    </div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'pharos-image-card': PharosImageCard;
+  }
+}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -1,7 +1,6 @@
 import { html, LitElement, property, query } from 'lit-element';
 import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit-element';
 import { nothing } from 'lit-html';
-import { classMap } from 'lit-html/directives/class-map.js';
 import { imageCardStyles } from './pharos-image-card.css';
 import { designTokens } from '../../styles/variables.css';
 import { customElement } from '../../utils/decorators';
@@ -45,6 +44,13 @@ export class PharosImageCard extends LitElement {
   public link = '';
 
   /**
+   * Indicates the variant of card.
+   * @attr variant
+   */
+  @property({ type: String, reflect: true })
+  public variant: ImageCardVariant = 'base';
+
+  /**
    * Indicates if the image is not available or accessible.
    * @attr error
    */
@@ -64,13 +70,6 @@ export class PharosImageCard extends LitElement {
    */
   @property({ type: String, reflect: true, attribute: 'action-menu' })
   public actionMenu?: string;
-
-  /**
-   * Indicates the variant of card.
-   * @attr variant
-   */
-  @property({ type: String, reflect: true })
-  public variant: ImageCardVariant = 'base';
 
   @query('.card__link--title')
   private _title!: PharosLink;
@@ -136,6 +135,7 @@ export class PharosImageCard extends LitElement {
   protected get renderTitle(): TemplateResult {
     return html`<pharos-link class="card__link--title" href="${this.link}" subtle flex
       ><pharos-heading
+        class="card__heading"
         preset="${this.variant === 'collection' ? '2' : '1--bold'}"
         level="3"
         no-margin
@@ -160,12 +160,7 @@ export class PharosImageCard extends LitElement {
   private _renderMetadata(): TemplateResult | typeof nothing {
     return this.subtle
       ? nothing
-      : html`<div
-          class="${classMap({
-            [`card__metadata`]: true,
-            [`card__metadata--${this.variant}`]: this.variant,
-          })}"
-        >
+      : html`<div class="card__metadata">
           <slot name="metadata"></slot>
         </div>`;
   }
@@ -173,14 +168,7 @@ export class PharosImageCard extends LitElement {
   protected render(): TemplateResult {
     return html`<div class="card">
       ${this._renderImage()}
-      <div
-        class="${classMap({
-          [`card__title`]: true,
-          [`card__title--${this.variant}`]: this.variant,
-        })}"
-      >
-        ${this.renderTitle} ${this._renderActionButton()}
-      </div>
+      <div class="card__title">${this.renderTitle} ${this._renderActionButton()}</div>
       ${this._renderMetadata()}
     </div>`;
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -68,7 +68,10 @@ export class PharosImageCard extends LitElement {
         </div>`
       : html`<pharos-link class="card__image" href="${this.link}" subtle flex
           ><slot name="image"></slot>${this.subtle
-            ? html`<div class="card__metadata--hover"><slot name="metadata"></slot></div>`
+            ? html`<div class="card__metadata--hover">
+                <strong class="card__title--hover">${this.title}</strong
+                ><slot name="metadata"></slot>
+              </div>`
             : nothing}</pharos-link
         >`;
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -1,11 +1,13 @@
 import { html, LitElement, property } from 'lit-element';
 import type { TemplateResult, CSSResultArray } from 'lit-element';
+import { nothing } from 'lit-html';
 import { imageCardStyles } from './pharos-image-card.css';
 import { designTokens } from '../../styles/variables.css';
 import { customElement } from '../../utils/decorators';
 
 import '../heading/pharos-heading';
 import '../link/pharos-link';
+import '../icon/pharos-icon';
 
 @customElement('pharos-image-card')
 export class PharosImageCard extends LitElement {
@@ -23,18 +25,50 @@ export class PharosImageCard extends LitElement {
   @property({ type: String, reflect: true })
   public link = '';
 
+  /**
+   * Indicates if the image is not available or accessible.
+   * @attr error
+   */
+  @property({ type: Boolean, reflect: true })
+  public error = false;
+
+  /**
+   * Indicates if the metadata should only show on hover of the image.
+   * @attr subtle
+   */
+  @property({ type: Boolean, reflect: true })
+  public subtle = false;
+
   public static get styles(): CSSResultArray {
     return [designTokens, imageCardStyles];
   }
 
+  private _renderImage(): TemplateResult {
+    return this.error
+      ? html`<div class="card__container--error">
+          <pharos-icon name="exclamation-inverse"></pharos-icon>Preview not available
+        </div>`
+      : html`<pharos-link class="card__image" href="${this.link}" subtle flex
+          ><slot name="image"></slot>${this.subtle
+            ? html`<div class="card__metadata--hover"><slot name="metadata"></slot></div>`
+            : nothing}</pharos-link
+        >`;
+  }
+
+  protected get renderTitle(): TemplateResult {
+    return html`<pharos-link class="card__title" href="${this.link}" subtle flex
+      ><pharos-heading preset="1--bold" level="3" no-margin
+        >${this.title}</pharos-heading
+      ></pharos-link
+    >`;
+  }
+
   protected render(): TemplateResult {
     return html`<div class="card">
-      <pharos-link class="card__image" href="${this.link}" subtle flex><slot name="image"></slot></pharos-link>
-      <pharos-link class="card__title" href="${this.link}" subtle flex
-        ><pharos-heading preset="1--bold" level="3" no-margin
-          >${this.title}</pharos-heading
-        ></pharos-link
-      ><div class="card__metadata"><slot name="metadata"></div></slot>
+      ${this._renderImage()} ${this.renderTitle}
+      ${this.subtle
+        ? nothing
+        : html`<div class="card__metadata"><slot name="metadata"></slot></div>`}
     </div>`;
   }
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -28,13 +28,13 @@ export class PharosImageCard extends LitElement {
   }
 
   protected render(): TemplateResult {
-    return html`<div>
-      <slot name="image"></slot>
-      <pharos-link href="${this.link}" subtle flex
+    return html`<div class="card">
+      <pharos-link class="card__image" href="${this.link}" subtle flex><slot name="image"></slot></pharos-link>
+      <pharos-link class="card__title" href="${this.link}" subtle flex
         ><pharos-heading preset="1--bold" level="3" no-margin
           >${this.title}</pharos-heading
         ></pharos-link
-      ><slot name="metadata"></slot>
+      ><div class="card__metadata"><slot name="metadata"></div></slot>
     </div>`;
   }
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -4,10 +4,13 @@ import { nothing } from 'lit-html';
 import { imageCardStyles } from './pharos-image-card.css';
 import { designTokens } from '../../styles/variables.css';
 import { customElement } from '../../utils/decorators';
+import type { PharosButton } from '../button/pharos-button';
+import type { PharosDropdownMenu } from '../dropdown-menu/pharos-dropdown-menu';
 
 import '../heading/pharos-heading';
 import '../link/pharos-link';
 import '../icon/pharos-icon';
+import '../button/pharos-button';
 
 @customElement('pharos-image-card')
 export class PharosImageCard extends LitElement {
@@ -39,8 +42,23 @@ export class PharosImageCard extends LitElement {
   @property({ type: Boolean, reflect: true })
   public subtle = false;
 
+  /**
+   * Indicates the action menu id to be passed to the action button.
+   * @attr action-menu
+   */
+  @property({ type: String, reflect: true, attribute: 'action-menu' })
+  public actionMenu?: string;
+
   public static get styles(): CSSResultArray {
     return [designTokens, imageCardStyles];
+  }
+
+  private _handleClick(e: MouseEvent): void {
+    const trigger = e.target as PharosButton;
+    const menu: PharosDropdownMenu | null = document.querySelector(
+      `pharos-dropdown-menu#${this.actionMenu}`
+    );
+    menu?.openWithTrigger(trigger);
   }
 
   private _renderImage(): TemplateResult {
@@ -63,9 +81,22 @@ export class PharosImageCard extends LitElement {
     >`;
   }
 
+  private _renderActionButton(): TemplateResult | typeof nothing {
+    return this.actionMenu
+      ? html`<pharos-button
+          class="card__button"
+          icon="ellipses-vertical"
+          variant="subtle"
+          icon-condensed
+          @click=${this._handleClick}
+        ></pharos-button>`
+      : nothing;
+  }
+
   protected render(): TemplateResult {
     return html`<div class="card">
-      ${this._renderImage()} ${this.renderTitle}
+      ${this._renderImage()}
+      <div class="card__container--title">${this.renderTitle} ${this._renderActionButton()}</div>
       ${this.subtle
         ? nothing
         : html`<div class="card__metadata"><slot name="metadata"></slot></div>`}

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -62,3 +62,32 @@ export const Template = (args) => html`<pharos-image-card
     `}
   </Story>
 </Canvas>
+
+# With Action Menu
+
+<Canvas>
+  <Story name="With Action Menu" args={{ actionMenu: 'my-dropdown-menu' }}>
+    {html`
+      <pharos-image-card
+        title="South Hall"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        action-menu="my-dropdown-menu"
+      >
+        <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div slot="metadata">1889-1892 (creation)</div>
+        <div slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+      <pharos-dropdown-menu id="my-dropdown-menu">
+        <pharos-dropdown-menu-item>Item 1</pharos-dropdown-menu-item>
+        <pharos-dropdown-menu-item>Item 2</pharos-dropdown-menu-item>
+        <pharos-dropdown-menu-item>Item 3</pharos-dropdown-menu-item>
+      </pharos-dropdown-menu>
+    `}
+  </Story>
+</Canvas>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -5,21 +5,56 @@ import './pharos-image-card';
 
 <Meta title="Components/Image Card" />
 
-# ImageCard
+# Image Card
+
+export const Template = (args) => html`<pharos-image-card
+  title="South Hall"
+  link="https://www.jstor.org/stable/10.2307/community.26220188"
+  ?error=${args.error}
+>
+  <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+  <div slot="metadata">Tubby, William Bunker (American architect,...</div>
+  <div slot="metadata">1889-1892 (creation)</div>
+  <div slot="metadata">
+    Part of
+    <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+      >Pratt Institute Buildings Image Collection</pharos-link
+    >
+  </div>
+</pharos-image-card>`;
 
 <Canvas>
-  <Story name="Base">
+  <Story name="Base">{Template.bind({})}</Story>
+</Canvas>
+
+## API
+
+<ArgsTable of="pharos-image-card" />
+
+# Error State
+
+<Canvas>
+  <Story name="Error State" args={{ error: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+# Subtle Card
+
+<Canvas>
+  <Story name="Subtle Card">
     {html`
       <pharos-image-card
         title="South Hall"
         link="https://www.jstor.org/stable/10.2307/community.26220188"
+        subtle
       >
         <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
         <div slot="metadata">Tubby, William Bunker (American architect,...</div>
         <div slot="metadata">1889-1892 (creation)</div>
         <div slot="metadata">
           Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image" on-background
             >Pratt Institute Buildings Image Collection</pharos-link
           >
         </div>
@@ -27,7 +62,3 @@ import './pharos-image-card';
     `}
   </Story>
 </Canvas>
-
-## API
-
-<ArgsTable of="pharos-image-card" />

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -8,7 +8,24 @@ import './pharos-image-card';
 # ImageCard
 
 <Canvas>
-  <Story name="Base">{html` <pharos-image-card title="South Hall"></pharos-image-card> `}</Story>
+  <Story name="Base">
+    {html`
+      <pharos-image-card
+        title="South Hall"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+      >
+        <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div slot="metadata">1889-1892 (creation)</div>
+        <div slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
 </Canvas>
 
 ## API

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -1,30 +1,79 @@
 import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs/blocks';
 import { html } from 'lit-html';
+import { viewports } from '../../pages/shared/viewports';
 
 import './pharos-image-card';
+import '../layout/pharos-layout';
 
-<Meta title="Components/Image Card" />
+import { items, collections } from '../../pages/item-detail/mocks';
+
+<Meta
+  title="Components/Image Card"
+  parameters={{
+    layout: 'fullscreen',
+    viewport: {
+      viewports,
+    },
+  }}
+/>
 
 # Image Card
 
-export const Template = (args) => html`<pharos-image-card
-  title="South Hall"
-  link="https://www.jstor.org/stable/10.2307/community.26220188"
-  ?error=${args.error}
->
-  <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-  <div slot="metadata">Tubby, William Bunker (American architect,...</div>
-  <div slot="metadata">1889-1892 (creation)</div>
-  <div slot="metadata">
-    Part of
-    <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-      >Pratt Institute Buildings Image Collection</pharos-link
+export const Template = (args) => html`<pharos-layout style="margin: 1rem 0"
+  ><pharos-image-card
+    title="South Hall"
+    link="https://www.jstor.org/stable/10.2307/community.26220188"
+    ?error=${args.error}
+    ?subtle=${args.subtle}
+    style="grid-column: span 2"
+  >
+    <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+    <div slot="metadata">Tubby, William Bunker (American architect,...</div>
+    <div slot="metadata">1889-1892 (creation)</div>
+    <div slot="metadata">
+      Part of
+      <pharos-link
+        href="https://www.jstor.org/site/pratt/buildings-image"
+        ?on-background=${args.subtle}
+        >Pratt Institute Buildings Image Collection</pharos-link
+      >
+    </div>
+  </pharos-image-card></pharos-layout
+>`;
+
+export const MultipleTemplate = () => html`<pharos-layout style="margin: 1rem 0">
+  ${items.map((item, index) => {
+    return html`<pharos-image-card title="Card Title" link="#" style="grid-column: span 2">
+      <img src="./images/item-detail/${item.image}" alt="Card Title ${index}" slot="image" />
+      <div slot="metadata">Creator of the item</div>
+      <div slot="metadata">1990-2000</div>
+      <div slot="metadata">
+        Part of
+        <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+          >An Example Collection</pharos-link
+        >
+      </div>
+    </pharos-image-card>`;
+  })}</pharos-layout
+>`;
+
+export const CollectionsTemplate = () => html`<pharos-layout style="margin: 1rem 0">
+  ${collections.map((collection) => {
+    return html`<pharos-image-card
+      title="${collection.title}"
+      link="#"
+      variant="collection"
+      style="grid-column: span 3"
     >
-  </div>
-</pharos-image-card>`;
+      <img src="./images/item-detail/${collection.image}" alt="${collection.title}" slot="image" />
+      <div slot="metadata"><strong>${collection.items} items</strong></div>
+      <div slot="metadata">Selections from the global permanent collection.</div>
+    </pharos-image-card>`;
+  })}</pharos-layout
+>`;
 
 <Canvas>
-  <Story name="Base">{Template.bind({})}</Story>
+  <Story name="Base">{MultipleTemplate.bind({})}</Story>
 </Canvas>
 
 ## API
@@ -39,50 +88,37 @@ export const Template = (args) => html`<pharos-image-card
   </Story>
 </Canvas>
 
-# Subtle Card
+# Subtle
 
 <Canvas>
-  <Story name="Subtle Card">
-    {html`
-      <pharos-image-card
-        title="South Hall"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        subtle
-      >
-        <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div slot="metadata">1889-1892 (creation)</div>
-        <div slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image" on-background
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
+  <Story name="Subtle" args={{ subtle: true }}>
+    {Template.bind({})}
   </Story>
 </Canvas>
 
 # With Action Menu
 
 <Canvas>
-  <Story name="With Action Menu" args={{ actionMenu: 'my-dropdown-menu' }}>
+  <Story name="With Action Menu">
     {html`
-      <pharos-image-card
-        title="South Hall"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        action-menu="my-dropdown-menu"
-      >
-        <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div slot="metadata">1889-1892 (creation)</div>
-        <div slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
+      <pharos-layout style="margin: 1rem 0">
+        <pharos-image-card
+          title="South Hall"
+          link="https://www.jstor.org/stable/10.2307/community.26220188"
+          action-menu="my-dropdown-menu"
+          style="grid-column: span 2"
+        >
+          <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+          <div slot="metadata">Tubby, William Bunker (American architect,...</div>
+          <div slot="metadata">1889-1892 (creation)</div>
+          <div slot="metadata">
+            Part of
+            <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+              >Pratt Institute Buildings Image Collection</pharos-link
+            >
+          </div>
+        </pharos-image-card>
+      </pharos-layout>
       <pharos-dropdown-menu id="my-dropdown-menu">
         <pharos-dropdown-menu-item>Item 1</pharos-dropdown-menu-item>
         <pharos-dropdown-menu-item>Item 2</pharos-dropdown-menu-item>
@@ -90,4 +126,10 @@ export const Template = (args) => html`<pharos-image-card
       </pharos-dropdown-menu>
     `}
   </Story>
+</Canvas>
+
+# Collection
+
+<Canvas>
+  <Story name="Collection">{CollectionsTemplate.bind({})}</Story>
 </Canvas>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -44,52 +44,50 @@ export const Template = (args) => html`<pharos-layout style="margin: 1rem 0"
   </pharos-image-card></pharos-layout
 >`;
 
-export const MultipleTemplate = () => html`<pharos-layout style="margin: 1rem 0">
+export const MultipleTemplate = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
   ${items.map((item, index) => {
-    return html`<pharos-image-card
-      id="card-${index}"
-      title="Card Title"
-      link="#"
-      style="grid-column: span 2"
-    >
-      <img
-        id="image-${index}"
-        src="./images/item-detail/${item.image}"
-        alt="Card Title ${index}"
-        slot="image"
-      />
-      <div id="creator-${index}" slot="metadata">Creator of the item</div>
-      <div id="item-date-${index}" slot="metadata">1990-2000</div>
-      <div id="collection-${index}" slot="metadata">
-        Part of
-        <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-          >An Example Collection</pharos-link
-        >
-      </div>
-    </pharos-image-card>`;
+    return html`<li style="grid-column: span 2">
+      <pharos-image-card id="card-${index}" title="Card Title" link="#">
+        <img
+          id="image-${index}"
+          src="./images/item-detail/${item.image}"
+          alt="Card Title ${index}"
+          slot="image"
+        />
+        <div id="creator-${index}" slot="metadata">Creator of the item</div>
+        <div id="item-date-${index}" slot="metadata">1990-2000</div>
+        <div id="collection-${index}" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >An Example Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    </li>`;
   })}</pharos-layout
 >`;
 
-export const CollectionsTemplate = () => html`<pharos-layout style="margin: 1rem 0">
+export const CollectionsTemplate = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
   ${collections.map((collection, index) => {
-    return html`<pharos-image-card
-      id="card-${index}"
-      title="${collection.title}"
-      link="#"
-      variant="collection"
-      class="image-card-example__card--collection"
-    >
-      <img
-        id="image-${index}"
-        src="./images/item-detail/${collection.image}"
-        alt="${collection.title}"
-        slot="image"
-      />
-      <div id="items-${index}" slot="metadata"><strong>${collection.items} items</strong></div>
-      <div id="description-${index}" slot="metadata">
-        Selections from the global permanent collection.
-      </div>
-    </pharos-image-card>`;
+    return html`<li class="image-card-example__card--collection">
+      <pharos-image-card
+        id="card-${index}"
+        title="${collection.title}"
+        link="#"
+        variant="collection"
+      >
+        <img
+          id="image-${index}"
+          src="./images/item-detail/${collection.image}"
+          alt="${collection.title}"
+          slot="image"
+        />
+        <div id="items-${index}" slot="metadata"><strong>${collection.items} items</strong></div>
+        <div id="description-${index}" slot="metadata">
+          Selections from the global permanent collection.
+        </div>
+      </pharos-image-card>
+    </li>`;
   })}</pharos-layout
 >`;
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -4,6 +4,9 @@ import { viewports } from '../../pages/shared/viewports';
 
 import './pharos-image-card';
 import '../layout/pharos-layout';
+import '../link/pharos-link';
+import '../dropdown-menu/pharos-dropdown-menu';
+import '../dropdown-menu/pharos-dropdown-menu-item';
 
 import { items, collections } from '../../pages/item-detail/mocks';
 
@@ -27,10 +30,10 @@ export const Template = (args) => html`<pharos-layout style="margin: 1rem 0"
     ?subtle=${args.subtle}
     style="grid-column: span 2"
   >
-    <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-    <div slot="metadata">Tubby, William Bunker (American architect,...</div>
-    <div slot="metadata">1889-1892 (creation)</div>
-    <div slot="metadata">
+    <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+    <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+    <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+    <div id="collection" slot="metadata">
       Part of
       <pharos-link
         href="https://www.jstor.org/site/pratt/buildings-image"
@@ -43,11 +46,21 @@ export const Template = (args) => html`<pharos-layout style="margin: 1rem 0"
 
 export const MultipleTemplate = () => html`<pharos-layout style="margin: 1rem 0">
   ${items.map((item, index) => {
-    return html`<pharos-image-card title="Card Title" link="#" style="grid-column: span 2">
-      <img src="./images/item-detail/${item.image}" alt="Card Title ${index}" slot="image" />
-      <div slot="metadata">Creator of the item</div>
-      <div slot="metadata">1990-2000</div>
-      <div slot="metadata">
+    return html`<pharos-image-card
+      id="card-${index}"
+      title="Card Title"
+      link="#"
+      style="grid-column: span 2"
+    >
+      <img
+        id="image-${index}"
+        src="./images/item-detail/${item.image}"
+        alt="Card Title ${index}"
+        slot="image"
+      />
+      <div id="creator-${index}" slot="metadata">Creator of the item</div>
+      <div id="item-date-${index}" slot="metadata">1990-2000</div>
+      <div id="collection-${index}" slot="metadata">
         Part of
         <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
           >An Example Collection</pharos-link
@@ -58,16 +71,24 @@ export const MultipleTemplate = () => html`<pharos-layout style="margin: 1rem 0"
 >`;
 
 export const CollectionsTemplate = () => html`<pharos-layout style="margin: 1rem 0">
-  ${collections.map((collection) => {
+  ${collections.map((collection, index) => {
     return html`<pharos-image-card
+      id="card-${index}"
       title="${collection.title}"
       link="#"
       variant="collection"
-      style="grid-column: span 3"
+      class="image-card-example__card--collection"
     >
-      <img src="./images/item-detail/${collection.image}" alt="${collection.title}" slot="image" />
-      <div slot="metadata"><strong>${collection.items} items</strong></div>
-      <div slot="metadata">Selections from the global permanent collection.</div>
+      <img
+        id="image-${index}"
+        src="./images/item-detail/${collection.image}"
+        alt="${collection.title}"
+        slot="image"
+      />
+      <div id="items-${index}" slot="metadata"><strong>${collection.items} items</strong></div>
+      <div id="description-${index}" slot="metadata">
+        Selections from the global permanent collection.
+      </div>
     </pharos-image-card>`;
   })}</pharos-layout
 >`;
@@ -88,10 +109,10 @@ export const CollectionsTemplate = () => html`<pharos-layout style="margin: 1rem
   </Story>
 </Canvas>
 
-# Subtle
+# Subtle State
 
 <Canvas>
-  <Story name="Subtle" args={{ subtle: true }}>
+  <Story name="Subtle State" args={{ subtle: true }}>
     {Template.bind({})}
   </Story>
 </Canvas>
@@ -108,10 +129,15 @@ export const CollectionsTemplate = () => html`<pharos-layout style="margin: 1rem
           action-menu="my-dropdown-menu"
           style="grid-column: span 2"
         >
-          <img src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-          <div slot="metadata">Tubby, William Bunker (American architect,...</div>
-          <div slot="metadata">1889-1892 (creation)</div>
-          <div slot="metadata">
+          <img
+            id="image"
+            src="./images/item-detail/collection_5.png"
+            alt="south hall"
+            slot="image"
+          />
+          <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+          <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+          <div id="collection" slot="metadata">
             Part of
             <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
               >Pratt Institute Buildings Image Collection</pharos-link

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -1,0 +1,16 @@
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs/blocks';
+import { html } from 'lit-html';
+
+import './pharos-image-card';
+
+<Meta title="Components/Image Card" />
+
+# ImageCard
+
+<Canvas>
+  <Story name="Base">{html` <pharos-image-card title="South Hall"></pharos-image-card> `}</Story>
+</Canvas>
+
+## API
+
+<ArgsTable of="pharos-image-card" />

--- a/packages/pharos/src/components/layout/pharos-layout.test.ts
+++ b/packages/pharos/src/components/layout/pharos-layout.test.ts
@@ -24,16 +24,28 @@ describe('pharos-layout', () => {
     component.areas = "'top' 'body'";
     await component.updateComplete;
 
-    const layout = component.renderRoot.querySelector('.layout') as HTMLDivElement;
-    expect(layout.style.gridTemplateAreas).to.equal('"top" "body"');
+    expect(component['_layout'].style.gridTemplateAreas).to.equal('"top" "body"');
   });
 
   it('has an attribute to set the inner grid rows', async () => {
     component.rows = 'max-content 1fr';
     await component.updateComplete;
 
-    const layout = component.renderRoot.querySelector('.layout') as HTMLDivElement;
-    expect(layout.style.gridTemplateRows).to.equal('max-content 1fr');
+    expect(component['_layout'].style.gridTemplateRows).to.equal('max-content 1fr');
+  });
+
+  it('has an attribute to set the inner grid row gap', async () => {
+    component.rowGap = '1rem';
+    await component.updateComplete;
+
+    expect(component['_layout'].style.rowGap).to.equal('1rem');
+  });
+
+  it('has an attribute to set the HTML tag of the inner grid', async () => {
+    component.tag = 'ol';
+    await component.updateComplete;
+
+    expect(component['_layout'].tagName).to.equal('OL');
   });
 
   it('throws an error for an invalid preset value', async () => {

--- a/packages/pharos/src/components/layout/pharos-layout.ts
+++ b/packages/pharos/src/components/layout/pharos-layout.ts
@@ -1,6 +1,6 @@
-import { html, LitElement, property } from 'lit-element';
+import { html, LitElement, property, query } from 'lit-element';
 import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit-element';
-import { styleMap } from 'lit-html/directives/style-map.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { layoutStyles } from './pharos-layout.css';
 import { designTokens } from '../../styles/variables.css';
 import { customElement } from '../../utils/decorators';
@@ -49,6 +49,16 @@ export class PharosLayout extends LitElement {
   @property({ type: String, reflect: true, attribute: 'row-gap' })
   public rowGap = PharosSpacingThreeAndAHalfX;
 
+  /**
+   * Indicates the HTML tag to use for the inner grid.
+   * @attr tag
+   */
+  @property({ type: String, reflect: true })
+  public tag = 'div';
+
+  @query('.layout')
+  private _layout!: HTMLElement;
+
   public static get styles(): CSSResultArray {
     return [designTokens, layoutStyles];
   }
@@ -64,18 +74,21 @@ export class PharosLayout extends LitElement {
     }
   }
 
+  protected updated(changedProperties: PropertyValues): void {
+    if (changedProperties.has('areas')) {
+      this._layout.style.gridTemplateAreas = this.areas;
+    }
+    if (changedProperties.has('rows')) {
+      this._layout.style.gridTemplateRows = this.rows;
+    }
+    if (changedProperties.has('rowGap')) {
+      this._layout.style.rowGap = this.rowGap;
+    }
+  }
+
   protected render(): TemplateResult {
-    return html`<slot name="top"></slot>
-      <div
-        class="layout"
-        style=${styleMap({
-          gridTemplateAreas: this.areas,
-          gridTemplateRows: this.rows,
-          rowGap: this.rowGap,
-        })}
-      >
-        <slot></slot>
-      </div>`;
+    const template = `<slot name="top"></slot><${this.tag} class="layout"><slot></slot></${this.tag}>`;
+    return html`${unsafeHTML(template)}`;
   }
 }
 

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -56,6 +56,12 @@
   @include mixins.no-underline;
 }
 
+:host([subtle]) #link-element.link--hover {
+  @include mixins.underline($text-decoration-color: var(--pharos-color-hover-primary));
+
+  color: var(--pharos-color-hover-primary);
+}
+
 :host([on-background][subtle]) #link-element:hover {
   @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
 }

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -69,6 +69,9 @@ export class PharosLink extends FocusMixin(AnchorElement) {
   @state()
   private _alert!: PharosAlert;
 
+  @state()
+  private _hover = false;
+
   public static get styles(): CSSResultArray {
     return [designTokens, linkStyles];
   }
@@ -86,6 +89,7 @@ export class PharosLink extends FocusMixin(AnchorElement) {
       id="link-element"
       class="${classMap({
         [`link--alert`]: this._alert && this._alert.status !== 'error',
+        [`link--hover`]: this._hover,
       })}"
       download=${ifDefined(this.download)}
       href=${ifDefined(this.href)}

--- a/packages/pharos/src/components/toast/PharosToast.react.stories.mdx
+++ b/packages/pharos/src/components/toast/PharosToast.react.stories.mdx
@@ -84,7 +84,6 @@ import { PharosLink } from '../../react-components/link/pharos-link';
           <PharosButton
             id="long-toast-button"
             onClick={() => {
-              console.log('test');
               const event = new CustomEvent('pharos-toast-open', {
                 detail: {
                   content:

--- a/packages/pharos/src/index.ts
+++ b/packages/pharos/src/index.ts
@@ -38,3 +38,4 @@ export { PharosToaster } from './components/toast/pharos-toaster';
 export { PharosToastButton } from './components/toast/pharos-toast-button';
 export { PharosSidenavButton } from './components/sidenav/pharos-sidenav-button';
 export { PharosLayout } from './components/layout/pharos-layout';
+export { PharosImageCard } from './components/image-card/pharos-image-card';

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -249,7 +249,7 @@
 }
 
 @mixin link-base {
-  @include font-base($font-size: inherit);
+  @include font-base($font-size: inherit, $line-height: inherit);
   @include underline;
 
   color: var(--pharos-color-interactive-secondary);

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -435,3 +435,11 @@
     }
   }
 }
+
+@mixin truncate-text($lines: 1) {
+  overflow: hidden;
+  -webkit-line-clamp: $lines;
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  white-space: normal;
+}

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -357,6 +357,9 @@
   grid-template-columns: repeat(map-get(variables.$breakpoints, large, columns), 1fr);
   grid-template-rows: auto;
   column-gap: var(--pharos-spacing-gutter);
+  padding: 0;
+  margin: 0;
+  list-style: none;
 
   @include until(medium) {
     grid-template-columns: repeat(map-get(variables.$breakpoints, medium, columns), 1fr);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,10 +4414,10 @@
     "@types/mocha" "^8.2.0"
     "@web/test-runner-core" "^0.10.8"
 
-"@web/test-runner-playwright@^0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-playwright/-/test-runner-playwright-0.8.5.tgz#a007a6511086ae1706b960eaf994850fdc52a79d"
-  integrity sha512-4UvWKBT/1QogQ1LxFTOB4hrIwEOu6xmYxgRSbaNlQ98ouPApTawXkgKwRcAwJrlAYazzAo98WCQ6w7v+YGxChw==
+"@web/test-runner-playwright@^0.8.6":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-playwright/-/test-runner-playwright-0.8.6.tgz#4f1c1543bef2d6b6d7788e4c835e5cf0cf365abe"
+  integrity sha512-GjjCd5MtCxmCsNlfe4HmmRyTg1S1SMAn0+i+2yhG9pvYwSJWLmLqN4AE39ZhlhuPh79spSVU889F6CGEXZGXPg==
   dependencies:
     "@web/test-runner-core" "^0.10.8"
     "@web/test-runner-coverage-v8" "^0.4.5"
@@ -16673,10 +16673,10 @@ platform@^1.3.6:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-playwright@^1.10.0, playwright@^1.8.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.10.0.tgz#a14d295f1ad886caf4cc5e674afe03ac832066bc"
-  integrity sha512-b7SGBcCPq4W3pb4ImEDmNXtO0ZkJbZMuWiShsaNJd+rGfY/6fqwgllsAojmxGSgFmijYw7WxCoPiAIEDIH16Kw==
+playwright@^1.11.0, playwright@^1.8.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.11.0.tgz#0796cf08f4756e8187e01c705315d8e1fb48e25f"
+  integrity sha512-s3FQBRpu/pW/vZ/lFYhG/Q3WBUbT2rvMgrgy1PHDA7QtPN910C2rj9Ovd6A/m8yxuLnltd/OKqvlAGevWISHKw==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -16691,6 +16691,7 @@ playwright@^1.10.0, playwright@^1.8.1:
     rimraf "^3.0.2"
     stack-utils "^2.0.3"
     ws "^7.3.1"
+    yazl "^2.5.1"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -23101,6 +23102,13 @@ yauzl@^2.10.0, yauzl@^2.4.2:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Add image card component to be used for presenting a list of items or collections on the platform.

**How does this change work?**

- Add card component with `error` and `subtle` states
- Add `action-menu` attribute to render an action button to act as the trigger for the menu
- Add `collection` variant to present collection in 4:3 aspect ratio
- Add `tag` prop to `pharos-layout` to specify the HTML tag to use for the inner grid
- Update `playwright`