### PR TITLE
fix(input-group): shift validity icon placement

### DIFF
--- a/.changeset/late-dots-kick.md
+++ b/.changeset/late-dots-kick.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix positioning of validity icons in the presence of appended group items (like buttons)

--- a/packages/pharos/src/components/input-group/PharosInputGroup.react.stories.mdx
+++ b/packages/pharos/src/components/input-group/PharosInputGroup.react.stories.mdx
@@ -43,6 +43,39 @@ import { PharosIcon } from '../../react-components/icon/pharos-icon';
 
 <ArgsTable of={PharosInputGroup} />
 
+# Validity
+
+<Canvas withToolbar>
+  <Story name="Validity">
+    <div
+      style={{
+        display: 'grid',
+        gridGap: '1rem',
+        gridTemplateColumns: 'repeat(1, 524px)',
+      }}
+    >
+      <PharosInputGroup invalidated value="not an email" name="my-input-group">
+        <span slot="label">Search</span>
+        <PharosButton
+          name="search-button"
+          icon="search"
+          variant="subtle"
+          label="search"
+        ></PharosButton>
+      </PharosInputGroup>
+      <PharosInputGroup validated value="here@there.com" name="my-input-group">
+        <span slot="label">Search</span>
+        <PharosButton
+          name="search-button"
+          icon="search"
+          variant="subtle"
+          label="search"
+        ></PharosButton>
+      </PharosInputGroup>
+    </div>
+  </Story>
+</Canvas>
+
 # Composition
 
 <Canvas withToolbar>

--- a/packages/pharos/src/components/input-group/pharos-input-group.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group.ts
@@ -5,7 +5,7 @@ import { inputGroupStyles } from './pharos-input-group.css';
 import { customElement } from '../../utils/decorators';
 import { PharosTextInput } from '../text-input/pharos-text-input';
 import type { TextInputType, TextInputAutocomplete } from '../text-input/pharos-text-input';
-import { PharosSpacingThreeQuartersX } from '../../styles/variables';
+import { PharosSpacingOneAndAHalfX, PharosSpacingThreeQuartersX } from '../../styles/variables';
 
 export type { TextInputType, TextInputAutocomplete };
 
@@ -44,14 +44,15 @@ export class PharosInputGroup extends PharosTextInput {
     super.updated(changedProperties);
 
     if (changedProperties.has('_prependGroupWidth')) {
-      super[
-        '_input'
-      ].style.paddingLeft = `calc(${PharosSpacingThreeQuartersX} + ${this._prependGroupWidth}px)`;
+      this._input.style.paddingLeft = `calc(${PharosSpacingThreeQuartersX} + ${this._prependGroupWidth}px)`;
     }
     if (changedProperties.has('_appendGroupWidth')) {
-      super[
-        '_input'
-      ].style.paddingRight = `calc(${PharosSpacingThreeQuartersX} + ${this._appendGroupWidth}px)`;
+      if (this._inputIcon) {
+        this._inputIcon.style.right = `${this._appendGroupWidth}px`;
+        this._input.style.paddingRight = `calc(${PharosSpacingOneAndAHalfX} + ${this._appendGroupWidth}px)`;
+      } else {
+        this._input.style.paddingRight = `calc(${PharosSpacingThreeQuartersX} + ${this._appendGroupWidth}px)`;
+      }
     }
   }
 
@@ -83,17 +84,13 @@ export class PharosInputGroup extends PharosTextInput {
 
   private _adjustPadding(event: FocusEvent) {
     const amount = event.type === 'focus' ? -1 : 1;
-    super['_input'].style.paddingLeft = `${
-      parseInt(
-        window.getComputedStyle(super['_input'], null).getPropertyValue('padding-left'),
-        10
-      ) + amount
+    this._input.style.paddingLeft = `${
+      parseInt(window.getComputedStyle(this._input, null).getPropertyValue('padding-left'), 10) +
+      amount
     }px`;
-    super['_input'].style.paddingRight = `${
-      parseInt(
-        window.getComputedStyle(super['_input'], null).getPropertyValue('padding-right'),
-        10
-      ) + amount
+    this._input.style.paddingRight = `${
+      parseInt(window.getComputedStyle(this._input, null).getPropertyValue('padding-right'), 10) +
+      amount
     }px`;
   }
 

--- a/packages/pharos/src/components/input-group/pharos-input-group.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group.ts
@@ -46,7 +46,9 @@ export class PharosInputGroup extends PharosTextInput {
     if (changedProperties.has('_prependGroupWidth')) {
       this._input.style.paddingLeft = `calc(${PharosSpacingThreeQuartersX} + ${this._prependGroupWidth}px)`;
     }
-    if (changedProperties.has('_appendGroupWidth')) {
+    if (
+      ['invalidated', 'validated', '_appendGroupWidth'].some((key) => changedProperties.has(key))
+    ) {
       if (this._inputIcon) {
         this._inputIcon.style.right = `${this._appendGroupWidth}px`;
         this._input.style.paddingRight = `calc(${PharosSpacingOneAndAHalfX} + ${this._appendGroupWidth}px)`;
@@ -83,7 +85,7 @@ export class PharosInputGroup extends PharosTextInput {
   }
 
   private _adjustPadding(event: FocusEvent) {
-    const amount = event.type === 'focus' ? -1 : 1;
+    const amount = this.invalidated ? 0 : event.type === 'focus' ? -1 : 1;
     this._input.style.paddingLeft = `${
       parseInt(window.getComputedStyle(this._input, null).getPropertyValue('padding-left'), 10) +
       amount

--- a/packages/pharos/src/components/input-group/pharos-input-group.wc.stories.mdx
+++ b/packages/pharos/src/components/input-group/pharos-input-group.wc.stories.mdx
@@ -34,6 +34,35 @@ import '../button/pharos-button';
 
 <ArgsTable of="pharos-input-group" />
 
+# Validity
+
+<Canvas>
+  <Story name="Validity">
+    {html`
+      <div style="display: grid; grid-gap: 1rem; grid-template-columns: 524px;">
+        <pharos-input-group invalidated value="not an email" name="my-input-group">
+          <span slot="label">Email</span>
+          <pharos-button
+            name="search-button"
+            icon="search"
+            variant="subtle"
+            label="search"
+          ></pharos-button>
+        </pharos-input-group>
+        <pharos-input-group validated value="here@there.com" name="my-input-group">
+          <span slot="label">Email</span>
+          <pharos-button
+            name="search-button"
+            icon="search"
+            variant="subtle"
+            label="search"
+          ></pharos-button>
+        </pharos-input-group>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
 # Composition
 
 <Canvas>

--- a/packages/pharos/src/components/text-input/pharos-text-input.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.ts
@@ -128,7 +128,10 @@ export class PharosTextInput extends FormMixin(FormElement) {
   public onBackground = false;
 
   @query('#input-element')
-  private _input!: HTMLInputElement;
+  protected _input!: HTMLInputElement;
+
+  @query('.input__icon')
+  protected _inputIcon!: HTMLInputElement;
 
   public static override get styles(): CSSResultArray {
     return [super.styles, textInputStyles];


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

Fixes #204 

**How does this change work?**

* Consider the width of the appended input group content (like buttons) when determining the icon's placement and the input's padding.
* Add a story to show validity for input groups to identify regressions

**Additional context**

I replaced instances of `super['_input']` with `this._input` and made `_input` a protected instead of private member of the base class. This feels fine encapsulation-wise and makes the inheritance feel more smooth.
