### PR TITLE
fix(pharos): set overflow for subtle image cards

### DIFF
--- a/.changeset/good-fans-hope.md
+++ b/.changeset/good-fans-hope.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+set overflow for subtle image cards

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -41,6 +41,7 @@
 
   height: 100%;
   box-sizing: border-box;
+  overflow: auto;
   color: var(--pharos-color-text-white);
   background-color: rgba(0, 0, 0, 0);
   padding: var(--pharos-spacing-three-quarters-x);


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
fixes #56 

**How does this change work?**

- Set overflow for subtle image cards