### PR TITLE
fix(pharos): render link for error image cards and allow subtle state

### DIFF
--- a/.changeset/angry-dragons-eat.md
+++ b/.changeset/angry-dragons-eat.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+render link for error image cards and allow subtle state

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -20,7 +20,6 @@
 }
 
 .card__link--image,
-.card__container--error,
 .card__container--collection {
   margin-bottom: var(--pharos-spacing-1-x);
 }
@@ -64,6 +63,7 @@
   align-items: center;
   text-align: center;
   row-gap: var(--pharos-spacing-1-x);
+  align-self: flex-end;
 }
 
 .card__title {

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -137,7 +137,24 @@ describe('pharos-image-card', () => {
     expect(metadataHover).not.to.be.null;
   });
 
+  it('renders a hoverable version of the metadata in the error and subtle state', async () => {
+    component.subtle = true;
+    component.error = true;
+    await component.updateComplete;
+
+    const metadataHover = component.renderRoot.querySelector('.card__metadata--hover');
+    expect(metadataHover).not.to.be.null;
+  });
+
   it('renders a link around the image for the base variant', async () => {
+    const link = component.renderRoot.querySelector('pharos-link.card__link--image');
+    expect(link).not.to.be.null;
+  });
+
+  it('renders a link around the container for the error state', async () => {
+    component.error = true;
+    await component.updateComplete;
+
     const link = component.renderRoot.querySelector('pharos-link.card__link--image');
     expect(link).not.to.be.null;
   });

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -107,25 +107,32 @@ export class PharosImageCard extends LitElement {
     </div>`;
   }
 
-  private _renderBaseImage(): TemplateResult {
+  private _renderLinkContent(): TemplateResult {
     return this.error
       ? html`<div class="card__container--error">
           <pharos-icon name="exclamation-inverse"></pharos-icon>Preview not available
         </div>`
-      : html`<pharos-link
-          class="card__link--image"
-          href="${this.link}"
-          subtle
-          flex
-          @mouseenter=${this._handleImageHover}
-          @mouseleave=${this._handleImageHover}
-          ><slot name="image"></slot>${this.subtle
-            ? html`<div class="card__metadata--hover">
-                <strong class="card__title--hover">${this.title}</strong
-                ><slot name="metadata"></slot>
-              </div>`
-            : nothing}</pharos-link
-        >`;
+      : html`<slot name="image"></slot>`;
+  }
+
+  private _renderHoverMetadata(): TemplateResult | typeof nothing {
+    return this.subtle
+      ? html`<div class="card__metadata--hover">
+          <strong class="card__title--hover">${this.title}</strong><slot name="metadata"></slot>
+        </div>`
+      : nothing;
+  }
+
+  private _renderBaseImage(): TemplateResult {
+    return html`<pharos-link
+      class="card__link--image"
+      href="${this.link}"
+      subtle
+      flex
+      @mouseenter=${this._handleImageHover}
+      @mouseleave=${this._handleImageHover}
+      >${this._renderLinkContent()}${this._renderHoverMetadata()}</pharos-link
+    >`;
   }
 
   private _renderImage(): TemplateResult {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Image cards in the error state should render a link around the "Preview not available" container and show metadata on hover in combination with the subtle state.

**How does this change work?**

- render link for error image cards and allow subtle state