### PR TITLE
fix(pharos): update tooltip and breadcrumb overflow logic when slotted content is non-HTML

### DIFF
--- a/.changeset/ninety-ravens-exercise.md
+++ b/.changeset/ninety-ravens-exercise.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix tooltip and breadcrumb overflow logic when slotted content is non-HTML

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.ts
@@ -54,7 +54,7 @@ export class PharosBreadcrumbItem extends FocusMixin(AnchorElement) {
   protected get content(): HTMLElement | Text {
     return Array.prototype.slice
       .call(this.childNodes)
-      ?.find((node) => node.textContent && node.nodeName === '#text');
+      ?.find((node) => node.textContent && node.nodeName !== '#comment');
   }
 
   protected firstUpdated(): void {

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.ts
@@ -84,9 +84,7 @@ export class PharosTooltip extends OverlayElement {
   );
 
   protected get content(): HTMLElement | Text {
-    return Array.prototype.slice
-      .call(this._contentNodes)
-      ?.find((node) => node.textContent && node.nodeName === '#text');
+    return Array.prototype.slice.call(this._contentNodes)?.find((node) => node.textContent);
   }
 
   constructor() {

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.ts
@@ -84,7 +84,9 @@ export class PharosTooltip extends OverlayElement {
   );
 
   protected get content(): HTMLElement | Text {
-    return Array.prototype.slice.call(this._contentNodes)?.find((node) => node.textContent);
+    return Array.prototype.slice
+      .call(this._contentNodes)
+      ?.find((node) => node.textContent && node.nodeName !== '#comment');
   }
 
   constructor() {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
When the slotted content provided to a `pharos-tooltip` is anything other than text, the desired overflow wrapping logic (30+ characters) breaks.

Example:
```html
<pharos-tooltip>
    <div>I am some text that happens to be longer than 30 characters.</div>
</pharos-tooltip>
```
 
**How does this change work?**
It appears that during the [upgrade to Lit 2](https://github.com/ithaka/pharos/pull/19) we added check to only look for text nodes. This PR undoes that so we can look for nodes other than text in order to assess their lengths. Not 100% sure I understand the original context to know if this is the correct fix or not.
