### PR TITLE
fix(pharos-site): remove trailing slashes from Gatsby paths

### DIFF
--- a/.changeset/smart-years-impress.md
+++ b/.changeset/smart-years-impress.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+remove trailing slashes from Gatsby paths

--- a/packages/pharos-site/gatsby-config.js
+++ b/packages/pharos-site/gatsby-config.js
@@ -63,5 +63,6 @@ module.exports = {
         allExtensions: true,
       },
     },
+    `gatsby-plugin-remove-trailing-slashes`,
   ],
 };

--- a/packages/pharos-site/package.json
+++ b/packages/pharos-site/package.json
@@ -16,6 +16,7 @@
     "gatsby-plugin-mdx": "^2.6.0",
     "gatsby-plugin-offline": "^4.6.0",
     "gatsby-plugin-react-helmet": "^4.6.0",
+    "gatsby-plugin-remove-trailing-slashes": "^3.6.0",
     "gatsby-plugin-sass": "^4.6.0",
     "gatsby-plugin-sharp": "^3.6.0",
     "gatsby-source-filesystem": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,7 +1065,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.13.17", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.13.17", "@babel/runtime@^7.14.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
@@ -10839,6 +10839,13 @@ gatsby-plugin-react-helmet@^4.6.0:
   integrity sha512-+OR34N+H3vZcSN4e4dEyk6tR6NBBP8gINWztDw6/b3sXVJM0hfHRCpbBtgtJGclyjaxAdwbtfos1geKh3AvDHA==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+gatsby-plugin-remove-trailing-slashes@^3.6.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-3.7.0.tgz#9f78ab6716fe777293ff7cbc77e31f444b92bc47"
+  integrity sha512-0i2reT3x7bEFrfY/Qgs07p6Sllj3YS96Du0OpvcaC1a9SCmL/WC4rPVHYQTmr0QQiewP3kpX7yhqDv+o++v8gw==
+  dependencies:
+    "@babel/runtime" "^7.14.0"
 
 gatsby-plugin-sass@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Gatsby adds a trailing slash when you refresh a page or access a subpath via a URL. This leads to images not loading correctly (such as the logo used in the header doc). It also messes with analytics for the site as the same URL with or without the slash are counted as separate pages.

**How does this change work?**

- Use the official Gatsby plugin [gatsby-plugin-remove-trailing-slashes](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-remove-trailing-slashes) to remove trailing slashes