### PR TITLE
fix(cli): import html from lit

### DIFF
--- a/.changeset/flat-tools-decide.md
+++ b/.changeset/flat-tools-decide.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-cli': patch
+---
+
+import html from lit

--- a/packages/pharos-cli/src/templates/unit-test-template.js
+++ b/packages/pharos-cli/src/templates/unit-test-template.js
@@ -1,5 +1,6 @@
 const template = ({ titleCaseName, componentName }) => `
-import { html, fixture, expect } from '@open-wc/testing';
+import { fixture, expect } from '@open-wc/testing';
+import { html } from 'lit/static-html.js';
 import sinon from 'sinon';
 import type { SinonSpy } from 'sinon';
 import './pharos-${componentName}';


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Importing `html` from `@open-wc/testing` is deprecated. It should be imported from `lit` instead.

**How does this change work?**

- import html from lit