### PR TITLE
fix(image-card): horizontally center image within card

### DIFF
--- a/.changeset/nervous-chefs-dance.md
+++ b/.changeset/nervous-chefs-dance.md
@@ -2,4 +2,7 @@
 '@ithaka/pharos': patch
 ---
 
-center images within image card
+image-card style updates
+
+* center images horizontally within image card
+* align card title to top instead of center

--- a/.changeset/nervous-chefs-dance.md
+++ b/.changeset/nervous-chefs-dance.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+center images within image card

--- a/.changeset/nervous-chefs-dance.md
+++ b/.changeset/nervous-chefs-dance.md
@@ -6,3 +6,4 @@ image-card style updates
 
 * center images horizontally within image card
 * align card title to top instead of center
+* remove contain styling from the card element

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -12,16 +12,12 @@
 
 .card__link--image {
   height: 14rem;
+  margin: 0 auto var(--pharos-spacing-1-x);
 }
 
 .card__link--image,
 .card__link--title {
   display: inline-flex;
-}
-
-.card__link--image,
-.card__link--collection {
-  margin-bottom: var(--pharos-spacing-1-x);
 }
 
 .card__metadata {
@@ -81,6 +77,7 @@
   display: grid;
   position: relative;
   height: auto;
+  margin-bottom: var(--pharos-spacing-1-x);
 }
 
 .card__action-button {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -2,7 +2,6 @@
 
 :host {
   display: inline-flex;
-  contain: layout;
 }
 
 .card {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -81,6 +81,7 @@
 
 .card__action-button {
   margin-left: auto;
+  display: inline-flex;
 }
 
 .card__title--hover {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -69,6 +69,7 @@
 
 .card__title {
   display: flex;
+  justify-content: space-between;
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
@@ -77,11 +78,6 @@
   position: relative;
   height: auto;
   margin-bottom: var(--pharos-spacing-1-x);
-}
-
-.card__action-button {
-  margin-left: auto;
-  display: inline-flex;
 }
 
 .card__title--hover {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -69,7 +69,6 @@
 
 .card__title {
   display: flex;
-  align-items: center;
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -173,7 +173,7 @@ export class PharosImageCard extends LitElement {
           label="More actions"
           @click=${this._handleClick}
         ></pharos-button>`
-      : html`<div class="card__action-button"><slot name="action-button"></slot></div>`;
+      : html`<slot name="action-button"></slot>`;
   }
 
   private _renderMetadata(): TemplateResult | typeof nothing {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
This centers images smaller than the width horizontally within the image card

Before:
![image](https://user-images.githubusercontent.com/13315416/124147772-007df300-da5d-11eb-9e64-4ee1a543c3a7.png)

After:
![image](https://user-images.githubusercontent.com/13315416/124178656-b5c1a280-da7f-11eb-9bc1-c8d42cd8d6d5.png)


**How does this change work?**
Adds CSS to have auto left/right margins
