### PR TITLE
feature/make icon size immutable

### DIFF
--- a/.changeset/funny-spies-suffer.md
+++ b/.changeset/funny-spies-suffer.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': major
+---
+
+Remove icon height and width as public properties

--- a/packages/pharos/src/components/alert/pharos-alert.test.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.test.ts
@@ -31,9 +31,7 @@ describe('pharos-alert', () => {
         <pharos-icon
           class="alert__icon"
           description=""
-          height="24"
           name="info-inverse"
-          width="24"
         >
         </pharos-icon>
         <div class="alert__body">

--- a/packages/pharos/src/components/icon/pharos-icon.test.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.test.ts
@@ -19,10 +19,21 @@ describe('pharos-icon', () => {
     expect('No icon named "fake"').to.be.thrown;
   });
 
+  it('uses dimensions 24x24 when the icon name does not end in "-small"', async () => {
+    component.name = 'checkmark';
+    await component.updateComplete;
+    const svg = component.renderRoot.querySelector('svg');
+    expect(svg?.getAttribute('viewBox')).to.equal('0 0 24 24');
+    expect(svg?.getAttribute('height')).to.equal('24');
+    expect(svg?.getAttribute('width')).to.equal('24');
+  });
+
   it('updates its dimensions to 16x16 when the icon name ends with "-small"', async () => {
     component.name = 'checkmark-small';
     await component.updateComplete;
-    expect(component.width).to.equal(16);
-    expect(component.height).to.equal(16);
+    const svg = component.renderRoot.querySelector('svg');
+    expect(svg?.getAttribute('viewBox')).to.equal('0 0 16 16');
+    expect(svg?.getAttribute('height')).to.equal('16');
+    expect(svg?.getAttribute('width')).to.equal('16');
   });
 });

--- a/packages/pharos/src/components/icon/pharos-icon.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.ts
@@ -1,6 +1,6 @@
 import { LitElement, html } from 'lit';
 import { property } from 'lit/decorators.js';
-import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit';
+import type { TemplateResult, CSSResultArray } from 'lit';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import { iconStyles } from './pharos-icon.css';
 import { customElement } from '../../utils/decorators';
@@ -13,6 +13,9 @@ export type IconName = keyof typeof tokens.asset.icon;
 export const iconNames = Object.keys(icons).map((icon) =>
   icon.replace('PHAROS_ASSET_ICON_', '').replace(/_/g, '-').toLowerCase()
 );
+
+const SMALL_ICON_SIZE = 16;
+const LARGE_ICON_SIZE = 24;
 
 /**
  * Pharos icon component.
@@ -30,20 +33,6 @@ export class PharosIcon extends LitElement {
   public name?: IconName;
 
   /**
-   * The height of the icon
-   * @attr height
-   */
-  @property({ type: Number, reflect: true })
-  public height = 24;
-
-  /**
-   * The width of the icon
-   * @attr width
-   */
-  @property({ type: Number, reflect: true })
-  public width = 24;
-
-  /**
    * A description of what the icon represents
    * @attr description
    */
@@ -54,16 +43,8 @@ export class PharosIcon extends LitElement {
     return [iconStyles];
   }
 
-  protected updated(changedProperties: PropertyValues): void {
-    if (changedProperties.has('name')) {
-      if (this.name?.endsWith('-small')) {
-        this.height = 16;
-        this.width = 16;
-      } else {
-        this.height = 24;
-        this.width = 24;
-      }
-    }
+  private _getIconSize(): number {
+    return this.name?.endsWith('-small') ? SMALL_ICON_SIZE : LARGE_ICON_SIZE;
   }
 
   protected render(): TemplateResult {
@@ -79,17 +60,19 @@ export class PharosIcon extends LitElement {
       throw new Error(`No icon named "${this.name}"`);
     }
 
+    const size = this._getIconSize();
+
     return html`
       <svg
         xmlns="http://www.w3.org/2000/svg"
         version="1.1"
-        viewBox="0 0 ${this.width} ${this.height}"
+        viewBox="0 0 ${size} ${size}"
         class="icon"
         role="img"
         aria-hidden=${this.description === ''}
         aria-label=${this.description || ''}
-        height="${this.height}"
-        width="${this.width}"
+        height="${size}"
+        width="${size}"
         focusable="false"
       >
         ${unsafeSVG(svg)}

--- a/packages/pharos/src/components/text-input/pharos-text-input.test.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.test.ts
@@ -178,9 +178,7 @@ describe('pharos-text-input', () => {
         <pharos-icon
           class="input__icon"
           description=""
-          height="24"
           name="exclamation"
-          width="24"
         >
         </pharos-icon>
       </div>
@@ -211,9 +209,7 @@ describe('pharos-text-input', () => {
         <pharos-icon
           class="input__icon"
           description=""
-          height="24"
           name="checkmark"
-          width="24"
         >
         </pharos-icon>
       </div>


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [x] Yes
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

Resolves #46

**How does this change work?**

Remove the height and width properties altogether, and react during rendering to the current `name` value.
