### PR TITLE
fix(breadcrumb): allow items to wrap

### DIFF
--- a/.changeset/stupid-experts-pretend.md
+++ b/.changeset/stupid-experts-pretend.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Allow breadcrumb items to wrap

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.scss
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.scss
@@ -4,6 +4,7 @@
 
   .breadcrumb {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

Fixes #195 

**How does this change work?**

Allow the flex items to wrap when there isn't enough space on a single line using `flex-wrap: wrap`.
