### PR TITLE
fix(layout): apply margins for breakpoints medium and above for 1-col

### DIFF
--- a/.changeset/chilled-birds-invite.md
+++ b/.changeset/chilled-birds-invite.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+apply margins medium and above for 1-col layout

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -545,7 +545,9 @@
   $property: if($fixed-width, width, min-width);
 
   @if $fixed-width {
-    margin: auto;
+    @include at-least(medium) {
+      margin: auto;
+    }
   }
 
   @each $breakpoint, $margin in $breakpoints {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Currently auto margins are applied at and between every breakpoint for the `1-col` preset. When going below the medium breakpoint, the margins apply undesired shrinking of elements such as inputs. We can remove these margins when going below `medium` as the layout's margins are static and not fluid like the ones above the breakpoint.

**How does this change work?**

- Apply margins for `1-col` layouts only at `medium` and above