### PR TITLE
Docs: Update image card examples to a reasonable width

### DIFF
--- a/.changeset/many-toys-hope.md
+++ b/.changeset/many-toys-hope.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+Update ImageCard examples to a reasonable width

--- a/packages/pharos-site/static/guidelines/image-card.docs.mdx
+++ b/packages/pharos-site/static/guidelines/image-card.docs.mdx
@@ -68,7 +68,7 @@ import baseImageExample from '../../../../.storybook/assets/images/item-detail/c
       corresponding information or metadata.
     </p>
     <Canvas>
-      <PharosImageCard title="Card title" link="#">
+      <PharosImageCard title="Card title" link="#" style={{ width: '150px' }}>
         <img id="image" src={baseImageExample} alt="south hall" slot="image" />
         <div id="creator" slot="metadata">
           Tubby, William Bunker (American architect,...
@@ -88,7 +88,12 @@ import baseImageExample from '../../../../.storybook/assets/images/item-detail/c
       aspect ratio format with corresponding information or metadata.
     </p>
     <Canvas>
-      <PharosImageCard title="Pratt Institute Buildings" link="#" variant="collection">
+      <PharosImageCard
+        title="Pratt Institute Buildings"
+        link="#"
+        variant="collection"
+        style={{ width: '250px' }}
+      >
         <img id="image" src={baseImageExample} alt="Collection image example" slot="image" />
         <strong id="item-number" slot="metadata">
           452 items
@@ -108,7 +113,7 @@ import baseImageExample from '../../../../.storybook/assets/images/item-detail/c
       information about the item to be shown with an overlay.
     </p>
     <Canvas>
-      <PharosImageCard title="Card title" link="#" subtle variant="base">
+      <PharosImageCard title="Card title" link="#" subtle variant="base" style={{ width: '150px' }}>
         <img id="image" src={baseImageExample} alt="south hall" slot="image" />
         <div id="creator" slot="metadata">
           Tubby, William Bunker (American architect,...
@@ -131,7 +136,7 @@ import baseImageExample from '../../../../.storybook/assets/images/item-detail/c
       server or access issue.
     </p>
     <Canvas>
-      <PharosImageCard title="Card title" link="#" error variant="base">
+      <PharosImageCard title="Card title" link="#" error variant="base" style={{ width: '150px' }}>
         <img id="image" src={baseImageExample} alt="south hall" slot="image" />
         <div id="creator" slot="metadata">
           Tubby, William Bunker (American architect,...
@@ -151,7 +156,13 @@ import baseImageExample from '../../../../.storybook/assets/images/item-detail/c
       taken on the item by rendering an action button that triggers a dropdown menu.
     </p>
     <Canvas>
-      <PharosImageCard title="Card title" link="#" action-menu="my-dropdown-menu" variant="base">
+      <PharosImageCard
+        title="Card title"
+        link="#"
+        action-menu="my-dropdown-menu"
+        variant="base"
+        style={{ width: '150px' }}
+      >
         <img id="image" src={baseImageExample} alt="south hall" slot="image" />
         <div id="creator" slot="metadata">
           Tubby, William Bunker (American architect,...


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

Fixes #161 

**How does this change work?**

Add explicit widths to examples, using a wider width for the collection variant to give a sense of its usage in the wild.

**Additional context**

<img width="250" alt="Screen Shot 2021-10-02 at 12 53 05" src="https://user-images.githubusercontent.com/1808306/135725595-5011fee0-d884-4901-b821-35a26ee5ff2d.png"> <img width="250" alt="Screen Shot 2021-10-02 at 12 53 14" src="https://user-images.githubusercontent.com/1808306/135725596-25c1d844-a425-4d50-9286-9a5c4d886dc5.png">
