### PR TITLE
Image Card: Allow promotional variant images to have dynamic height

### DIFF
--- a/.changeset/red-students-rescue.md
+++ b/.changeset/red-students-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Allow promotional image cards to have dynamic heights

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -23,6 +23,10 @@
   min-width: 0;
 }
 
+:host([variant='promotional']) .card__link--image {
+  height: unset;
+}
+
 .card__metadata {
   @include mixins.font-base(
     $font-size: var(--pharos-font-size-small),


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

Promotional image cards are meant to allow for a broader range of possible images because they're hand-chosen. This means they should also be given room to be sized dynamically/bespoke.

**How does this change work?**
Remove the stringent `14rem` height from promotional images. Images can be sized either with layouts or explicitly with CSS by the consumer.
