### PR TITLE
feat(pharos-site): reactivate logo guidelines and deactivate design token overview

### DIFF
--- a/.changeset/shy-lizards-lie.md
+++ b/.changeset/shy-lizards-lie.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+Reactiviate logo guidelines and deactiviate design token overview

--- a/packages/pharos-site/src/components/Sidenav.tsx
+++ b/packages/pharos-site/src/components/Sidenav.tsx
@@ -82,7 +82,7 @@ const Sidenav: FC = () => {
         </PharosSidenavSection>
         <PharosSidenavSection label="Brand Guidelines" showDivider>
           <PharosSidenavMenu label="Brand expressions" expanded={isExpanded('brand-expressions')}>
-            {['Typography', 'Color', 'Imagery', 'Iconography'].map(
+            {['Logos', 'Typography', 'Color', 'Imagery', 'Iconography'].map(
               createSidenavLink.bind(this, 'brand-expressions')
             )}
           </PharosSidenavMenu>
@@ -102,7 +102,6 @@ const Sidenav: FC = () => {
         <PharosSidenavSection label="Design System">
           <PharosSidenavMenu label="Design Tokens" expanded={isExpanded('design-tokens')}>
             {[
-              'Overview',
               'Alias colors',
               'Global colors',
               'Font family',


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Removes the design tokens overview link from the site while adding the logo guidelines to the brand expressions section.

