### PR TITLE
fix: exclude changesets from lint-staged

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   '*.{ts,tsx,mdx,js,mjs}': ['eslint --fix'],
   '*.{scss,css}': ['stylelint --fix'],
-  '*.md': (filenames) => filenames.map((filename) => `yarn markdown-toc -i '${filename}'`),
+  '**/!(.changeset)/*.md': (filenames) =>
+    filenames.map((filename) => `yarn markdown-toc -i '${filename}'`),
 };


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
fixes #43 

**How does this change work?**

- Exclude `.changeset` directory from lint-staged