### PR TITLE
feat: update to TypeScript 4.3

### DIFF
--- a/.changeset/sharp-files-nail.md
+++ b/.changeset/sharp-files-nail.md
@@ -1,0 +1,11 @@
+---
+'@ithaka/pharos': minor
+'@ithaka/pharos-cli': patch
+'@ithaka/pharos-site': patch
+---
+
+update to TypeScript 4.3:
+
+* Update packages to use TypeScript 4.3
+* Add `noImplicitOverride` flag
+* Update Prettier to support the new `override` keyword

--- a/docs/development/anatomy-of-a-component.md
+++ b/docs/development/anatomy-of-a-component.md
@@ -155,11 +155,11 @@ Now you've got all the ingredients needed to write the component definition. Add
 ```typescript
 @customElement('pharos-sparkly-text')
 export class PharosSparklyText extends LitElement {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [sparklyTextStyles];
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="sparkly__content">
         <slot name="content"></slot>

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "postcss-import": "^14.0.0",
     "postcss-loader": "^6.1.0",
     "postcss-preset-env": "^6.7.0",
-    "prettier": "2.2.1",
+    "prettier": "^2.3.2",
     "pretty-quick": "^3.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/packages/pharos-cli/package.json
+++ b/packages/pharos-cli/package.json
@@ -20,7 +20,7 @@
     "jest": "^27.0.1",
     "ts-jest": "^27.0.1",
     "ts-node": "^10.0.0",
-    "typescript": "^4.2.2"
+    "typescript": "^4.3.5"
   },
   "scripts": {
     "test": "jest",

--- a/packages/pharos-cli/src/templates/typescript-file-template.js
+++ b/packages/pharos-cli/src/templates/typescript-file-template.js
@@ -6,11 +6,11 @@ import { customElement } from '../../utils/decorators';
 
 @customElement('pharos-${componentName}')
 export class Pharos${titleCaseName} extends LitElement {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [${camelCaseName}Styles];
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html\` <span>This is the ${titleCaseName} component!</span> \`;
   }
 }

--- a/packages/pharos-site/package.json
+++ b/packages/pharos-site/package.json
@@ -21,7 +21,7 @@
     "gatsby-plugin-sharp": "^3.6.0",
     "gatsby-source-filesystem": "^3.6.0",
     "gatsby-transformer-sharp": "^3.6.0",
-    "prettier": "2.2.1",
+    "prettier": "^2.3.2",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -35,7 +35,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/react": "^17.0.1",
     "babel-preset-gatsby": "^1.6.0",
-    "typescript": "^4.2.2"
+    "typescript": "^4.3.5"
   },
   "author": "ITHAKA",
   "license": "MIT",

--- a/packages/pharos-site/src/pages/brand-expressions/logos.mdx
+++ b/packages/pharos-site/src/pages/brand-expressions/logos.mdx
@@ -110,7 +110,8 @@ import PageSection from '../../components/statics/PageSection';
           style={{ width: '100%', marginBottom: '1rem' }}
         />
         <p>
-          The filigree and J are transparent and the "surface" they're put on can be seen through{' '}
+          The filigree and J are transparent and the "surface" they're put on can be seen
+          through{' '}
         </p>
       </div>
       <div>

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -65,7 +65,7 @@
     "chokidar": "^3.5.2",
     "globby": "^12.0.0",
     "postcss": "^8.3.0",
-    "prettier": "2.2.1",
+    "prettier": "^2.3.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "replace-in-file": "^6.1.0",
@@ -75,7 +75,7 @@
     "sinon": "^11.1.1",
     "style-dictionary": "^3.0.1",
     "ts-lit-plugin": "^1.2.1",
-    "typescript": "^4.2.2"
+    "typescript": "^4.3.5"
   },
   "customElements": "custom-elements.json"
 }

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -53,11 +53,11 @@ export class PharosAlert extends FocusMixin(LitElement) {
 
   private _allLinks!: NodeListOf<PharosLink>;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [alertStyles];
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (!this.status) {
@@ -84,7 +84,7 @@ export class PharosAlert extends FocusMixin(LitElement) {
     });
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div
         role="alert"

--- a/packages/pharos/src/components/base/anchor-element.ts
+++ b/packages/pharos/src/components/base/anchor-element.ts
@@ -54,7 +54,7 @@ export class AnchorElement extends LitElement {
   @property({ type: String, reflect: true })
   public target?: LinkTarget;
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('target') && this.target && !TARGETS.includes(this.target)) {

--- a/packages/pharos/src/components/base/form-element.ts
+++ b/packages/pharos/src/components/base/form-element.ts
@@ -66,11 +66,11 @@ export class FormElement extends FocusMixin(LitElement) {
   @property({ type: Boolean, reflect: true, attribute: 'hide-label' })
   public hideLabel = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [formElementStyles];
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('validated') && this.validated) {
       this.removeAttribute('invalidated');
     } else if (changedProperties.has('invalidated') && this.invalidated) {

--- a/packages/pharos/src/components/base/overlay-element.ts
+++ b/packages/pharos/src/components/base/overlay-element.ts
@@ -44,7 +44,7 @@ export class OverlayElement extends LitElement {
   protected _popper?: Instance;
   protected _options?: Options;
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('placement') && !placements.includes(this.placement)) {
@@ -71,7 +71,7 @@ export class OverlayElement extends LitElement {
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     if (
       changedProperties.has('placement') ||
       changedProperties.has('fallbackPlacements') ||

--- a/packages/pharos/src/components/base/side-element.ts
+++ b/packages/pharos/src/components/base/side-element.ts
@@ -6,7 +6,7 @@ import { sideElementStyles } from './side-element.css';
  * The base side element class to house shared properties, styles, and methods.
  */
 export class SideElement extends LitElement {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [sideElementStyles];
   }
 }

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.ts
@@ -43,7 +43,7 @@ export class PharosBreadcrumbItem extends FocusMixin(AnchorElement) {
   @state()
   private _last = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [breadcrumbItemStyles];
   }
 
@@ -57,7 +57,7 @@ export class PharosBreadcrumbItem extends FocusMixin(AnchorElement) {
       ?.find((node) => node.textContent && node.nodeName !== '#comment');
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.setAttribute('role', 'listitem');
     this._setItem();
     this._contentObserver.observe(this.content, {
@@ -74,7 +74,7 @@ export class PharosBreadcrumbItem extends FocusMixin(AnchorElement) {
       : this._fullText || '';
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     const classes = {
       [`breadcrumb-item`]: true,
       [`breadcrumb-item--last`]: this._last,

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.ts
@@ -20,7 +20,7 @@ import FocusMixin from '../../utils/mixins/focus';
  */
 @customElement('pharos-breadcrumb')
 export class PharosBreadcrumb extends FocusMixin(LitElement) {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [breadcrumbStyles];
   }
 
@@ -35,7 +35,7 @@ export class PharosBreadcrumb extends FocusMixin(LitElement) {
     });
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`<nav aria-label="breadcrumb">
       <ol class="breadcrumb">
         <slot @slotchange=${this._handleSlotchange}></slot>

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -36,7 +36,7 @@ export class PharosButton extends FocusMixin(AnchorElement) {
    * @attr autofocus
    */
   @property({ type: Boolean, reflect: true })
-  public autofocus = false;
+  public override autofocus = false;
 
   /**
    * Indicates that the button cannot be pressed or focused by the user.
@@ -144,17 +144,17 @@ export class PharosButton extends FocusMixin(AnchorElement) {
     this._stopClickLeak = this._stopClickLeak.bind(this);
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [buttonStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._formButton = document.createElement('button');
     this._formButton.addEventListener('click', this._stopClickLeak);
     this.addEventListener('click', this._handleClick);
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('type') && this.type && !TYPES.includes(this.type)) {
@@ -167,12 +167,12 @@ export class PharosButton extends FocusMixin(AnchorElement) {
     }
   }
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback && super.connectedCallback();
     this._form = this.closest('form');
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     super.disconnectedCallback && super.disconnectedCallback();
   }
 
@@ -229,7 +229,7 @@ export class PharosButton extends FocusMixin(AnchorElement) {
         `;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return this.href
       ? html`
           <a

--- a/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.ts
+++ b/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.ts
@@ -38,11 +38,11 @@ export class PharosCheckboxGroup extends FormElement {
       .map((box) => (box as PharosCheckbox).value);
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, checkboxGroupStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._setBoxes();
 
     const boxes = this.querySelectorAll('pharos-checkbox') as NodeListOf<PharosCheckbox>;
@@ -60,7 +60,7 @@ export class PharosCheckboxGroup extends FormElement {
     });
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (
@@ -83,7 +83,7 @@ export class PharosCheckboxGroup extends FormElement {
     });
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     const labels = ['legend'];
     if (this.messageId) {
       labels.push(this.messageId);

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.ts
@@ -57,11 +57,11 @@ export class PharosCheckbox extends FormMixin(FormElement) {
   @query('#checkbox-element')
   private _checkbox!: HTMLInputElement;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, checkboxStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._checkbox.defaultChecked = this.checked;
   }
 
@@ -111,7 +111,7 @@ export class PharosCheckbox extends FormMixin(FormElement) {
     }
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <input
         id="checkbox-element"

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -107,11 +107,11 @@ export class PharosCombobox extends FormMixin(FormElement) {
     }
   );
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, comboboxStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._setDisplayValue();
     this._input.defaultValue = this._displayValue;
     this._defaultValue = this.value;
@@ -122,7 +122,7 @@ export class PharosCombobox extends FormMixin(FormElement) {
     });
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
 
     if (changedProperties.has('open') && !this.open) {
@@ -134,7 +134,7 @@ export class PharosCombobox extends FormMixin(FormElement) {
     }
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     this._childrenObserver.disconnect();
     super.disconnectedCallback && super.disconnectedCallback();
   }
@@ -447,7 +447,7 @@ export class PharosCombobox extends FormMixin(FormElement) {
     this.open = !this.open;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <label for="input-element" id="input-label">
         <slot name="label"></slot>

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.ts
@@ -32,18 +32,18 @@ export class PharosDropdownMenuNavLink extends PharosLink {
     this.flex = true;
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, dropdownMenuNavLinkStyles];
   }
 
-  protected get appendContent(): TemplateResult | typeof nothing {
+  protected override get appendContent(): TemplateResult | typeof nothing {
     if (this.hasAttribute('data-dropdown-menu-id')) {
       return html`<pharos-icon name="chevron-down" class="link__icon"></pharos-icon>`;
     }
     return nothing;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`${super.render()}`;
   }
 }

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.ts
@@ -29,11 +29,11 @@ export class PharosDropdownMenuNav extends FocusMixin(LitElement) {
   private _allLinks!: NodeListOf<PharosDropdownMenuNavLink>;
   private _allMenus!: NodeListOf<PharosDropdownMenu>;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [dropdownMenuNavStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('focus', () => this._closeAllMenus());
   }
 
@@ -65,7 +65,7 @@ export class PharosDropdownMenuNav extends FocusMixin(LitElement) {
     });
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <nav class="dropdown-menu-nav__container" aria-label=${ifDefined(this.label)}>
         <slot @slotchange=${this._handleSlotChange}></slot>

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
@@ -68,11 +68,11 @@ export class PharosDropdownMenuItem extends FocusMixin(LitElement) {
   @state()
   private _menu!: PharosDropdownMenu;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [dropdownMenuItemStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('click', this._handleClick);
     this.addEventListener('mousedown', this._handleMousedown);
     this.addEventListener('mouseup', this._handleMouseup);
@@ -145,7 +145,7 @@ export class PharosDropdownMenuItem extends FocusMixin(LitElement) {
     `;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <li
         class="${classMap({

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -87,7 +87,7 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     this._handleTriggerKeydown = this._handleTriggerKeydown.bind(this);
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [dropdownMenuStyles];
   }
 
@@ -105,13 +105,13 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     }
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('click', this._handleMenuClick);
     this.addEventListener('keydown', this._handleMenuKeydown);
     this._addTriggerListeners();
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
   }
 
@@ -128,7 +128,7 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('open')) {
       if (this._currentTrigger && this._navMenu) {
         (this._currentTrigger as PharosDropdownMenuNavLink).isActive = this.open;
@@ -170,7 +170,7 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     super.updated(changedProperties);
   }
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback && super.connectedCallback();
     document.addEventListener('click', this._handleClick);
     document.addEventListener('keydown', this._handleKeydown);
@@ -193,7 +193,7 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     this._triggers = [];
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     document.removeEventListener('click', this._handleClick);
     document.removeEventListener('keydown', this._handleKeydown);
     this._removeTriggerListeners();
@@ -579,7 +579,7 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     `;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return this._navMenu
       ? html`${this._renderList()}`
       : html`<focus-trap>${this._renderList()}</focus-trap>`;

--- a/packages/pharos/src/components/footer/pharos-footer.ts
+++ b/packages/pharos/src/components/footer/pharos-footer.ts
@@ -28,7 +28,7 @@ export class PharosFooter extends ObserveChildrenMixin(LitElement) {
   @queryAssignedNodes('google-widget', false, '#google_translate_element')
   private _widgetNodes!: NodeListOf<HTMLElement>;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [footerStyles];
   }
 
@@ -51,7 +51,7 @@ export class PharosFooter extends ObserveChildrenMixin(LitElement) {
     }
   );
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     if (this._widgetNodes.length) {
       this._widgetObserver.observe(this._widgetNodes[0], {
         childList: true,
@@ -59,12 +59,12 @@ export class PharosFooter extends ObserveChildrenMixin(LitElement) {
     }
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     this._widgetObserver.disconnect();
     super.disconnectedCallback && super.disconnectedCallback();
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <footer id="footer-element">
         <div class="footer__content">

--- a/packages/pharos/src/components/header/pharos-header.ts
+++ b/packages/pharos/src/components/header/pharos-header.ts
@@ -16,11 +16,11 @@ import { customElement } from '../../utils/decorators';
  */
 @customElement('pharos-header')
 export class PharosHeader extends LitElement {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [headerStyles];
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <header id="header-element">
         <div class="header__top">

--- a/packages/pharos/src/components/heading/pharos-heading.ts
+++ b/packages/pharos/src/components/heading/pharos-heading.ts
@@ -74,11 +74,11 @@ export class PharosHeading extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'no-margin' })
   public noMargin = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [headingStyles];
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (!this.level) {
@@ -98,7 +98,7 @@ export class PharosHeading extends LitElement {
     }
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     const template = `
       <h${this.level} class="heading">
         <slot></slot>

--- a/packages/pharos/src/components/icon/pharos-icon.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.ts
@@ -37,11 +37,11 @@ export class PharosIcon extends LitElement {
   @state()
   private _svg = '';
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [iconStyles];
   }
 
-  protected async updated(changedProperties: PropertyValues): Promise<void> {
+  protected override async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('name')) {
       try {
         const icon = await import(`../../styles/icons/${this.name}`);
@@ -56,7 +56,7 @@ export class PharosIcon extends LitElement {
     return this.name?.endsWith('-small') ? SMALL_ICON_SIZE : LARGE_ICON_SIZE;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     const size = this._getIconSize();
 
     return html`

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -40,7 +40,7 @@ export class PharosImageCard extends LitElement {
    * @attr title
    */
   @property({ type: String, reflect: true })
-  public title = '';
+  public override title = '';
 
   /**
    * Indicates the item type of the source content represented by the card.
@@ -95,11 +95,11 @@ export class PharosImageCard extends LitElement {
   @query('.card__link--title')
   private _title!: PharosLink;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [imageCardStyles];
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('variant') && this.variant && !VARIANTS.includes(this.variant)) {
@@ -218,7 +218,7 @@ export class PharosImageCard extends LitElement {
         </div>`;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`<div class="card">
       ${this._renderImage()} ${this._renderSourceType()}
       <div class="card__title">${this.renderTitle} ${this._renderActionButton()}</div>

--- a/packages/pharos/src/components/input-group/pharos-input-group-select.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group-select.ts
@@ -11,11 +11,11 @@ import { PharosSelect } from '../select/pharos-select';
  */
 @customElement('pharos-input-group-select')
 export class PharosInputGroupSelect extends PharosSelect {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, inputGroupSelectStyles];
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html` ${super.render()} `;
   }
 }

--- a/packages/pharos/src/components/input-group/pharos-input-group.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group.ts
@@ -31,16 +31,16 @@ export class PharosInputGroup extends PharosTextInput {
   @state()
   private _prependGroupWidth = 0;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, inputGroupStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('focus', this._adjustPadding);
     this.addEventListener('blur', this._adjustPadding);
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
 
     if (changedProperties.has('_prependGroupWidth')) {
@@ -55,7 +55,7 @@ export class PharosInputGroup extends PharosTextInput {
     }
   }
 
-  protected get prependContent(): TemplateResult {
+  protected override get prependContent(): TemplateResult {
     return html`
       <div class="input-group input-group--prepend">
         <slot name="prepend" @slotchange=${this._updatePrependPadding}></slot>
@@ -63,7 +63,7 @@ export class PharosInputGroup extends PharosTextInput {
     `;
   }
 
-  protected get appendContent(): TemplateResult {
+  protected override get appendContent(): TemplateResult {
     return html`
       <div class="input-group input-group--append">
         <slot @slotchange=${this._updateAppendPadding}></slot>
@@ -97,7 +97,7 @@ export class PharosInputGroup extends PharosTextInput {
     }px`;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html` ${super.render()} `;
   }
 }

--- a/packages/pharos/src/components/layout/pharos-layout.ts
+++ b/packages/pharos/src/components/layout/pharos-layout.ts
@@ -60,11 +60,11 @@ export class PharosLayout extends LitElement {
   @query('.layout')
   private _layout!: HTMLElement;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [layoutStyles];
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('preset') && !PRESETS.includes(this.preset)) {
@@ -75,7 +75,7 @@ export class PharosLayout extends LitElement {
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('areas')) {
       this._layout.style.gridTemplateAreas = this.areas;
     }
@@ -87,7 +87,7 @@ export class PharosLayout extends LitElement {
     }
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     const template = `<slot name="top"></slot><${this.tag} id="layout-container" class="layout"><slot></slot></${this.tag}>`;
     return html`${unsafeHTML(template)}`;
   }

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -85,7 +85,7 @@ export class PharosLink extends FocusMixin(AnchorElement) {
   @state()
   private _hover = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [linkStyles];
   }
 
@@ -101,7 +101,7 @@ export class PharosLink extends FocusMixin(AnchorElement) {
     return nothing;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`<a
       id="link-element"
       class="${classMap({

--- a/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.ts
+++ b/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.ts
@@ -24,11 +24,11 @@ export class PharosLoadingSpinner extends LitElement {
   @query('.loading-spinner__animation')
   private _spinner!: SVGCircleElement;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [loadingSpinnerStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._setupAnimation();
   }
 
@@ -70,7 +70,7 @@ export class PharosLoadingSpinner extends LitElement {
     this._icon.animate(rotateKeys, rotateTiming);
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div
         class="loading-spinner__wrapper"

--- a/packages/pharos/src/components/modal/pharos-modal.ts
+++ b/packages/pharos/src/components/modal/pharos-modal.ts
@@ -76,15 +76,15 @@ export class PharosModal extends LitElement {
     this._handleTriggerClick = this._handleTriggerClick.bind(this);
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [modalStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._addTriggerListeners();
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('size') && !SIZES.includes(this.size)) {
@@ -92,7 +92,7 @@ export class PharosModal extends LitElement {
     }
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('open')) {
       const body = document.querySelector('body');
 
@@ -110,14 +110,14 @@ export class PharosModal extends LitElement {
     }
   }
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback && super.connectedCallback();
     document.addEventListener('keydown', this._handleKeydown);
 
     this._addTriggerListeners();
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     document.removeEventListener('keydown', this._handleKeydown);
     this._triggers.forEach((trigger) => {
       trigger.removeEventListener('click', this._handleTriggerClick);
@@ -244,7 +244,7 @@ export class PharosModal extends LitElement {
       (e.target as HTMLSlotElement).assignedNodes({ flatten: true }).length === 0;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="modal__overlay">
         <div

--- a/packages/pharos/src/components/pagination/pharos-pagination.ts
+++ b/packages/pharos/src/components/pagination/pharos-pagination.ts
@@ -38,7 +38,7 @@ export class PharosPagination extends LitElement {
   @property({ type: Number, reflect: true, attribute: 'current-page' })
   public currentPage = 1;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [paginationStyles];
   }
 
@@ -46,7 +46,7 @@ export class PharosPagination extends LitElement {
     return Math.ceil(this.totalResults / this.pageSize);
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (
@@ -138,7 +138,7 @@ export class PharosPagination extends LitElement {
     return nothing;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="pagination__wrapper" role="navigation" aria-label="pagination">
         ${this._renderPrevLink()}

--- a/packages/pharos/src/components/progress-bar/pharos-progress-bar.ts
+++ b/packages/pharos/src/components/progress-bar/pharos-progress-bar.ts
@@ -24,11 +24,11 @@ export class PharosProgressBar extends LitElement {
   @property({ type: Number, reflect: true })
   public value = 0;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [progressBarStyles];
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div id="title" class="progress-bar__title"><slot name="title"></slot></div>
       <div

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.ts
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.ts
@@ -37,11 +37,11 @@ export class PharosRadioButton extends FormMixin(FormElement) {
   @query('#radio-element')
   private _radio!: HTMLInputElement;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, radioButtonStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._radio.defaultChecked = this.checked;
   }
 
@@ -76,7 +76,7 @@ export class PharosRadioButton extends FormMixin(FormElement) {
     }
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <input
         id="radio-element"

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.ts
@@ -42,11 +42,11 @@ export class PharosRadioGroup extends FormElement {
 
   private _clicked = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, radioGroupStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._setRadios();
     this._addFocusListeners();
 
@@ -73,7 +73,7 @@ export class PharosRadioGroup extends FormElement {
     this.addEventListener('keydown', this._handleKeydown);
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (
@@ -174,7 +174,7 @@ export class PharosRadioGroup extends FormElement {
     });
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     const labels = ['legend'];
     if (this.messageId) {
       labels.push(this.messageId);

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.ts
@@ -33,9 +33,11 @@ export class PharosRadioGroup extends FormElement {
    */
   @property({ type: String, attribute: false })
   public get value(): string {
-    return ([...this.children].find(
-      (child) => !child.slot && (child as PharosRadioButton).checked
-    ) as PharosRadioButton)?.value;
+    return (
+      [...this.children].find(
+        (child) => !child.slot && (child as PharosRadioButton).checked
+      ) as PharosRadioButton
+    )?.value;
   }
 
   private _clicked = false;

--- a/packages/pharos/src/components/select/pharos-select.ts
+++ b/packages/pharos/src/components/select/pharos-select.ts
@@ -40,11 +40,11 @@ export class PharosSelect extends ObserveChildrenMixin(FormMixin(FormElement)) {
     ) as HTMLOptionElement[];
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, selectStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     if (this.value && this._options.find((o) => o.value === this.value)) {
       this._select.value = this.value;
     } else {
@@ -82,7 +82,7 @@ export class PharosSelect extends ObserveChildrenMixin(FormMixin(FormElement)) {
     this._setOption();
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <label for="select-element">
         <slot name="label"></slot>

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-button.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-button.ts
@@ -23,11 +23,11 @@ export class PharosSidenavButton extends PharosButton {
     this.label = 'Open menu';
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, sidenavButtonStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('click', this._handleClickOpen);
   }
 

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
@@ -41,18 +41,18 @@ export class PharosSidenavLink extends PharosLink {
   @property({ type: Boolean, reflect: true, attribute: 'menu-item' })
   public menuItem = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, sidenavLinkStyles];
   }
 
-  protected get appendContent(): TemplateResult | typeof nothing {
+  protected override get appendContent(): TemplateResult | typeof nothing {
     if (this.external) {
       return html`<pharos-icon name="link-external" class="link__icon"></pharos-icon>`;
     }
     return nothing;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`${super.render()}`;
   }
 }

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
@@ -35,11 +35,11 @@ export class PharosSidenavMenu extends FocusMixin(LitElement) {
 
   private _allLinks!: NodeListOf<PharosSidenavLink>;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [sidenavMenuStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._allLinks = this.querySelectorAll('pharos-sidenav-link');
     this._allLinks.forEach((link) => {
       link.menuItem = true;
@@ -84,7 +84,7 @@ export class PharosSidenavMenu extends FocusMixin(LitElement) {
     `;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <button
         id="button-element"

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-section.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-section.ts
@@ -30,7 +30,7 @@ export class PharosSidenavSection extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: 'show-divider' })
   public showDivider = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [sidenavSectionStyles];
   }
 
@@ -52,7 +52,7 @@ export class PharosSidenavSection extends LitElement {
     return nothing;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="section__container">
         ${this._renderLabel()}

--- a/packages/pharos/src/components/sidenav/pharos-sidenav.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav.ts
@@ -43,17 +43,17 @@ export class PharosSidenav extends FocusMixin(SideElement) {
     this._handleMediaChange = this._handleMediaChange.bind(this);
   }
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback && super.connectedCallback();
     this._mediaQuery.addEventListener('change', this._handleMediaChange);
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     this._mediaQuery.removeEventListener('change', this._handleMediaChange);
     super.disconnectedCallback && super.disconnectedCallback();
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, sidenavStyles];
   }
 
@@ -76,7 +76,7 @@ export class PharosSidenav extends FocusMixin(SideElement) {
       : nothing;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <nav id="nav-element" class="side-element__container">
         <div class="side-element__content">

--- a/packages/pharos/src/components/tabs/pharos-tab-panel.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab-panel.ts
@@ -22,11 +22,11 @@ export class PharosTabPanel extends LitElement {
   @property({ type: Boolean, reflect: true })
   public selected = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [tabPanelStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.setAttribute('role', 'tabpanel');
     this.addEventListener('keydown', this._handleKeydown);
     const focusableElements = this.querySelector(focusable);
@@ -39,7 +39,7 @@ export class PharosTabPanel extends LitElement {
     event.stopPropagation();
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html` <slot></slot> `;
   }
 }

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -26,11 +26,11 @@ export class PharosTab extends LitElement {
   @state()
   private _focused = false;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [tabStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('click', this._handleClick);
 
     this.setAttribute('role', 'tab');
@@ -40,7 +40,7 @@ export class PharosTab extends LitElement {
     this.dataset.text = this.textContent || '';
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('selected')) {
       this._focused = this.selected;
       this.setAttribute('aria-selected', this.selected ? 'true' : 'false');
@@ -59,7 +59,7 @@ export class PharosTab extends LitElement {
     this.dispatchEvent(new CustomEvent('pharos-tab-selected', details));
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html` <slot></slot> `;
   }
 }

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -16,11 +16,11 @@ import type { PharosTabPanel } from './pharos-tab-panel';
  */
 @customElement('pharos-tabs')
 export class PharosTabs extends LitElement {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [tabsStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('pharos-tab-selected', this._handleTabSelected);
     this.addEventListener('keydown', this._handleKeydown);
     this.addEventListener('focusout', this._handleFocusout);
@@ -137,7 +137,7 @@ export class PharosTabs extends LitElement {
     });
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="tab__list" role="tablist">
         <slot></slot>

--- a/packages/pharos/src/components/text-input/pharos-text-input.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.ts
@@ -130,15 +130,15 @@ export class PharosTextInput extends FormMixin(FormElement) {
   @query('#input-element')
   private _input!: HTMLInputElement;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, textInputStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._input.defaultValue = this.value;
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('type') && !TYPES.includes(this.type)) {
@@ -210,7 +210,7 @@ export class PharosTextInput extends FormMixin(FormElement) {
     return nothing;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <label for="input-element">
         <slot name="label"></slot>

--- a/packages/pharos/src/components/textarea/pharos-textarea.ts
+++ b/packages/pharos/src/components/textarea/pharos-textarea.ts
@@ -112,15 +112,15 @@ export class PharosTextarea extends FormMixin(FormElement) {
   @query('#textarea-element')
   private _textarea!: HTMLTextAreaElement;
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, textareaStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._textarea.defaultValue = this.value;
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('resize') && !RESIZES.includes(this.resize)) {
@@ -159,7 +159,7 @@ export class PharosTextarea extends FormMixin(FormElement) {
     this.value = this._textarea.defaultValue;
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <label for="textarea-element">
         <slot name="label"></slot>

--- a/packages/pharos/src/components/toast/pharos-toast-button.ts
+++ b/packages/pharos/src/components/toast/pharos-toast-button.ts
@@ -25,7 +25,7 @@ export class PharosToastButton extends PharosButton {
     this.iconCondensed = true;
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, toastButtonStyles];
   }
 }

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -55,18 +55,18 @@ export class PharosToast extends FocusMixin(LitElement) {
     this.close();
   }, TOAST_LIFE);
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [toastStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('focusin', this._handleTimer);
     this.addEventListener('focusout', this._handleTimer);
 
     this.open = true;
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (changedProperties.has('status') && !STATUSES.includes(this.status)) {
@@ -102,7 +102,7 @@ export class PharosToast extends FocusMixin(LitElement) {
     }, 500)();
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div
         role="alert"

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -34,17 +34,17 @@ export class PharosToaster extends LitElement {
     this._closeToast = this._closeToast.bind(this);
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [toasterStyles];
   }
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback && super.connectedCallback();
     document.addEventListener('pharos-toast-open', this._openToast as EventListener);
     document.addEventListener('pharos-toast-close', this._closeToast as EventListener);
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     document.removeEventListener('pharos-toast-open', this._openToast as EventListener);
     document.removeEventListener('pharos-toast-close', this._closeToast as EventListener);
     super.disconnectedCallback && super.disconnectedCallback();
@@ -65,7 +65,7 @@ export class PharosToaster extends LitElement {
     this.removeChild(event.detail);
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="toaster__container">
         <slot></slot>

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -14,11 +14,11 @@ import type { PharosToggleButton } from './pharos-toggle-button';
  */
 @customElement('pharos-toggle-button-group')
 export class PharosToggleButtonGroup extends LitElement {
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [toggleButtonGroupStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('pharos-toggle-button-selected', this._handleButtonSelected);
     this.addEventListener('keydown', this._handleKeydown);
     this.addEventListener('focusout', this._handleFocusout);
@@ -129,7 +129,7 @@ export class PharosToggleButtonGroup extends LitElement {
     });
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="toggle-button__list" role="group">
         <slot></slot>

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
@@ -42,11 +42,11 @@ export class PharosToggleButton extends PharosButton {
     this.type = 'button';
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [super.styles, toggleButtonStyles];
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
 
     if (
@@ -78,7 +78,7 @@ export class PharosToggleButton extends PharosButton {
     }
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this.addEventListener('click', this._handleClickToggle);
   }
 

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.ts
@@ -97,11 +97,11 @@ export class PharosTooltip extends OverlayElement {
     this._handleClose = this._handleClose.bind(this);
   }
 
-  public static get styles(): CSSResultArray {
+  public static override get styles(): CSSResultArray {
     return [tooltipStyles];
   }
 
-  protected firstUpdated(): void {
+  protected override firstUpdated(): void {
     this._setTextLength();
 
     this.addEventListener('mouseenter', this._handleBubbleHover);
@@ -114,7 +114,7 @@ export class PharosTooltip extends OverlayElement {
     });
   }
 
-  protected update(changedProperties: PropertyValues): void {
+  protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
   }
 
@@ -122,7 +122,7 @@ export class PharosTooltip extends OverlayElement {
     return this._textLength > 30;
   }
 
-  protected updated(changedProperties: PropertyValues): void {
+  protected override updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('open')) {
       if (
         this.open &&
@@ -151,7 +151,7 @@ export class PharosTooltip extends OverlayElement {
     super.updated(changedProperties);
   }
 
-  connectedCallback(): void {
+  override connectedCallback(): void {
     super.connectedCallback && super.connectedCallback();
     document.addEventListener('keydown', this._handleKeydown);
     document.addEventListener('pharos-tooltip-close', this._handleClose as EventListener);
@@ -159,7 +159,7 @@ export class PharosTooltip extends OverlayElement {
     this._addTriggerListeners();
   }
 
-  disconnectedCallback(): void {
+  override disconnectedCallback(): void {
     document.removeEventListener('keydown', this._handleKeydown);
     document.removeEventListener('pharos-tooltip-close', this._handleClose as EventListener);
 
@@ -351,7 +351,7 @@ export class PharosTooltip extends OverlayElement {
     }
   }
 
-  protected render(): TemplateResult {
+  protected override render(): TemplateResult {
     return html`
       <div class="tooltip__body" role="tooltip" aria-hidden="${!this.open}">
         <span

--- a/packages/pharos/src/styles/tokens.wc.stories.mdx
+++ b/packages/pharos/src/styles/tokens.wc.stories.mdx
@@ -150,7 +150,9 @@ export const GlobalColorTokens = () => {
           </tr>
         </thead>
         <tbody>
-          ${colorTokens.filter((color) => color.group === 'primary').map((color) => ColorRow(color))}
+          ${colorTokens
+            .filter((color) => color.group === 'primary')
+            .map((color) => ColorRow(color))}
         </tbody>
       `
     )} ${TokenTable(

--- a/packages/pharos/src/utils/decorators.ts
+++ b/packages/pharos/src/utils/decorators.ts
@@ -75,9 +75,8 @@ const standardCustomElement = (tagName: string, descriptor: ClassDescriptor) => 
  * @category Decorator
  * @param tagName The name of the custom element to define.
  */
-export const customElement = (tagName: string) => (
-  classOrDescriptor: Constructor<HTMLElement> | ClassDescriptor
-) =>
-  typeof classOrDescriptor === 'function'
-    ? legacyCustomElement(tagName, classOrDescriptor)
-    : standardCustomElement(tagName, classOrDescriptor);
+export const customElement =
+  (tagName: string) => (classOrDescriptor: Constructor<HTMLElement> | ClassDescriptor) =>
+    typeof classOrDescriptor === 'function'
+      ? legacyCustomElement(tagName, classOrDescriptor)
+      : standardCustomElement(tagName, classOrDescriptor);

--- a/packages/pharos/src/utils/mixins/focus.ts
+++ b/packages/pharos/src/utils/mixins/focus.ts
@@ -11,7 +11,7 @@ const FocusMixinImplementation = <T extends Constructor<HTMLElement>>(Base: T): 
    * A mixin class to handle focusing pharos components.
    */
   class Focus extends Base {
-    public focus(): void {
+    public override focus(): void {
       const target = this.shadowRoot?.querySelector(focusable) || this.querySelector(focusable);
       (target as HTMLElement)?.focus();
     }

--- a/packages/pharos/src/utils/mixins/form.ts
+++ b/packages/pharos/src/utils/mixins/form.ts
@@ -28,7 +28,7 @@ const FormMixinImplementation = <T extends Constructor<HTMLElement>>(Base: T): T
       this._handleFormReset = this._handleFormReset.bind(this);
     }
 
-    connectedCallback(): void {
+    override connectedCallback(): void {
       super.connectedCallback && super.connectedCallback();
       const form = this.closest('form');
       if (form) {
@@ -37,7 +37,7 @@ const FormMixinImplementation = <T extends Constructor<HTMLElement>>(Base: T): T
       }
     }
 
-    disconnectedCallback(): void {
+    override disconnectedCallback(): void {
       const form = this.closest('form');
       if (form) {
         form.removeEventListener('formdata', this._handleFormdata);

--- a/packages/pharos/src/utils/mixins/observe-children.ts
+++ b/packages/pharos/src/utils/mixins/observe-children.ts
@@ -17,7 +17,7 @@ const ObserveChildrenMixinImplementation = <T extends Constructor<LitElement>>(B
       this.requestUpdate();
     };
 
-    connectedCallback(): void {
+    override connectedCallback(): void {
       super.connectedCallback && super.connectedCallback();
       this._childrenObserver = new MutationObserver(this._handleMutation);
       this._childrenObserver?.observe(this, {
@@ -27,7 +27,7 @@ const ObserveChildrenMixinImplementation = <T extends Constructor<LitElement>>(B
       });
     }
 
-    disconnectedCallback(): void {
+    override disconnectedCallback(): void {
       if (this._childrenObserver) {
         this._childrenObserver.disconnect();
         this._childrenObserver = null;

--- a/packages/pharos/tsconfig.json
+++ b/packages/pharos/tsconfig.json
@@ -20,6 +20,7 @@
     "forceConsistentCasingInFileNames": true,
     "importsNotUsedAsValues": "error",
     "resolveJsonModule": true,
+    "noImplicitOverride": true,
     "types": ["mocha"],
     "plugins": [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17991,15 +17991,20 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.2.1, prettier@^2.0.5, prettier@~2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
-
 prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.5, prettier@~2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
+prettier@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 pretty-bytes@^5.1.0, pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"
@@ -21709,10 +21714,10 @@ typescript@^3.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
-typescript@^4.2.2:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 typescript@^4.3.2:
   version "4.3.4"


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Update to [TypeScript 4.3](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html) and utilize the [override](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html#override-and-the---noimplicitoverride-flag) keyword to make sure that a method/property with the same name exists in a the base class when overriding its members.

Resolves #47

**How does this change work?**

- Update to TypeScript 4.3
- Add `noImplicitOverride` flag
- Update Prettier to support the new keyword