### PR TITLE
style(image-card): force 100% width for better alignment within the grid

### DIFF
--- a/.changeset/curvy-lies-develop.md
+++ b/.changeset/curvy-lies-develop.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+expand card to be full width to fix alignment issues for cards within a wider grid

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -2,11 +2,13 @@
 
 :host {
   display: inline-flex;
+  width: 100%;
 }
 
 .card {
   display: inline-flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .card__link--image {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Fixes issue where cards were misaligned and not taking up the full width of the grid column when their contents are narrower than the column width.

**How does this change work?**
Add `width: 100%` to make cards take up full width and center their contents

**Additional context**

Before:
https://user-images.githubusercontent.com/13315416/124817457-d5514300-df37-11eb-9e40-db909dc7e22c.mov

After:
https://user-images.githubusercontent.com/13315416/124817581-fe71d380-df37-11eb-956d-5db86d8f6518.mov