### PR TITLE
fix(combobox): clear input when value is reset

### DIFF
--- a/.changeset/wicked-waves-sparkle.md
+++ b/.changeset/wicked-waves-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+clear combobox input when value is reset

--- a/packages/pharos/src/components/combobox/pharos-combobox.test.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.test.ts
@@ -661,4 +661,14 @@ describe('pharos-combobox', () => {
 
     expect(component.open).to.be.false;
   });
+
+  it('clears the displayed value when the value is cleared programmatically', async () => {
+    component.value = '1';
+    await elementUpdated(component);
+
+    component.value = '';
+    await elementUpdated(component);
+
+    expect(component['_input'].value).to.equal('');
+  });
 });

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -334,7 +334,7 @@ export class PharosCombobox extends FormMixin(FormElement) {
   }
 
   private _handleInputBlur(): void {
-    this._setDisplayValue();
+    this._setDisplayValue(true);
     this._closeDropdown();
   }
 
@@ -437,9 +437,11 @@ export class PharosCombobox extends FormMixin(FormElement) {
     this._displayValue = this._input.defaultValue;
   }
 
-  private _setDisplayValue() {
+  private _setDisplayValue(blurred = false) {
     if (this.value && this.selectedIndex >= 0) {
       this._displayValue = this.options[this.selectedIndex].text.trim();
+    } else if (this.value === '' && !blurred) {
+      this._displayValue = '';
     }
   }
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Fixes #159 

**How does this change work?**

- Clear the displayed value when the value is cleared programmatically

**Additional context**
This only handles situations where an option has been first selected and then `value` is reset. To clear the display value with random text or when there is no matching option we would need to provide a public method consumers could call on the combobox instance.