### PR TITLE
feat: add dismissibility to alert component

### DIFF
--- a/.changeset/eight-shrimps-hide.md
+++ b/.changeset/eight-shrimps-hide.md
@@ -1,0 +1,6 @@
+---
+'@ithaka/pharos': minor
+'@ithaka/pharos-site': minor
+---
+
+Add dismissibility function to alert component

--- a/.changeset/eight-shrimps-hide.md
+++ b/.changeset/eight-shrimps-hide.md
@@ -5,4 +5,4 @@
 
 Add dismissibility function to alert component:
 
-* add `isDismissibility` property to `alert` component 
+* add `isDismissibile` property to `alert` component 

--- a/.changeset/eight-shrimps-hide.md
+++ b/.changeset/eight-shrimps-hide.md
@@ -3,4 +3,6 @@
 '@ithaka/pharos-site': minor
 ---
 
-Add dismissibility function to alert component
+Add dismissibility function to alert component:
+
+* add `isDismissibility` property to `alert` component 

--- a/packages/pharos-site/static/guidelines/alert.docs.mdx
+++ b/packages/pharos-site/static/guidelines/alert.docs.mdx
@@ -175,6 +175,16 @@ import BestPractices from '../../src/components/statics/BestPractices.tsx';
         </PharosAlert>
       </Canvas>
     </PageSection>
+    <PageSection title="Dismissible Alert" subSectionLevel={1}>
+      To allow for alerts to be closed, alerts have a button for dismissibility enabled.
+      <Canvas>
+        <PharosAlert status="warning" isDismissible>
+          The information provided does not match our records. Please check your username or
+          password and try again. If the issue persists, please contact{' '}
+          <PharosLink href="#">support@jstor.org</PharosLink>.
+        </PharosAlert>
+      </Canvas>
+    </PageSection>
   </PageSection>
 </PageSection>
 

--- a/packages/pharos/src/components/alert/PharosAlert.react.stories.mdx
+++ b/packages/pharos/src/components/alert/PharosAlert.react.stories.mdx
@@ -80,3 +80,21 @@ export const ErrorTemplate = (args) => (
     {ErrorTemplate.bind({})}
   </Story>
 </Canvas>
+
+## Dismissible Alert
+
+export const DismissibleTemplate = (args) => (
+  <pharos-alert status="error" isDismissible>
+    <p className="alert-example__content">{args.text}</p>
+    <p className="alert-example__content">
+      For more information,
+      <pharos-link href="#">read the documentation</pharos-link>.
+    </p>
+  </pharos-alert>
+);
+
+<Canvas withToolbar>
+  <Story name="Dismissible" args={{ text: "Your password didn't meet the minimum requirements." }}>
+    {DismissibleTemplate.bind({})}
+  </Story>
+</Canvas>

--- a/packages/pharos/src/components/alert/pharos-alert.scss
+++ b/packages/pharos/src/components/alert/pharos-alert.scss
@@ -13,11 +13,12 @@
   padding: var(--pharos-spacing-1-x);
   border-radius: var(--pharos-radius-base-standard);
   display: grid;
-  grid-template-areas: 'icon body';
-  grid-template-columns: var(--pharos-spacing-one-and-a-half-x) 1fr;
+  grid-template-areas: 'icon body dismiss';
+  grid-template-columns: var(--pharos-spacing-one-and-a-half-x) 1fr 1.75rem;
   grid-gap: var(--pharos-spacing-1-x);
   background: var(--pharos-alert-color-background-base);
   color: var(--pharos-alert-color-text-base);
+  align-items: start;
 }
 
 .alert__icon {
@@ -27,6 +28,10 @@
 
 .alert__body {
   grid-area: body;
+}
+
+.alert__button {
+  grid-area: dismiss;
 }
 
 .alert--info {

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 import type { PropertyValues, TemplateResult, CSSResultArray } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
@@ -8,6 +8,7 @@ import type { PharosLink } from '../link/pharos-link';
 
 import FocusMixin from '../../utils/mixins/focus';
 import '../icon/pharos-icon';
+import '../button/pharos-button';
 
 export type AlertStatus = 'info' | 'success' | 'warning' | 'error';
 
@@ -26,6 +27,8 @@ const STATUSES = ['info', 'success', 'warning', 'error'];
  * @tag pharos-alert
  *
  * @slot - Contains the alert message (the default slot).
+ *
+ * @fires pharos-alert-close - Fires when the toast has closed
  *
  * @cssprop {Color} --pharos-alert-color-text-inverse - The inverted text color for messaging in a dark-colored alert
  * @cssprop {Color} --pharos-alert-color-link-inverse - The inverted text color for links in a dark-colored alert
@@ -50,6 +53,13 @@ export class PharosAlert extends FocusMixin(LitElement) {
    */
   @property({ type: String, reflect: true })
   public status!: AlertStatus;
+
+  /**
+   * Indicates if the modal is open.
+   * @attr dismissisible
+   */
+  @property({ type: Boolean, reflect: true })
+  public isDismissible = false;
 
   private _allLinks!: NodeListOf<PharosLink>;
 
@@ -84,6 +94,23 @@ export class PharosAlert extends FocusMixin(LitElement) {
     });
   }
 
+  private close(): void {
+    this.remove();
+  }
+
+  private _getCloseButton(): TemplateResult | typeof nothing {
+    return this.isDismissible
+      ? html` <pharos-button
+          type="button"
+          variant="subtle"
+          icon="close"
+          label="Close alert"
+          class="alert__button"
+          @click=${this.close}
+        ></pharos-button>`
+      : nothing;
+  }
+
   protected override render(): TemplateResult {
     return html`
       <div
@@ -98,6 +125,7 @@ export class PharosAlert extends FocusMixin(LitElement) {
         <div class="alert__body">
           <slot @slotchange=${this._handleSlotChange}></slot>
         </div>
+        ${this._getCloseButton()}
       </div>
     `;
   }

--- a/packages/pharos/src/components/alert/pharos-alert.wc.stories.mdx
+++ b/packages/pharos/src/components/alert/pharos-alert.wc.stories.mdx
@@ -73,3 +73,19 @@ export const ErrorTemplate = (args) => html` <pharos-alert status="error">
     {ErrorTemplate.bind({})}
   </Story>
 </Canvas>
+
+## Dismissible Alert
+
+export const DismissibleTemplate = (args) => html` <pharos-alert status="error" isDismissible>
+  <p class="alert-example__content">${args.text}</p>
+  <p class="alert-example__content">
+    For more information,
+    <pharos-link href="#">read the documentation</pharos-link>.
+  </p>
+</pharos-alert>`;
+
+<Canvas withToolbar>
+  <Story name="Dismissible" args={{ text: "Your password didn't meet the minimum requirements." }}>
+    {DismissibleTemplate.bind({})}
+  </Story>
+</Canvas>


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [] Fixes a bug
- [] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
This change allows for users to have the option to dismiss alerts.

**How does this change work?**
- Add the `isDismissible` property to `PharosAlert` component.


