### PR TITLE
ci: use setup-node for caching

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,21 +24,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,21 +22,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,20 +17,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile
@@ -48,35 +35,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Cache Browsers
-        uses: actions/cache@v2
-        id: browsers-cache # use this to check for `cache-hit` (`steps.browsers-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: '~/.cache/ms-playwright'
-          key: ${{ runner.os }}-browsers-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-browsers-
+          cache: yarn
 
       - name: Install Browsers Dependencies
         run: npx playwright install-deps
 
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: 0
 
       - name: Test
         run: yarn test

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,13 +37,20 @@ jobs:
           node-version: 14.x
           cache: yarn
 
+      - name: Cache Browsers
+        uses: actions/cache@v2
+        id: browsers-cache # use this to check for `cache-hit` (`steps.browsers-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: '~/.cache/ms-playwright'
+          key: ${{ runner.os }}-browsers-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-browsers-
+
       - name: Install Browsers Dependencies
         run: npx playwright install-deps
 
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: 0
 
       - name: Test
         run: yarn test


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Use `setup-node` to [cache](https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/) dependencies.

**How does this change work?**

- Update `actions/setup-node` to cache dependencies in place of `actions/cache`