### PR TITLE
fix(site): correct footer on smaller breakpoints

### DIFF
--- a/.changeset/two-pandas-rule.md
+++ b/.changeset/two-pandas-rule.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+correct footer on smaller breakpoints

--- a/packages/pharos-site/src/components/footer.module.css
+++ b/packages/pharos-site/src/components/footer.module.css
@@ -1,8 +1,11 @@
+.footer__container {
+  grid-area: footer;
+}
+
 .footer {
   background: var(--pharos-color-marble-gray-10);
   color: var(--pharos-color-text-white);
   padding: var(--pharos-spacing-3-x) 0;
-  grid-area: footer;
 }
 
 .right-text {

--- a/packages/pharos-site/src/components/footer.tsx
+++ b/packages/pharos-site/src/components/footer.tsx
@@ -13,6 +13,7 @@ import {
   badge,
   container__link,
   logo__link,
+  footer__container,
 } from './footer.module.css';
 import logoWhite from '../../static/images/footer/logo-white.svg';
 
@@ -25,7 +26,7 @@ const Footer: FC = () => {
     const { PharosHeading, PharosLink, PharosLayout } = Pharos;
 
     const content = (
-      <footer>
+      <footer className={footer__container}>
         <PharosLayout preset="1-col--sidenav-comfy" rows="auto min-content" className={footer}>
           <div className={container__start}>
             <PharosLink className={logo__link} href="https://www.jstor.org/" target="_blank" flex>

--- a/packages/pharos-site/src/pages/brand-expressions/logos.mdx
+++ b/packages/pharos-site/src/pages/brand-expressions/logos.mdx
@@ -48,7 +48,7 @@ import PageSection from '../../components/statics/PageSection';
         placement area is horizontal in width.
       </p>
     </div>
-    <img src={horizontalLogo} alt="Horizontal logo" height="80" />
+    <img src={horizontalLogo} alt="Horizontal logo" height="70" />
   </Grid>
   <Grid columns={2}>
     <div>

--- a/packages/pharos-site/src/pages/brand-expressions/logos.mdx
+++ b/packages/pharos-site/src/pages/brand-expressions/logos.mdx
@@ -48,7 +48,7 @@ import PageSection from '../../components/statics/PageSection';
         placement area is horizontal in width.
       </p>
     </div>
-    <img src={horizontalLogo} alt="Horizontal logo" />
+    <img src={horizontalLogo} alt="Horizontal logo" height="80" />
   </Grid>
   <Grid columns={2}>
     <div>


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Fix regressions from #221 

**How does this change work?**

- Move `grid-area` to footer container
- Fix giant logo