### PR TITLE
fix(storybook): try using more explicit patterns to fix routing

### DIFF
--- a/.changeset/proud-pumpkins-own.md
+++ b/.changeset/proud-pumpkins-own.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+Fix Netlify app routing involving slashes

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,29 +1,35 @@
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/wc/*"
-  to = "https://pharos-storybooks.netlify.app/wc/:splat"
+  from = "/storybook"
+  to = "https://pharos-storybooks.netlify.app/main/"
   status = 200
   force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/react/*"
-  to = "https://pharos-storybooks.netlify.app/react/:splat"
-  status = 200
-  force = true
-
-[[redirects]]
-  from = "https://pharos.jstor.org/storybook/*"
+  from = "/storybook/*"
   to = "https://pharos-storybooks.netlify.app/main/:splat"
   status = 200
   force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/wc"
-  to = "https://pharos.jstor.org/storybooks/wc/"
+  from = "/storybooks/wc"
+  to = "https://pharos-storybooks.netlify.app/wc/"
+  status = 200
+  force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/react"
-  to = "https://pharos.jstor.org/storybooks/react/"
+  from = "/storybooks/wc/*"
+  to = "https://pharos-storybooks.netlify.app/wc/:splat"
+  status = 200
+  force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybook"
-  to = "https://pharos.jstor.org/storybook/"
+  from = "/storybooks/react"
+  to = "https://pharos-storybooks.netlify.app/react/"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/storybooks/react/*"
+  to = "https://pharos-storybooks.netlify.app/react/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Routing to the Storybooks still only works when a trailing slash is included. This could be because Netlify treats URLs with/without a trailing slash as equivalent to maximize cache hits, and our redirects weren't sending some requests explicitly to the backing app, instead just trying to append a slash to the incoming URL.

**How does this change work?**
Create an explicit redirect to the backing app for each of:

* `/storybook`
* `/storybook/*`
* `/storybooks/react`
* `/storybooks/react/*`
* `/storybooks/wc`
* `/storybooks/wc/*`

**Additional context**
I also simplified the `from` values to be just the paths rather than the full URL, and ordered them by route from most general to most specific.
