### PR TITLE
fix(image-card): remove containment styling for title

### DIFF
--- a/.changeset/thick-chicken-sin.md
+++ b/.changeset/thick-chicken-sin.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Remove containment styling for linked title in image-card component

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -12,13 +12,13 @@
 }
 
 .card__link--image {
-  contain: unset;
   height: 14rem;
   margin: 0 auto var(--pharos-spacing-1-x);
 }
 
 .card__link--image,
 .card__link--title {
+  contain: unset;
   display: inline-flex;
   min-width: 0;
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Closes #197

**How does this change work?**
This unsets the `contain: layout` style from the link element

**Additional context**
Marked as potential browser bug because the misaligned tooltip predicating this issue is only present on Firefox.
