### PR TITLE
fix(select): set the selection when a value is initially passed

### DIFF
--- a/.changeset/smart-peaches-compete.md
+++ b/.changeset/smart-peaches-compete.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+set the selection when a value is initially passed for selects

--- a/packages/pharos/src/components/select/pharos-select.test.ts
+++ b/packages/pharos/src/components/select/pharos-select.test.ts
@@ -232,4 +232,19 @@ describe('pharos-select', () => {
 
     expect(component.renderRoot.querySelectorAll('option')?.length).to.equal(4);
   });
+
+  it('sets the selection when a value is initially passed', async () => {
+    component = await fixture(
+      html`<pharos-select value="2">
+        <span slot="label">test</span>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+        <option value="5">Option 5</option>
+      </pharos-select>`
+    );
+    await component.updateComplete;
+    expect(component['_select'].value).to.equal('2');
+  });
 });

--- a/packages/pharos/src/components/select/pharos-select.ts
+++ b/packages/pharos/src/components/select/pharos-select.ts
@@ -47,7 +47,7 @@ export class PharosSelect extends ObserveChildrenMixin(FormMixin(FormElement)) {
   protected firstUpdated(): void {
     if (!this.value) {
       this._setOption();
-    } else {
+    } else if (this._options.find((o) => o.value === this.value)) {
       this._select.value = this.value;
     }
     this._options.forEach((option) => (option.defaultSelected = option.hasAttribute('selected')));

--- a/packages/pharos/src/components/select/pharos-select.ts
+++ b/packages/pharos/src/components/select/pharos-select.ts
@@ -45,10 +45,10 @@ export class PharosSelect extends ObserveChildrenMixin(FormMixin(FormElement)) {
   }
 
   protected firstUpdated(): void {
-    if (!this.value) {
-      this._setOption();
-    } else if (this._options.find((o) => o.value === this.value)) {
+    if (this.value && this._options.find((o) => o.value === this.value)) {
       this._select.value = this.value;
+    } else {
+      this._setOption();
     }
     this._options.forEach((option) => (option.defaultSelected = option.hasAttribute('selected')));
   }
@@ -56,7 +56,7 @@ export class PharosSelect extends ObserveChildrenMixin(FormMixin(FormElement)) {
   private _setOption(): void {
     // Set value to selected option
     const selected = (this.querySelector('option[selected]') ||
-      this.querySelector('option')) as HTMLOptionElement;
+      this.querySelector('option:not([disabled])')) as HTMLOptionElement;
     this.value = selected?.value;
   }
 

--- a/packages/pharos/src/components/select/pharos-select.ts
+++ b/packages/pharos/src/components/select/pharos-select.ts
@@ -45,7 +45,11 @@ export class PharosSelect extends ObserveChildrenMixin(FormMixin(FormElement)) {
   }
 
   protected firstUpdated(): void {
-    this._setOption();
+    if (!this.value) {
+      this._setOption();
+    } else {
+      this._select.value = this.value;
+    }
     this._options.forEach((option) => (option.defaultSelected = option.hasAttribute('selected')));
   }
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Fixes #168 

**How does this change work?**

- set the selection when a value is initially passed

**Additional context**
The `value` attribute is not a standard for native selects. [Frameworks such as React and Vue](https://reactjs.org/docs/forms.html#the-select-tag) use it to improve developer experience. Because our component has to render options instead of using a slot, `value` does not get reflected on initial render and so we have to manually set it.