### PR TITLE
feat(pharos): enable setting elements in a shadow DOM as tooltip boundary

### DIFF
--- a/.changeset/stupid-laws-roll.md
+++ b/.changeset/stupid-laws-roll.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+enable setting elements in a shadow DOM as tooltip boundary

--- a/packages/pharos/src/components/base/overlay-element.ts
+++ b/packages/pharos/src/components/base/overlay-element.ts
@@ -1,6 +1,6 @@
 import { LitElement, property } from 'lit-element';
 import type { PropertyValues } from 'lit-element';
-
+import deepSelector from '../../utils/deepSelector';
 import { placements } from '../../utils/popper';
 import type { Instance, Options, Placement, PositioningStrategy } from '../../utils/popper';
 
@@ -91,9 +91,7 @@ export class OverlayElement extends LitElement {
         );
         if (preventOverflow?.options) {
           preventOverflow.options.boundary =
-            this.boundary === 'clippingParents'
-              ? this.boundary
-              : document.querySelector(`#${this.boundary}`);
+            this.boundary === 'clippingParents' ? this.boundary : deepSelector(`#${this.boundary}`);
         }
 
         this._popper?.setOptions(this._options);

--- a/packages/pharos/src/components/layout/pharos-layout.ts
+++ b/packages/pharos/src/components/layout/pharos-layout.ts
@@ -87,7 +87,7 @@ export class PharosLayout extends LitElement {
   }
 
   protected render(): TemplateResult {
-    const template = `<slot name="top"></slot><${this.tag} class="layout"><slot></slot></${this.tag}>`;
+    const template = `<slot name="top"></slot><${this.tag} id="layout-container" class="layout"><slot></slot></${this.tag}>`;
     return html`${unsafeHTML(template)}`;
   }
 }

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.ts
@@ -5,6 +5,7 @@ import { styleMap } from 'lit-html/directives/style-map.js';
 import { createPopper } from '../../utils/popper';
 import debounce from '../../utils/debounce';
 import observeResize from '../../utils/observeResize';
+import deepSelector from '../../utils/deepSelector';
 import { tooltipStyles } from './pharos-tooltip.css';
 import { designTokens } from '../../styles/variables.css';
 import { customElement } from '../../utils/decorators';
@@ -227,7 +228,7 @@ export class PharosTooltip extends OverlayElement {
               boundary:
                 this.boundary === 'clippingParents'
                   ? this.boundary
-                  : document.querySelector(`#${this.boundary}`),
+                  : deepSelector(`#${this.boundary}`),
             },
           },
         ],


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Custom boundaries have been restricted to what `document.querySelector` is able to return. We should allow elements in a shadow DOM to also be boundaries (which is now possible with the `deepSelector` utility function).

**How does this change work?**

- Enable setting elements in a shadow DOM as tooltip boundary
- Add `id` to layout's inner container