### PR TITLE
docs(pharos-site): add storybook links to public component sections

### DIFF
--- a/.changeset/pink-fishes-sparkle.md
+++ b/.changeset/pink-fishes-sparkle.md
@@ -1,0 +1,9 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+docs(pharos-site): add storybook links to public component sections
+
+- add `storyBookType` prop to `PageSection` component which takes in the element type for a specified component
+- if 'storyBookType' is passed, pharos link is rendered to component specified url
+- pass in `storyBookType` into the component sections…

--- a/.changeset/pink-fishes-sparkle.md
+++ b/.changeset/pink-fishes-sparkle.md
@@ -6,4 +6,4 @@ docs(pharos-site): add storybook links to public component sections
 
 - add `storyBookType` prop to `PageSection` component which takes in the element type for a specified component
 - if 'storyBookType' is passed, pharos link is rendered to component specified url
-- pass in `storyBookType` into the component sections…
+- pass in `storyBookType` into the component sections

--- a/packages/pharos-site/src/components/statics/PageSection.tsx
+++ b/packages/pharos-site/src/components/statics/PageSection.tsx
@@ -45,7 +45,7 @@ const PageSection: FC<PageSectionProps> = ({
     const { PharosHeading } = Pharos;
     const { PharosLink } = Pharos;
     const url =
-      'https://pharos.jstor.org/storybooks/wc/?path=/story/' +
+      'https://pharos.jstor.org/storybook/?path=/story/webcomponents_' +
       storyBookType +
       '-' +
       title.replace(/ /g, '-') +

--- a/packages/pharos-site/src/components/statics/PageSection.tsx
+++ b/packages/pharos-site/src/components/statics/PageSection.tsx
@@ -136,7 +136,17 @@ const PageSection: FC<PageSectionProps> = ({
       </div>
     );
     setDisplay(content);
-  }, [Pharos, children, description, isHeader, moreTitleSpace, title, lessMargin, subSectionLevel]);
+  }, [
+    Pharos,
+    children,
+    description,
+    isHeader,
+    moreTitleSpace,
+    title,
+    lessMargin,
+    subSectionLevel,
+    storyBookType,
+  ]);
 
   return Display;
 };

--- a/packages/pharos-site/src/components/statics/PageSection.tsx
+++ b/packages/pharos-site/src/components/statics/PageSection.tsx
@@ -20,6 +20,7 @@ interface PageSectionProps {
   subSectionLevel: 1 | 2 | 3;
   moreTitleSpace?: boolean;
   lessMargin?: boolean;
+  storyBookType?: string;
 }
 
 const PageSection: FC<PageSectionProps> = ({
@@ -30,6 +31,7 @@ const PageSection: FC<PageSectionProps> = ({
   children,
   moreTitleSpace,
   lessMargin,
+  storyBookType,
 }) => {
   const [Display, setDisplay] = useState<ReactElement | null>(null);
   const Pharos =
@@ -41,6 +43,13 @@ const PageSection: FC<PageSectionProps> = ({
 
   useEffect(() => {
     const { PharosHeading } = Pharos;
+    const { PharosLink } = Pharos;
+    const url =
+      'https://pharos.jstor.org/storybooks/wc/?path=/story/' +
+      storyBookType +
+      '-' +
+      title.replace(/ /g, '-') +
+      '--base';
 
     const headerTitle = (
       <div className={title__isHeader}>
@@ -82,6 +91,14 @@ const PageSection: FC<PageSectionProps> = ({
       </div>
     );
 
+    const storyBookLink = (
+      <div>
+        <PharosLink href={url} target="_blank">
+          See in Storybook
+        </PharosLink>
+      </div>
+    );
+
     const displayedTitle = () => {
       if (isHeader) {
         return headerTitle;
@@ -114,6 +131,7 @@ const PageSection: FC<PageSectionProps> = ({
         {description ? (
           <div className={isHeader ? description__isHeader : description__base}>{description}</div>
         ) : null}
+        {storyBookType ? storyBookLink : null}
         {children}
       </div>
     );

--- a/packages/pharos-site/static/guidelines/alert.docs.mdx
+++ b/packages/pharos-site/static/guidelines/alert.docs.mdx
@@ -4,13 +4,10 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 <PageSection
   title="Alert"
   isHeader
+  storyBookType="components"
   description="Alerts inform users about important information, which can be displayed as persistent site
   messaging or appear based on a task that a user is trying to complete."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection
   title="Usage"

--- a/packages/pharos-site/static/guidelines/breadcrumb.docs.mdx
+++ b/packages/pharos-site/static/guidelines/breadcrumb.docs.mdx
@@ -3,14 +3,11 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Breadcrumb"
   description="The breadcrumb component is a secondary navigational pattern that allows users to move between
     and obtain context of various levels of hierarchy."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection
   title="Usage"

--- a/packages/pharos-site/static/guidelines/button.docs.mdx
+++ b/packages/pharos-site/static/guidelines/button.docs.mdx
@@ -2,11 +2,12 @@ import PageSection from '../../src/components/statics/PageSection.tsx';
 import BestPractices from '../../src/components/statics/BestPractices.tsx';
 import ellipsesExample from '../images/components/button/buttons_ellipses-example.png';
 
-<PageSection title="Button" description="Buttons communicate actions that users can take." isHeader>
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+<PageSection
+  title="Button"
+  description="Buttons communicate actions that users can take."
+  isHeader
+  storyBookType="components"
+></PageSection>
 
 <PageSection title="Usage" description="Buttons communicate actions that users can take.">
   <PageSection title="When to use buttons" subSectionLevel={1}>
@@ -234,7 +235,7 @@ import ellipsesExample from '../images/components/button/buttons_ellipses-exampl
   <PageSection title="With icons" subSectionLevel={1}>
     <p>
       Pair text with an icon to better clarify the meaning of the button. Use no more than one icon
-      before text and one icon after text (see
+      before text and one icon after text (see &nbsp;
       <PharosLink href="https://pharos.jstor.org/brand-expressions/iconography">
         Pharos icons
       </PharosLink>

--- a/packages/pharos-site/static/guidelines/checkbox.docs.mdx
+++ b/packages/pharos-site/static/guidelines/checkbox.docs.mdx
@@ -6,11 +6,8 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
   description="Checkboxes present items in a list of one or more options where the user can have several
   different combinations of selections."
   isHeader
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+  storyBookType="forms"
+></PageSection>
 
 <PageSection
   title="Usage"

--- a/packages/pharos-site/static/guidelines/combobox.docs.mdx
+++ b/packages/pharos-site/static/guidelines/combobox.docs.mdx
@@ -6,11 +6,8 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
   description="Comboboxes combine text inputs and dropdowns. The text input is used for filtering the options,
   while the dropdown allows the selecting of options."
   isHeader
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+  istoryBookType="forms"
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/dropdown-menu-nav.docs.mdx
+++ b/packages/pharos-site/static/guidelines/dropdown-menu-nav.docs.mdx
@@ -5,11 +5,8 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
   title="Dropdown Menu Nav"
   description="The dropdown menu nav provides users an overview of your site's page hierarchy."
   isHeader
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+  storyBookType="components"
+></PageSection>
 
 <PageSection
   title="Usage"

--- a/packages/pharos-site/static/guidelines/dropdown-menu.docs.mdx
+++ b/packages/pharos-site/static/guidelines/dropdown-menu.docs.mdx
@@ -5,11 +5,8 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
   isHeader
   title="Dropdown Menu"
   description="Dropdown menus present a list of menu items from which a user can choose from."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+  storyBookType="components"
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/footer.docs.mdx
+++ b/packages/pharos-site/static/guidelines/footer.docs.mdx
@@ -5,11 +5,8 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
   isHeader
   title="Footer"
   description="Footers are used as a container for site navigational elements and disclaimers."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+  storyBookType="organisms"
+></PageSection>
 
 <PageSection
   title="Usage"

--- a/packages/pharos-site/static/guidelines/header.docs.mdx
+++ b/packages/pharos-site/static/guidelines/header.docs.mdx
@@ -5,11 +5,8 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
   isHeader
   title="Header"
   description="Headers are generally used as a container for introductory content or navigational elements."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+  storyBookType="organisms"
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/heading.docs.mdx
+++ b/packages/pharos-site/static/guidelines/heading.docs.mdx
@@ -1,22 +1,12 @@
 import PageSection from '../../src/components/statics/PageSection.tsx';
 import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
-<PharosHeading
-  level={'1'}
-  preset={'7--bold'}
-  style={{ color: 'black', marginBottom: 'var(--pharos-spacing-2-x)' }}
->
-  Heading
-</PharosHeading>
-
-<div style={{ marginBottom: 'var(--pharos-spacing-5-x)' }}>
-  <p style={{ fontSize: 'var(--pharos-type-scale-6)', lineHeight: '2rem' }}>
-    Headings are used as the titles or labels of each major section of a page that make up the UI.
-  </p>
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</div>
+<PageSection
+  isHeader
+  title="Heading"
+  description="Headings are used as the titles or labels of each major section of a page that make up the UI."
+  storyBookType="components"
+></PageSection>
 
 ## Usage
 

--- a/packages/pharos-site/static/guidelines/icon.docs.mdx
+++ b/packages/pharos-site/static/guidelines/icon.docs.mdx
@@ -3,13 +3,10 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Icon"
   description="Pharos Icons are SVG visual representations of objects, items or content, or actions a user can take."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <PageSection title="When to use" subSectionLevel={1}>

--- a/packages/pharos-site/static/guidelines/input-group.docs.mdx
+++ b/packages/pharos-site/static/guidelines/input-group.docs.mdx
@@ -3,14 +3,11 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="forms"
   title="Input Group"
   description="Input groups allow users to provide information as part of a form in combination with a button,
     icon, or select element on either side of the text input for extra functionality."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/link.docs.mdx
+++ b/packages/pharos-site/static/guidelines/link.docs.mdx
@@ -3,13 +3,10 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Link"
   description="Links enable users to navigate to a different place or to additional information."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   Use links to allow users to navigate to another page within the application, navigate to a

--- a/packages/pharos-site/static/guidelines/loading-spinner.docs.mdx
+++ b/packages/pharos-site/static/guidelines/loading-spinner.docs.mdx
@@ -4,13 +4,10 @@ import CodeBlock from '../../src/components/CodeBlock';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Loading Spinner"
   description="Loading spinners indicate that a page, section, or content is loading."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/modal.docs.mdx
+++ b/packages/pharos-site/static/guidelines/modal.docs.mdx
@@ -4,14 +4,11 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 <PageSection
   title="Modal"
   isHeader
+  storyBookType="components"
   description="Modals are overlays that present a user with focused information and actions that sit on top of
     a page's content. They are used for getting a user's attention and for taking action without
     changing page context."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <PageSection title="Overview" subSectionLevel={1} lessMargin>

--- a/packages/pharos-site/static/guidelines/pagination.docs.mdx
+++ b/packages/pharos-site/static/guidelines/pagination.docs.mdx
@@ -4,13 +4,10 @@ import CodeBlock from '../../src/components/CodeBlock';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Pagination"
   description="Pagination allows users to move through a list or set of items that have been split into different pages."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/progress-bar.docs.mdx
+++ b/packages/pharos-site/static/guidelines/progress-bar.docs.mdx
@@ -4,13 +4,10 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 <PageSection
   isHeader
   title="Progress Bar"
+  storyBookType="components"
   description="The progress bar visually represents progress of a particular process. It shows how much of the
     task has been completed and how much is remaining."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/radio.docs.mdx
+++ b/packages/pharos-site/static/guidelines/radio.docs.mdx
@@ -3,14 +3,11 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="forms"
   title="Radio Button"
   description="Radio buttons present items in a list of two or more options where the user can select only one
   option at a time."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Best practices">
   <p>

--- a/packages/pharos-site/static/guidelines/select.docs.mdx
+++ b/packages/pharos-site/static/guidelines/select.docs.mdx
@@ -3,13 +3,10 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="forms"
   title="Select"
   description="A select allows users to choose one option from a list in a form."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Best practices">
   <p>

--- a/packages/pharos-site/static/guidelines/sidenav.docs.mdx
+++ b/packages/pharos-site/static/guidelines/sidenav.docs.mdx
@@ -3,14 +3,11 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Sidenav"
   description="The sidenav component is a vertical navigation layout that houses links and menus to help users
     navigate the site."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/tabs.docs.mdx
+++ b/packages/pharos-site/static/guidelines/tabs.docs.mdx
@@ -3,13 +3,10 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Tabs"
   description="Tabs are used to quickly navigate between views within the same context or page. Each tab's content is independently categorized and mutually exclusive of the content of other tabs."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/template.mdx
+++ b/packages/pharos-site/static/guidelines/template.mdx
@@ -6,7 +6,7 @@
 import PageSection from '../../src/components/statics/PageSection.tsx';
 import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
-<PageSection isHeader title="" description="" isStoryBook></PageSection>
+<PageSection isHeader title="" description="" storyBookType=""></PageSection>
 
 <PageSection title="Usage">
 

--- a/packages/pharos-site/static/guidelines/template.mdx
+++ b/packages/pharos-site/static/guidelines/template.mdx
@@ -6,11 +6,7 @@
 import PageSection from '../../src/components/statics/PageSection.tsx';
 import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
-<PageSection isHeader title="" description="">
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+<PageSection isHeader title="" description="" isStoryBook></PageSection>
 
 <PageSection title="Usage">
 

--- a/packages/pharos-site/static/guidelines/text-input.docs.mdx
+++ b/packages/pharos-site/static/guidelines/text-input.docs.mdx
@@ -3,13 +3,10 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="forms"
   title="Text Input"
   description="Text inputs enable users to supply data as part of a form or a query string for search."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/textarea.docs.mdx
+++ b/packages/pharos-site/static/guidelines/textarea.docs.mdx
@@ -4,12 +4,9 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 <PageSection
   isHeader
   title="Textarea"
+  storyBookType="forms"
   description="A text area allows users to enter long, free-form text that can be on multiple lines."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/toast.docs.mdx
+++ b/packages/pharos-site/static/guidelines/toast.docs.mdx
@@ -3,14 +3,11 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  isStoryBook
   title="Toast"
   description="Toasts are non-disruptive messages that appear at the top right corner of the UI to provide
     quick, at-a-glance feedback on the outcome of an action."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <p>

--- a/packages/pharos-site/static/guidelines/toast.docs.mdx
+++ b/packages/pharos-site/static/guidelines/toast.docs.mdx
@@ -3,7 +3,7 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
-  isStoryBook
+  storyBookType="components"
   title="Toast"
   description="Toasts are non-disruptive messages that appear at the top right corner of the UI to provide
     quick, at-a-glance feedback on the outcome of an action."

--- a/packages/pharos-site/static/guidelines/tooltip.docs.mdx
+++ b/packages/pharos-site/static/guidelines/tooltip.docs.mdx
@@ -7,14 +7,11 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
 
 <PageSection
   isHeader
+  storyBookType="components"
   title="Tooltip"
   description="Tooltips provide concise additional information upon hover or focus. The content should be
   contextual, helpful, and non-critical."
->
-  <PharosLink href="#" target="_blank">
-    See in Storybook
-  </PharosLink>
-</PageSection>
+></PageSection>
 
 <PageSection title="Usage">
   <PageSection subSectionLevel={1} title="Placement">

--- a/packages/pharos-site/static/guidelines/type-styles.docs.mdx
+++ b/packages/pharos-site/static/guidelines/type-styles.docs.mdx
@@ -5,7 +5,10 @@ import PageSection from '../../src/components/statics/PageSection.tsx';
   title="Type styles"
   description="Pharos type styles and mixins allow us to express our brand consistently and efficiently in our products."
 >
-  <PharosLink href="#" target="_blank">
+  <PharosLink
+    href="https://pharos.jstor.org/storybooks/wc/?path=/story/styles-typography--plain-text"
+    target="_blank"
+  >
     See in Storybook
   </PharosLink>
 </PageSection>


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Add storybook links to component pages now that it is public.

**How does this change work?**
- add `storyBookType` prop to `PageSection` component which takes in the element type for a specified component
- if 'storyBookType' is passed, pharos link is rendered to component specified url
- pass  in `storyBookType` into the component sections

