### PR TITLE
style(toast): set max-width on mobile

### DIFF
--- a/.changeset/kind-drinks-fold.md
+++ b/.changeset/kind-drinks-fold.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+set max-width for toasts on mobile

--- a/packages/pharos/src/components/toast/pharos-toast.scss
+++ b/packages/pharos/src/components/toast/pharos-toast.scss
@@ -58,3 +58,9 @@
   opacity: 1;
   transform: translateY(0);
 }
+
+@media only screen and (max-width: 570px) {
+  .toast {
+    max-width: 90vw;
+  }
+}

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
@@ -19,7 +19,7 @@ import '../link/pharos-link';
 <GuidelineLink path="toast" />
 
 <Canvas>
-  <Story name="Base">
+  <Story name="Base" parameters={{ chromatic: { viewports: [320, 1200] } }}>
     {() => {
       const effect = () => {
         useEffect(() => {
@@ -88,7 +88,7 @@ import '../link/pharos-link';
 ## Long Content Toast
 
 <Canvas>
-  <Story name="Long Content">
+  <Story name="Long Content" parameters={{ chromatic: { viewports: [320, 1200] } }}>
     {() => {
       const effect = () => {
         useEffect(() => {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
On mobile our toasts expand beyond the viewport as their widths are static and design did not specify styles for the viewport.

**How does this change work?**

- Set max-width on mobile to `90vw`