### PR TITLE
fix(dropdown-menu): update popper instance on trigger change

### DIFF
--- a/.changeset/poor-lemons-travel.md
+++ b/.changeset/poor-lemons-travel.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+update popper instance on trigger change for dropdown menus

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -134,11 +134,17 @@ export class PharosDropdownMenu extends FocusMixin(OverlayElement) {
         (this._currentTrigger as PharosDropdownMenuNavLink).isActive = this.open;
       }
 
+      if (this.open && !this._popper) {
+        this._setupMenu();
+      }
+
       if (
         this.open &&
-        (!this._popper || this._popper?.state.elements.reference !== this._currentTrigger)
+        this._popper &&
+        this._popper.state.elements.reference !== this._currentTrigger
       ) {
-        this._setupMenu();
+        this._popper.state.elements.reference = this._currentTrigger as Element;
+        this._popper.update();
       }
 
       if (!this._currentTrigger?.hasAttribute('data-dropdown-menu-hover') || this._enterByKey) {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Fixes #238 

**How does this change work?**

- Update popper instance on trigger change instead of recreating it