### PR TITLE
fix: update redirect logic

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
   from = "/storybook"
-  to = "https://pharos.jstor.org/storybook/"
+  to = "/storybook/"
   status = 301
   force = true
 
@@ -12,7 +12,7 @@
 
 [[redirects]]
   from = "/storybooks/wc"
-  to = "https://pharos.jstor.org/storybooks/wc/"
+  to = "/storybooks/wc/"
   status = 301
   force = true
 
@@ -24,7 +24,7 @@
 
 [[redirects]]
   from = "/storybooks/react"
-  to = "https://pharos.jstor.org/storybooks/react/"
+  to = "/storybooks/react/"
   status = 301
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
   from = "/storybook"
-  to = "https://pharos-storybooks.netlify.app/main/"
+  to = "https://pharos.jstor.org/storybook/"
   status = 301
   force = true
 
@@ -12,7 +12,7 @@
 
 [[redirects]]
   from = "/storybooks/wc"
-  to = "https://pharos-storybooks.netlify.app/wc/"
+  to = "https://pharos.jstor.org/storybooks/wc/"
   status = 301
   force = true
 
@@ -24,7 +24,7 @@
 
 [[redirects]]
   from = "/storybooks/react"
-  to = "https://pharos-storybooks.netlify.app/react/"
+  to = "https://pharos.jstor.org/storybooks/react/"
   status = 301
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,29 +1,40 @@
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/wc/*"
-  to = "https://pharos-storybooks.netlify.app/wc/:splat"
-  status = 200
+  from = "/storybook"
+  to = "https://pharos-storybooks.netlify.app/main/"
+  status = 301
   force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/react/*"
-  to = "https://pharos-storybooks.netlify.app/react/:splat"
-  status = 200
-  force = true
-
-[[redirects]]
-  from = "https://pharos.jstor.org/storybook/*"
+  from = "/storybook/*"
   to = "https://pharos-storybooks.netlify.app/main/:splat"
   status = 200
   force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/wc"
-  to = "https://pharos.jstor.org/storybooks/wc/"
+  from = "/storybooks/wc"
+  to = "https://pharos-storybooks.netlify.app/wc/"
+  status = 301
+  force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybooks/react"
-  to = "https://pharos.jstor.org/storybooks/react/"
+  from = "/storybooks/wc/*"
+  to = "https://pharos-storybooks.netlify.app/wc/:splat"
+  status = 200
+  force = true
 
 [[redirects]]
-  from = "https://pharos.jstor.org/storybook"
-  to = "https://pharos.jstor.org/storybook/"
+  from = "/storybooks/react"
+  to = "https://pharos-storybooks.netlify.app/react/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/storybooks/react/*"
+  to = "https://pharos-storybooks.netlify.app/react/:splat"
+  status = 200
+  force = true
+
+[[headers]]
+  for = "/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
   from = "/storybook"
-  to = "/storybook/"
+  to = "https://pharos.jstor.org/storybook/"
   status = 301
   force = true
 
@@ -12,7 +12,7 @@
 
 [[redirects]]
   from = "/storybooks/wc"
-  to = "/storybooks/wc/"
+  to = "https://pharos.jstor.org/storybooks/wc/"
   status = 301
   force = true
 
@@ -24,7 +24,7 @@
 
 [[redirects]]
   from = "/storybooks/react"
-  to = "/storybooks/react/"
+  to = "https://pharos.jstor.org/storybooks/react/"
   status = 301
   force = true
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Attempt to fix routing when URL does not contain trailing slash using redirect status codes.

**How does this change work?**

- Use redirect status codes for paths without a trailing slash

**Additional context**
For preview builds, the Storybooks will redirect to the production build URL pharos.jstor.org.