### PR TITLE
fix(button): check if click is canceled for submit buttons

### DIFF
--- a/.changeset/rare-teachers-taste.md
+++ b/.changeset/rare-teachers-taste.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+check if click is canceled for submit buttons

--- a/packages/pharos/src/components/button/pharos-button.test.ts
+++ b/packages/pharos/src/components/button/pharos-button.test.ts
@@ -270,5 +270,39 @@ describe('pharos-button', () => {
 
       expect(leak).to.be.false;
     });
+
+    it('allows clicks to be canceled when in a form and type is set to "submit"', async () => {
+      const parentNode = document.createElement('form');
+      let formdata = new FormData();
+      parentNode.setAttribute('name', 'my-form');
+
+      const submitButton = document.createElement('pharos-button') as PharosButton;
+      submitButton.type = 'submit';
+      submitButton.appendChild(document.createTextNode('I am a button'));
+      submitButton.addEventListener('click', (event) => {
+        event.preventDefault();
+      });
+      parentNode.appendChild(submitButton);
+
+      component = await fixture(
+        html`
+          <pharos-text-input name="my-input" value="test">
+            <span slot="label">I am a label</span>
+          </pharos-text-input>
+        `,
+        { parentNode }
+      );
+
+      const form = document.querySelector('form');
+      form?.addEventListener('submit', (event) => {
+        event.preventDefault();
+        formdata = createFormData(parentNode as HTMLFormElement);
+      });
+
+      submitButton?.click();
+      await component.updateComplete;
+
+      expect(formdata.get('my-input')).to.be.null;
+    });
   });
 });

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -186,8 +186,12 @@ export class PharosButton extends FocusMixin(AnchorElement) {
     }
   }
 
-  private _handleClick(): void {
-    if ((this.type === 'submit' || this.type === 'reset') && this._form) {
+  private _handleClick(event: MouseEvent): void {
+    if (
+      (this.type === 'submit' || this.type === 'reset') &&
+      this._form &&
+      !event.defaultPrevented
+    ) {
       this._formButton.type = this.type;
       this._form?.appendChild(this._formButton);
       this._formButton.click();


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
We should check for and respect canceled clicks for submit buttons.

**How does this change work?**

- Check `event.defaultPrevented` in the click handler