### PR TITLE
fix(image-card): do not truncate promotional titles

### DIFF
--- a/.changeset/polite-tables-breathe.md
+++ b/.changeset/polite-tables-breathe.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+do not truncate promotional image card titles

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -106,9 +106,11 @@
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
-.card__heading,
-.card__title--hover {
-  @include mixins.truncate-text($lines: 2);
+:host(:not([variant='promotional'])) {
+  .card__heading,
+  .card__title--hover {
+    @include mixins.truncate-text($lines: 2);
+  }
 }
 
 .card__svg {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
We do not want promotional image card titles to be truncated as they serve marketing/promotion needs and so should be fully legible.

**How does this change work?**

- Update styles to not apply truncation on the `promotional` variant