### PR TITLE
fix: point to separate netlify deployment for composition

### DIFF
--- a/.storybook/main/main.js
+++ b/.storybook/main/main.js
@@ -18,11 +18,11 @@ config.refs = (config, { configType }) => {
   return {
     webComponents: {
       title: 'Web Components',
-      url: 'https://pharos.jstor.org/storybooks/wc/',
+      url: 'https://pharos-storybooks.netlify.app/wc/',
     },
     react: {
       title: 'React',
-      url: 'https://pharos.jstor.org/storybooks/react/',
+      url: 'https://pharos-storybooks.netlify.app/react/',
     },
   };
 };


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Our composed Storybook doesn't work on pharos.jstor.org because the references Storybooks have the same domain.

**How does this change work?**

- Update references Storybook to https://pharos-storybooks.netlify.app/ versions