### PR TITLE
feat(button): Add overlay variant

### DIFF
--- a/.changeset/nine-shoes-joke.md
+++ b/.changeset/nine-shoes-joke.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Adds overlay button variant

--- a/.changeset/nine-shoes-joke.md
+++ b/.changeset/nine-shoes-joke.md
@@ -1,5 +1,5 @@
 ---
-'@ithaka/pharos': patch
+'@ithaka/pharos': minor
 ---
 
 Adds overlay button variant

--- a/packages/pharos/src/components/button/PharosButton.react.stories.mdx
+++ b/packages/pharos/src/components/button/PharosButton.react.stories.mdx
@@ -106,6 +106,9 @@ export const Template = (args) => (
         <PharosButton name="subtle" variant="subtle">
           Subtle
         </PharosButton>
+        <PharosButton name="overlay" variant="overlay">
+          Overlay
+        </PharosButton>
       </div>
       <div style={{ padding: '1rem', display: 'grid', gridGap: '1.5rem' }}>
         <PharosButton name="primary-disabled" disabled>
@@ -116,6 +119,9 @@ export const Template = (args) => (
         </PharosButton>
         <PharosButton name="subtle-disabled" variant="subtle" disabled>
           Subtle
+        </PharosButton>
+        <PharosButton name="overlay-disabled" variant="overlay" disabled>
+          Overlay
         </PharosButton>
       </div>
       <div
@@ -134,6 +140,9 @@ export const Template = (args) => (
         </PharosButton>
         <PharosButton name="subtle-on-background" variant="subtle" onBackground>
           Subtle
+        </PharosButton>
+        <PharosButton name="overlay-on-background" variant="overlay" onBackground>
+          Overlay
         </PharosButton>
       </div>
     </div>
@@ -161,6 +170,9 @@ export const Template = (args) => (
         <PharosButton name="large-subtle" variant="subtle" large>
           Subtle
         </PharosButton>
+        <PharosButton name="large-overlay" variant="overlay" large>
+          Overlay
+        </PharosButton>
       </div>
       <div style={{ padding: '1rem', display: 'grid', gridGap: '1.5rem' }}>
         <PharosButton name="large-primary-disabled" large disabled>
@@ -171,6 +183,9 @@ export const Template = (args) => (
         </PharosButton>
         <PharosButton name="large-subtle-disabled" variant="subtle" large disabled>
           Subtle
+        </PharosButton>
+        <PharosButton name="large-overlay-disabled" variant="overlay" large disabled>
+          Overlay
         </PharosButton>
       </div>
       <div
@@ -189,6 +204,9 @@ export const Template = (args) => (
         </PharosButton>
         <PharosButton name="large-subtle-on-background" variant="subtle" large onBackground>
           Subtle
+        </PharosButton>
+        <PharosButton name="large-overlay-on-background" variant="overlay" large onBackground>
+          Overlay
         </PharosButton>
       </div>
     </div>

--- a/packages/pharos/src/components/button/pharos-button.scss
+++ b/packages/pharos/src/components/button/pharos-button.scss
@@ -30,6 +30,16 @@
   );
 }
 
+:host([variant='overlay']) #button-element {
+  @include mixins.button-base(
+    $color: var(--pharos-color-ui-10),
+    $background-color: var(--pharos-color-marble-gray-10),
+    $border-color: var(--pharos-color-marble-gray-10)
+  );
+
+  opacity: 0.9;
+}
+
 :host([href]) #button-element {
   @include mixins.no-underline;
 }
@@ -83,6 +93,15 @@
     $color: var(--pharos-color-hover-primary),
     $background-color: var(--pharos-color-ui-20),
     $border-color: var(--pharos-color-ui-20)
+  );
+}
+
+:host([variant='overlay']:not([disabled])) #button-element:hover,
+:host([variant='overlay']:not([disabled])) #button-element:active {
+  @include mixins.button-color(
+    $color: var(--pharos-color-ui-10),
+    $background-color: var(--pharos-color-marble-gray-20),
+    $border-color: var(--pharos-color-marble-gray-20)
   );
 }
 

--- a/packages/pharos/src/components/button/pharos-button.test.ts
+++ b/packages/pharos/src/components/button/pharos-button.test.ts
@@ -49,6 +49,12 @@ describe('pharos-button', () => {
       await expect(component).to.be.accessible();
     });
 
+    it('is accessible as the overlay variant', async () => {
+      component.variant = 'overlay';
+      await component.updateComplete;
+      await expect(component).to.be.accessible();
+    });
+
     it('is accessible on a AA compliant background', async () => {
       const parentNode = document.createElement('div');
       parentNode.style.backgroundColor = PharosColorBlack;
@@ -78,6 +84,19 @@ describe('pharos-button', () => {
 
       component = await fixture(
         html`<pharos-button variant="subtle" on-background>I am a button</pharos-button>`,
+        {
+          parentNode,
+        }
+      );
+      await expect(component).to.be.accessible();
+    });
+
+    it('is accessible on a AA compliant background as the overlay variant', async () => {
+      const parentNode = document.createElement('div');
+      parentNode.style.backgroundColor = PharosColorBlack;
+
+      component = await fixture(
+        html`<pharos-button variant="overlay" on-background>I am a button</pharos-button>`,
         {
           parentNode,
         }

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -13,13 +13,13 @@ import type { IconName } from '../icon/pharos-icon';
 
 export type ButtonType = 'button' | 'submit' | 'reset';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'subtle';
+export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'overlay';
 
 export type { LinkTarget, IconName };
 
 const TYPES = ['button', 'submit', 'reset'];
 
-const VARIANTS = ['primary', 'secondary', 'subtle'];
+const VARIANTS = ['primary', 'secondary', 'subtle', 'overlay'];
 
 /**
  * Pharos button component.

--- a/packages/pharos/src/components/button/pharos-button.wc.stories.mdx
+++ b/packages/pharos/src/components/button/pharos-button.wc.stories.mdx
@@ -52,7 +52,7 @@ export const Template = (args) =>
     name="Base"
     argTypes={{
       variant: {
-        options: ['primary', 'secondary', 'subtle'],
+        options: ['primary', 'secondary', 'subtle', 'overlay'],
         control: {
           type: 'inline-radio',
         },
@@ -102,6 +102,7 @@ export const Template = (args) =>
           <pharos-button name="primary">Primary</pharos-button>
           <pharos-button name="secondary" variant="secondary">Secondary</pharos-button>
           <pharos-button name="subtle" variant="subtle">Subtle</pharos-button>
+          <pharos-button name="overlay" variant="overlay">Overlay</pharos-button>
         </div>
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
           <pharos-button name="primary-disabled" disabled>Primary</pharos-button>
@@ -109,6 +110,7 @@ export const Template = (args) =>
             >Secondary</pharos-button
           >
           <pharos-button name="subtle-disabled" variant="subtle" disabled>Subtle</pharos-button>
+          <pharos-button name="overlay-disabled" variant="overlay" disabled>Overlay</pharos-button>
         </div>
         <div style="background-color: #000000; padding: 1rem; display: grid; grid-gap: 1.5rem;">
           <pharos-button name="primary-on-background" on-background>Primary</pharos-button>
@@ -117,6 +119,9 @@ export const Template = (args) =>
           >
           <pharos-button name="subtle-on-background" variant="subtle" on-background
             >Subtle</pharos-button
+          >
+          <pharos-button name="overlay-on-background" variant="overlay" on-background
+            >Overlay</pharos-button
           >
         </div>
       </div>
@@ -134,6 +139,7 @@ export const Template = (args) =>
           <pharos-button name="large-primary" large>Primary</pharos-button>
           <pharos-button name="large-secondary" variant="secondary" large>Secondary</pharos-button>
           <pharos-button name="large-subtle" variant="subtle" large>Subtle</pharos-button>
+          <pharos-button name="large-overlay" variant="overlay" large>Overlay</pharos-button>
         </div>
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
           <pharos-button name="large-primary-disabled" large disabled>Primary</pharos-button>
@@ -142,6 +148,9 @@ export const Template = (args) =>
           >
           <pharos-button name="large-subtle-disabled" variant="subtle" large disabled
             >Subtle</pharos-button
+          >
+          <pharos-button name="large-overlay" variant="overlay" large disabled
+            >Overlay</pharos-button
           >
         </div>
         <div style="background-color: #000000; padding: 1rem; display: grid; grid-gap: 1.5rem;">
@@ -157,6 +166,9 @@ export const Template = (args) =>
           >
           <pharos-button name="large-subtle-on-background" variant="subtle" large on-background
             >Subtle</pharos-button
+          >
+          <pharos-button name="large-overlay" variant="overlay" large on-background
+            >Overlay</pharos-button
           >
         </div>
       </div>
@@ -224,7 +236,7 @@ export const Template = (args) =>
     name="Icon only"
     argTypes={{
       variant: {
-        options: ['primary', 'secondary', 'subtle'],
+        options: ['primary', 'secondary', 'subtle', 'overlay'],
         control: {
           type: 'inline-radio',
         },
@@ -262,7 +274,7 @@ export const Template = (args) =>
     name="Icon only (condensed)"
     argTypes={{
       variant: {
-        options: ['primary', 'secondary', 'subtle'],
+        options: ['primary', 'secondary', 'subtle', 'overlay'],
         control: {
           type: 'inline-radio',
         },
@@ -295,7 +307,7 @@ export const Template = (args) =>
     name="Link"
     argTypes={{
       variant: {
-        options: ['primary', 'secondary', 'subtle'],
+        options: ['primary', 'secondary', 'subtle', 'overlay'],
         control: {
           type: 'inline-radio',
         },


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
This PR introduces a new button variant that is intended to be placed "overlayed" on top of some other content. It is a variant that provides a dark background (with slight opacity) and a white font.

What is looks like:
![image](https://user-images.githubusercontent.com/3267412/132732675-8f5246c2-9dca-46db-8a2e-115079768070.png)

**How does this change work?**
Added a variant called `overlay` and the css style to accomplish it. Very open to feedback on the variant name of `overlay`. Struggled to land on something better. 
