### PR TITLE
ci: redirect to Storybooks from site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,11 @@
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/wc/*"
+  from = "/storybooks/wc/*"
   to = "https://pharos-storybooks.netlify.app/wc/:splat"
   status = 200
   force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/react/*"
+  from = "/storybooks/react/*"
   to = "https://pharos-storybooks.netlify.app/react/:splat"
   status = 200
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[[redirects]]
+  from = "https://pharos.jstor.org/storybooks/wc/*"
+  to = "https://pharos-storybooks.netlify.app/wc/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "https://pharos.jstor.org/storybooks/react/*"
+  to = "https://pharos-storybooks.netlify.app/react/:splat"
+  status = 200
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,11 @@
 [[redirects]]
-  from = "/storybooks/wc/*"
+  from = "https://pharos.jstor.org/storybooks/wc/*"
   to = "https://pharos-storybooks.netlify.app/wc/:splat"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/storybooks/react/*"
+  from = "https://pharos.jstor.org/storybooks/react/*"
   to = "https://pharos-storybooks.netlify.app/react/:splat"
   status = 200
   force = true


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
We want to be able to access the Storybooks deployed on Netlify from the Pharos site using the pharos.jstor.org domain.

**How does this change work?**

- Add toml with redirect rules