### PR TITLE
Image card: Fix long title overflow

### DIFF
--- a/.changeset/twelve-bananas-beg.md
+++ b/.changeset/twelve-bananas-beg.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix image card title overflow

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -20,6 +20,7 @@
 .card__link--image,
 .card__link--title {
   display: inline-flex;
+  min-width: 0;
 }
 
 .card__metadata {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Before:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/38861633/125699610-1ac22569-8afc-4c7d-ae50-d80e4a744d53.png">
 Now: 
<img width="202" alt="image" src="https://user-images.githubusercontent.com/38861633/125699650-c9cccf88-7898-484a-990c-1aa728eee07e.png">


**How does this change work?**
Add a min-width to the title.

**Additional context**
Needed for PLATO-1741
