### PR TITLE
ci: use last built commit for ignore

### DIFF
--- a/build-ignore.sh
+++ b/build-ignore.sh
@@ -2,8 +2,8 @@
 
 if [ "$SITE_NAME" == "pharos-storybooks" ]
 then
-  git diff --quiet HEAD^ HEAD packages/pharos/ .storybook/ package.json yarn.lock netlify.toml
+  git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF packages/pharos/ .storybook/ package.json yarn.lock netlify.toml
 elif [ "$SITE_NAME" == "pharos" ]
 then
-  git diff --quiet HEAD^ HEAD packages/pharos-site/ package.json yarn.lock netlify.toml
+  git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF packages/pharos-site/ package.json yarn.lock netlify.toml
 fi


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
As shown in Netlify's [examples](https://docs.netlify.com/configure-builds/common-configurations/ignore-builds/#ignore-examples) we should use their environment variables to check against the last built commit to avoid deployments for merge commits.

**How does this change work?**

- Use [CACHED_COMMIT_REF and COMMIT_REF](https://docs.netlify.com/configure-builds/environment-variables/#git-metadata)