### PR TITLE
fix(combobox): stop button from receiving focus

### DIFF
--- a/.changeset/pretty-impalas-explain.md
+++ b/.changeset/pretty-impalas-explain.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix keyboard navigation behavior for Combobox

--- a/packages/pharos/src/components/combobox/pharos-combobox.test.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.test.ts
@@ -111,7 +111,7 @@ describe('pharos-combobox', () => {
 
     matchingOption.click();
 
-    component['_button'].dispatchEvent(new FocusEvent('focus'));
+    component['_input'].dispatchEvent(new MouseEvent('click'));
     await aTimeout(100);
     await component.updateComplete;
 

--- a/packages/pharos/src/components/combobox/pharos-combobox.test.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.test.ts
@@ -339,25 +339,11 @@ describe('pharos-combobox', () => {
   });
 
   it('opens the dropdown list on focus of the dropdown button', async () => {
-    component['_button'].dispatchEvent(new FocusEvent('focus'));
+    component['_button'].dispatchEvent(new MouseEvent('click'));
     await aTimeout(100);
     await component.updateComplete;
 
     expect(component.open).to.be.true;
-  });
-
-  it('toggles the dropdown list on click of the dropdown button', async () => {
-    component['_button'].dispatchEvent(new MouseEvent('mousedown'));
-    component['_button'].dispatchEvent(new MouseEvent('click'));
-    await aTimeout(100);
-    await component.updateComplete;
-    expect(component.open).to.be.true;
-
-    component['_button'].dispatchEvent(new MouseEvent('mousedown'));
-    component['_button'].dispatchEvent(new MouseEvent('click'));
-    await aTimeout(100);
-    await component.updateComplete;
-    expect(component.open).to.be.false;
   });
 
   it('toggles the dropdown list on click of the input', async () => {

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -267,12 +267,11 @@ export class PharosCombobox extends FormMixin(FormElement) {
     } else {
       return html`
         <button
+          tabindex="-1"
           type="button"
           class="combobox__button"
           ?disabled=${this.disabled}
           @click=${this._handleButtonClick}
-          @mousedown=${this._handleButtonMousedown}
-          @focus=${this._handleButtonFocus}
           @blur=${this._handleButtonBlur}
         >
           <pharos-icon
@@ -298,31 +297,14 @@ export class PharosCombobox extends FormMixin(FormElement) {
     }, 100)();
   }
 
-  private _handleButtonFocus(): void {
-    if (!this._clicked) {
-      debounce(() => {
-        this.open = true;
-      }, 100)();
-    }
-  }
-
-  private _handleButtonMousedown(event: MouseEvent): void {
-    event.preventDefault();
-    this._clicked = true;
-  }
-
   private _handleButtonClick(event: MouseEvent): void {
     event.preventDefault();
-    this._button.focus();
-    this._clicked = false;
-
-    debounce(() => {
-      this.open = !this.open;
-    }, 100)();
+    this._input.focus();
+    this.open = true;
   }
 
-  private _handleButtonBlur(): void {
-    if (!this._clicked) {
+  private _handleButtonBlur(event: BlurEvent): void {
+    if (event.relatedTarget !== this._input) {
       this._closeDropdown();
     }
   }
@@ -333,9 +315,11 @@ export class PharosCombobox extends FormMixin(FormElement) {
     this._input.focus();
   }
 
-  private _handleInputBlur(): void {
+  private _handleInputBlur(event: BlurEvent): void {
     this._setDisplayValue(true);
-    this._closeDropdown();
+    if (event.relatedTarget !== this._button) {
+      this._closeDropdown();
+    }
   }
 
   private _handleInputKeydown(event: KeyboardEvent): void {

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -88,7 +88,6 @@ export class PharosCombobox extends FormMixin(FormElement) {
   @state()
   private _displayValue = '';
 
-  private _clicked = false;
   private _noResults = false;
   private _query = '';
   private _defaultValue = '';
@@ -303,7 +302,7 @@ export class PharosCombobox extends FormMixin(FormElement) {
     this.open = true;
   }
 
-  private _handleButtonBlur(event: BlurEvent): void {
+  private _handleButtonBlur(event: FocusEvent): void {
     if (event.relatedTarget !== this._input) {
       this._closeDropdown();
     }
@@ -315,7 +314,7 @@ export class PharosCombobox extends FormMixin(FormElement) {
     this._input.focus();
   }
 
-  private _handleInputBlur(event: BlurEvent): void {
+  private _handleInputBlur(event: FocusEvent): void {
     this._setDisplayValue(true);
     if (event.relatedTarget !== this._button) {
       this._closeDropdown();


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

#160 

**How does this change work?**

* Add `tabindex="-1"` to the combobox button to avoid keyboard focus
* Update click and blur handling for desired behavior

**Additional context**

This removes the ability to toggle the combobox open/closed by clicking the button repeatedly—we could change that, but this is consistent with the WAI ARIA example.