### PR TITLE
ci: update release workflow to merge main into develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Merge main into develop
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git checkout main
+          git pull origin main
+          git checkout develop
+          git merge main --ff-only
+          git push origin develop

--- a/docs/development/conventions/creating-a-release.md
+++ b/docs/development/conventions/creating-a-release.md
@@ -26,7 +26,7 @@ This brings the set of changes onto the `main` branch for a stable release. If t
 
 ## Publishing a release
 
-After pushing the commits to `main`, the [Changesets action](https://github.com/changesets/action) will create a pull request, titled `Version Packages`, with all of the package versions updated and changelogs updated. This pull request will automatically update whenever new changesets are pushed to `main`. When you're ready, you can merge the pull request and the action will publish the new versions to NPM for you.
+After pushing the commits to `main`, the [Changesets action](https://github.com/changesets/action) will create a pull request, titled **Version Packages**, with all of the package versions and changelogs updated. This pull request will automatically update whenever new changesets are pushed to `main`. When you're ready, you can merge the pull request and the action will publish the new versions to NPM for you.
 
 ## Manually publishing a release
 

--- a/docs/development/conventions/creating-a-release.md
+++ b/docs/development/conventions/creating-a-release.md
@@ -26,15 +26,7 @@ This brings the set of changes onto the `main` branch for a stable release. If t
 
 ## Publishing a release
 
-After pushing the commits to `main`, the [Changesets action](https://github.com/changesets/action) will create a pull request, titled `Version Packages`, with all of the package versions updated and changelogs updated. This pull request will automatically update whenever new changesets are pushed to `main`. When you're ready, you can merge the pull request and the action will publish the new versions to NPM for you. Lastly, the `main` branch's latest changes must be merged into the `develop` branch. It's important to do a fast-forward merge to avoid additional merge commits:
-
-```shell
-$ git checkout main
-$ git pull origin main
-$ git checkout develop
-$ git merge main --ff
-$ git push origin develop
-```
+After pushing the commits to `main`, the [Changesets action](https://github.com/changesets/action) will create a pull request, titled `Version Packages`, with all of the package versions updated and changelogs updated. This pull request will automatically update whenever new changesets are pushed to `main`. When you're ready, you can merge the pull request and the action will publish the new versions to NPM for you.
 
 ## Manually publishing a release
 
@@ -66,4 +58,12 @@ This publishes the newly-versioned packages to [npm](https://www.npmjs.com/) and
 $ git push --follow-tags
 ```
 
-The last step is to merge and push changes from `main` to `develop` to pull in the updated version strings.
+Lastly, the `main` branch's latest changes must be merged into the `develop` branch. It's important to do a fast-forward merge to avoid additional merge commits:
+
+```shell
+$ git checkout main
+$ git pull origin main
+$ git checkout develop
+$ git merge main --ff
+$ git push origin develop
+```


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
resolves #149 

**How does this change work?**

- Update release action to merge `main` into `develop` after publishing