### PR TITLE
feat(image-card): add property for setting aria label on the image link

### DIFF
--- a/.changeset/stale-baboons-happen.md
+++ b/.changeset/stale-baboons-happen.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add optional label for the link wrapping the image in the image card to improve accessibility

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -252,7 +252,6 @@ describe('pharos-image-card', () => {
   });
 
   it('renders a label for the link around the image for the base variant', async () => {
-
     const link = component.renderRoot.querySelector('pharos-link.card__link--image');
     expect(link?.getAttribute('label')).to.equal('Label for card image link');
   });

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -252,7 +252,6 @@ describe('pharos-image-card', () => {
   });
 
   it('renders a label for the link around the image for the base variant', async () => {
-    await component.updateComplete;
 
     const link = component.renderRoot.querySelector('pharos-link.card__link--image');
     expect(link?.getAttribute('label')).to.equal('Label for card image link');

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -10,7 +10,11 @@ describe('pharos-image-card', () => {
   let component: PharosImageCard;
 
   beforeEach(async () => {
-    component = await fixture(html`<pharos-image-card title="Card Title" link="#">
+    component = await fixture(html`<pharos-image-card
+      title="Card Title"
+      link="#"
+      image-link-label="Label for card image link"
+    >
       <img
         slot="image"
         alt="Card Title"
@@ -245,5 +249,20 @@ describe('pharos-image-card', () => {
 
     const link = component.renderRoot.querySelector('pharos-link.card__link--collection');
     expect(link).not.to.be.null;
+  });
+
+  it('renders a label for the link around the image for the base variant', async () => {
+    await component.updateComplete;
+
+    const link = component.renderRoot.querySelector('pharos-link.card__link--image');
+    expect(link?.getAttribute('label')).to.equal('Label for card image link');
+  });
+
+  it('renders a label for the link around the image for the collection variant', async () => {
+    component.variant = 'collection';
+    await component.updateComplete;
+
+    const link = component.renderRoot.querySelector('pharos-link.card__link--collection');
+    expect(link?.getAttribute('label')).to.equal('Label for card image link');
   });
 });

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -1,5 +1,6 @@
 import { html, LitElement, nothing } from 'lit';
 import { property, query } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit';
 import { imageCardStyles } from './pharos-image-card.css';
 import { customElement } from '../../utils/decorators';
@@ -55,6 +56,13 @@ export class PharosImageCard extends LitElement {
    */
   @property({ type: String, reflect: true })
   public link = '';
+
+  /**
+   * Indicates the label to apply to the image link.
+   * @attr link
+   */
+  @property({ type: String, reflect: true, attribute: 'image-link-label' })
+  public imageLinkLabel?: string;
 
   /**
    * Indicates the variant of card.
@@ -125,6 +133,7 @@ export class PharosImageCard extends LitElement {
     return html`<pharos-link
       class="card__link--collection"
       href="${this.link}"
+      aria-label=${ifDefined(this.imageLinkLabel)}
       subtle
       flex
       no-hover
@@ -155,6 +164,7 @@ export class PharosImageCard extends LitElement {
     return html`<pharos-link
       class="card__link--image"
       href="${this.link}"
+      aria-label=${ifDefined(this.imageLinkLabel)}
       subtle
       flex
       no-hover

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -133,7 +133,7 @@ export class PharosImageCard extends LitElement {
     return html`<pharos-link
       class="card__link--collection"
       href="${this.link}"
-      aria-label=${ifDefined(this.imageLinkLabel)}
+      label="${ifDefined(this.imageLinkLabel)}"
       subtle
       flex
       no-hover
@@ -164,7 +164,7 @@ export class PharosImageCard extends LitElement {
     return html`<pharos-link
       class="card__link--image"
       href="${this.link}"
-      aria-label=${ifDefined(this.imageLinkLabel)}
+      label=${ifDefined(this.imageLinkLabel)}
       subtle
       flex
       no-hover

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -59,7 +59,7 @@ export class PharosImageCard extends LitElement {
 
   /**
    * Indicates the label to apply to the image link.
-   * @attr link
+   * @attr image-link-label
    */
   @property({ type: String, reflect: true, attribute: 'image-link-label' })
   public imageLinkLabel?: string;


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
This allows the pharos consumer to add a label to the link surrounding the image on the image card

**How does this change work?**
Creates new `image-link-label` property on the image card and adds the value as an `aria-label` to the markup if defined

**Additional context**
Not sure if bugfix or feature. Thoughts on if this should be a minor change vs a patch? 
