### PR TITLE
fix(dropdown-menu): await close transition before updating popper instance

### DIFF
--- a/.changeset/chatty-flies-travel.md
+++ b/.changeset/chatty-flies-travel.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+await close transition before updating popper instance

--- a/packages/pharos/src/components/base/overlay-element.ts
+++ b/packages/pharos/src/components/base/overlay-element.ts
@@ -100,7 +100,7 @@ export class OverlayElement extends LitElement {
     }
   }
 
-  protected _setPopperListeners(): void {
+  protected async _setPopperListeners(): Promise<void> {
     // Enable listeners when open and disable them when closed
     if (this._options) {
       const listeners = this._options.modifiers.pop();
@@ -111,6 +111,10 @@ export class OverlayElement extends LitElement {
       }
 
       this._options.modifiers.push(listeners || {});
+
+      if (!this.open) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
       this._popper?.setOptions(this._options);
     }
   }

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -91,14 +91,14 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     return [dropdownMenuStyles];
   }
 
-  public async removeAllTriggers(): Promise<void> {
-    await new Promise((r) => setTimeout(r, 100));
+  public removeAllTriggers(): void {
     this._removeTriggerListeners();
   }
 
   public async openWithTrigger(trigger: HTMLElement): Promise<void> {
     if (this._currentTrigger !== trigger) {
-      await this.removeAllTriggers();
+      await new Promise((r) => setTimeout(r, 100));
+      this.removeAllTriggers();
       this._addTriggerElement(trigger);
       this._currentTrigger = trigger;
       this.open = true;

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -91,14 +91,14 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
     return [dropdownMenuStyles];
   }
 
-  public removeAllTriggers(): void {
+  public async removeAllTriggers(): Promise<void> {
+    await new Promise((r) => setTimeout(r, 100));
     this._removeTriggerListeners();
   }
 
   public async openWithTrigger(trigger: HTMLElement): Promise<void> {
     if (this._currentTrigger !== trigger) {
-      await new Promise((r) => setTimeout(r, 100));
-      this.removeAllTriggers();
+      await this.removeAllTriggers();
       this._addTriggerElement(trigger);
       this._currentTrigger = trigger;
       this.open = true;


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
There are instances where a dropdown menu trigger may not be present anymore when closed. In such instances `setOptions` will apply the menu to the body before the menu has fully closed, resulting in an awkward user experience.

**How does this change work?**

- Await the close transition before calling `setOptions`