### PR TITLE
feat(image-card): add slot for title

### DIFF
--- a/.changeset/rare-brooms-film.md
+++ b/.changeset/rare-brooms-film.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+add slot for title to image cards

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -117,6 +117,23 @@ describe('pharos-image-card', () => {
     expect(heading?.getAttribute('preset')).to.equal('2');
   });
 
+  it('renders the title via a slot when the title property is not set', async () => {
+    component = await fixture(html`<pharos-image-card link="#">
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <span slot="title">Card Title</span>
+      <div slot="metadata">Creator of the item</div>
+      <div slot="metadata">1990-2000</div>
+      <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
+    </pharos-image-card>`);
+
+    const titleSlot = component.renderRoot.querySelector('slot[name="title"]');
+    expect(titleSlot).not.to.be.null;
+  });
+
   it('renders an exclamation icon in the error state', async () => {
     component.error = true;
     await component.updateComplete;

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -24,6 +24,7 @@ const VARIANTS = ['base', 'collection'];
  *
  * @slot image - Contains the image to display on the card.
  * @slot metadata - Contains the metadata for the item.
+ * @slot title - Contains the title for the item (renders if title prop is not set).
  *
  */
 @customElement('pharos-image-card')
@@ -149,14 +150,16 @@ export class PharosImageCard extends LitElement {
 
   protected get renderTitle(): TemplateResult {
     return html`<pharos-link class="card__link--title" href="${this.link}" subtle flex
-      ><pharos-heading
-        class="card__heading"
-        preset="${this.variant === 'collection' ? '2' : '1--bold'}"
-        level="3"
-        no-margin
-        >${this.title}</pharos-heading
-      ></pharos-link
-    >`;
+      >${this.title
+        ? html`<pharos-heading
+            class="card__heading"
+            preset="${this.variant === 'collection' ? '2' : '1--bold'}"
+            level="3"
+            no-margin
+            >${this.title}</pharos-heading
+          >`
+        : html`<slot name="title"></slot>`}
+    </pharos-link>`;
   }
 
   private _renderActionButton(): TemplateResult | typeof nothing {


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Resolves #101 

**How does this change work?**

- Add slot for title to image cards that renders when `title` prop is not set