### PR TITLE
style(image-card): unset `contain` for link surrounding image

### DIFF
--- a/.changeset/empty-bikes-divide.md
+++ b/.changeset/empty-bikes-divide.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+link around image on card no longer has `contain: layout` style isolation

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -10,6 +10,7 @@
 }
 
 .card__link--image {
+  contain: unset;
   height: 14rem;
   margin: 0 auto var(--pharos-spacing-1-x);
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?

**What does this change address?**
https://user-images.githubusercontent.com/13315416/124319249-eff67700-db47-11eb-992c-1d78a1516b54.mov

**How does this change work?**
Unsets the link `contain: layout` styling
