### PR TITLE
feat(pharos-site): add links to JSTOR from site

### DIFF
--- a/.changeset/breezy-singers-reply.md
+++ b/.changeset/breezy-singers-reply.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': minor
+---
+
+add links to JSTOR from site

--- a/packages/pharos-site/src/components/Sidenav.tsx
+++ b/packages/pharos-site/src/components/Sidenav.tsx
@@ -79,6 +79,9 @@ const Sidenav: FC = () => {
           <PharosSidenavLink href="https://github.com/ithaka/pharos" target="_blank" external>
             GitHub
           </PharosSidenavLink>
+          <PharosSidenavLink href="https://www.jstor.org/" target="_blank" external>
+            JSTOR
+          </PharosSidenavLink>
         </PharosSidenavSection>
         <PharosSidenavSection label="Brand Guidelines" showDivider>
           <PharosSidenavMenu label="Brand expressions" expanded={isExpanded('brand-expressions')}>

--- a/packages/pharos-site/src/components/footer.module.css
+++ b/packages/pharos-site/src/components/footer.module.css
@@ -75,3 +75,7 @@
   align-items: center;
   column-gap: var(--pharos-spacing-three-quarters-x);
 }
+
+.logo__link {
+  display: flex;
+}

--- a/packages/pharos-site/src/components/footer.tsx
+++ b/packages/pharos-site/src/components/footer.tsx
@@ -12,6 +12,7 @@ import {
   netlifyLink,
   badge,
   container__link,
+  logo__link,
 } from './footer.module.css';
 import logoWhite from '../../static/images/footer/logo-white.svg';
 
@@ -27,7 +28,9 @@ const Footer: FC = () => {
       <div className={footer}>
         <div className={main}>
           <div className={container__start}>
-            <img src={logoWhite} alt="JSTOR Logo" width="70" height="100" />
+            <PharosLink className={logo__link} href="https://www.jstor.org/" target="_blank" flex>
+              <img src={logoWhite} alt="JSTOR Logo" width="70" height="100" />
+            </PharosLink>
             <div className={note}>Copyright © {new Date().getFullYear()} JSTOR</div>
           </div>
           <div className={container__center}>


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
We should have links to JSTOR on the Pharos site so that new visitors can go there to learn more about it.

**How does this change work?**

- Add links to JSTOR in the footer and sidenav