### PR TITLE
fix: run lit-analyzer on pre-commit

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,5 +3,5 @@ module.exports = {
   '*.{scss,css}': ['stylelint --fix'],
   '**/!(.changeset)/*.md': (filenames) =>
     filenames.map((filename) => `yarn markdown-toc -i '${filename}'`),
-  '!(*.css|*.test).ts': ['lit-analyzer --strict'],
+  '!(*.css|*.test)*.ts': ['lit-analyzer --strict'],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,5 +3,6 @@ module.exports = {
   '*.{scss,css}': ['stylelint --fix'],
   '**/!(.changeset)/*.md': (filenames) =>
     filenames.map((filename) => `yarn markdown-toc -i '${filename}'`),
-  '!(*.css|*.test)*.ts': ['lit-analyzer --strict'],
+  '!(*.css|*.test).ts': (filenames) =>
+    filenames.map((filename) => `yarn lit-analyzer '${filename}' --strict`),
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,4 +3,5 @@ module.exports = {
   '*.{scss,css}': ['stylelint --fix'],
   '**/!(.changeset)/*.md': (filenames) =>
     filenames.map((filename) => `yarn markdown-toc -i '${filename}'`),
+  '!(*.css|*.test).ts': ['lit-analyzer --strict'],
 };

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -72,6 +72,7 @@
     "sassdoc": "^2.7.3",
     "sinon": "^11.1.1",
     "style-dictionary": "^3.0.1",
+    "ts-lit-plugin": "^1.2.1",
     "typescript": "^4.2.2",
     "web-component-analyzer": "^1.1.6"
   }

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -7,7 +7,6 @@ import { customElement } from '../../utils/decorators';
 import type { PharosLink } from '../link/pharos-link';
 
 import FocusMixin from '../../utils/mixins/focus';
-import '../icon/pharos-icon';
 
 export type AlertStatus = 'info' | 'success' | 'warning' | 'error';
 
@@ -95,6 +94,7 @@ export class PharosAlert extends FocusMixin(LitElement) {
         tabindex="0"
       >
         <pharos-icon class="alert__icon" name="${this._getIcon()}"></pharos-icon>
+        <yay>test<yay>
         <div class="alert__body">
           <slot @slotchange=${this._handleSlotChange}></slot>
         </div>

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -7,6 +7,7 @@ import { customElement } from '../../utils/decorators';
 import type { PharosLink } from '../link/pharos-link';
 
 import FocusMixin from '../../utils/mixins/focus';
+import '../icon/pharos-icon';
 
 export type AlertStatus = 'info' | 'success' | 'warning' | 'error';
 

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -95,7 +95,6 @@ export class PharosAlert extends FocusMixin(LitElement) {
         tabindex="0"
       >
         <pharos-icon class="alert__icon" name="${this._getIcon()}"></pharos-icon>
-        <yay>test<yay>
         <div class="alert__body">
           <slot @slotchange=${this._handleSlotChange}></slot>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14098,7 +14098,7 @@ listr2@^3.8.2:
     through "^2.3.8"
     wrap-ansi "^7.0.0"
 
-lit-analyzer@^1.2.1:
+lit-analyzer@1.2.1, lit-analyzer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/lit-analyzer/-/lit-analyzer-1.2.1.tgz#725331a4019ae870dd631d4dd709d39a237161ea"
   integrity sha512-OEARBhDidyaQENavLbzpTKbEmu5rnAI+SdYsH4ia1BlGlLiqQXoym7uH1MaRPtwtUPbkhUfT4OBDZ+74VHc3Cg==
@@ -21299,6 +21299,13 @@ ts-jest@^27.0.1:
     mkdirp "1.x"
     semver "7.x"
     yargs-parser "20.x"
+
+ts-lit-plugin@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ts-lit-plugin/-/ts-lit-plugin-1.2.1.tgz#7fca17a454645c14911917fa7f17ade582fa3056"
+  integrity sha512-k/Me+aT1N9ckC/KuJCAlAJgCHFezOxuOGOzBE0q42xnKbJnUMNl08WqWF6C7OKecCPHIMRk5Wj5o6MDsmt9+qA==
+  dependencies:
+    lit-analyzer "1.2.1"
 
 ts-node@^10.0.0:
   version "10.0.0"


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
We want checks to be run as early as possible during development to minimize rework after opening a pull request.

**How does this change work?**

- Add `ts-lit-plugin` for better IDE hinting support
- Run `lit-analyzer` during pre-commit