### PR TITLE
Combobox: Prevent displayed text from overlapping with clear icon

### DIFF
--- a/.changeset/forty-boats-obey.md
+++ b/.changeset/forty-boats-obey.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Prevent any displayed text from overlapping with the clear icon

--- a/packages/pharos/src/components/combobox/pharos-combobox.scss
+++ b/packages/pharos/src/components/combobox/pharos-combobox.scss
@@ -63,7 +63,11 @@
   }
 }
 
-#input-element {
+.input-wrapper {
+  @include mixins.input-wrapper;
+}
+
+.input-element {
   @include mixins.input-base;
   @include mixins.input-required;
   @include mixins.input-placeholder;
@@ -75,23 +79,28 @@
     @include mixins.input-focus;
     @include mixins.input-padding-thick-border;
   }
+
+  &--populated,
+  &--populated:focus {
+    padding-right: var(--pharos-spacing-3-x);
+  }
 }
 
-:host([disabled]) #input-element {
+:host([disabled]) .input-element {
   @include mixins.input-disabled;
 
   border-color: var(--pharos-form-element-color-border-disabled);
 }
 
-.input-wrapper {
-  @include mixins.input-wrapper;
-}
-
-:host([invalidated]) #input-element {
+:host([invalidated]) .input-element {
   @include mixins.input-invalid;
   @include mixins.input-padding-thick-border;
 
   border-right: 0;
+
+  @at-root #{&}--populated {
+    padding-right: var(--pharos-spacing-3-x);
+  }
 }
 
 .combobox__list {

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -441,6 +441,7 @@ export class PharosCombobox extends FormMixin(FormElement) {
       <div class="input-wrapper">
         <input
           id="input-element"
+          class="input-element ${this._displayValue ? 'input-element--populated' : null}"
           name="${this.name}"
           type="text"
           .value="${this._displayValue}"


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
#208 

**How does this change work?**

* Update styles to use class selectors for reduced specificity collision (BEM)
* When the input is populated, include a right padding to avoid overlap.

**Additional context**

I chose to only adding padding when the box is populated so that any long placeholders used don't have padding, because that would probably be surprising.