### PR TITLE
perf(pharos): specify package side effects

### DIFF
--- a/.changeset/silent-worms-bake.md
+++ b/.changeset/silent-worms-bake.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+mark package side effect free

--- a/.changeset/silent-worms-bake.md
+++ b/.changeset/silent-worms-bake.md
@@ -2,4 +2,4 @@
 '@ithaka/pharos': patch
 ---
 
-mark package side effect free
+specify package side effects

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "main": "lib/index.js",
   "module": "lib/index.js",
+  "sideEffects": false,
   "scripts": {
     "analyze": "cem analyze --litelement --globs \"./src/(components|styles|utils|test)/**/!(*.css|*.test)*.ts\"",
     "build:tokens": "node --experimental-json-modules ./scripts/build-tokens.mjs",
@@ -38,7 +39,8 @@
   "browserslist": [
     "last 2 versions",
     "Firefox ESR",
-    "not dead"
+    "not dead",
+    "not IE 11"
   ],
   "repository": {
     "type": "git",

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -12,7 +12,11 @@
   "type": "module",
   "main": "lib/index.js",
   "module": "lib/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.scss",
+    "**/initComponents.ts"
+  ],
   "scripts": {
     "analyze": "cem analyze --litelement --globs \"./src/(components|styles|utils|test)/**/!(*.css|*.test)*.ts\"",
     "build:tokens": "node --experimental-json-modules ./scripts/build-tokens.mjs",

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -15,7 +15,7 @@
   "sideEffects": [
     "**/*.css",
     "**/*.scss",
-    "**/initComponents.ts"
+    "./src/test/initComponents.ts"
   ],
   "scripts": {
     "analyze": "cem analyze --litelement --globs \"./src/(components|styles|utils|test)/**/!(*.css|*.test)*.ts\"",


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
To register multiple components, we should allow folks to import from the entry point and [guarantee tree shaking](https://webpack.js.org/guides/tree-shaking/#clarifying-tree-shaking-and-sideeffects) from Webpack:

```
import { PharosLink, PharosButton, PharosIcon } from "@ithaka/pharos";
```

**How does this change work?**

- Specify side effects in `package.json`

**Additional context**
```
import { PharosButton } from "@ithaka/pharos";
```

**Before:**
<img width="503" alt="Screen Shot 2021-11-16 at 1 05 00 PM" src="https://user-images.githubusercontent.com/2147624/142210241-4fe4f2f7-c851-4ce5-9174-70b416397ee9.png">

**After:**
<img width="507" alt="Screen Shot 2021-11-16 at 1 05 10 PM" src="https://user-images.githubusercontent.com/2147624/142210273-567207aa-97cb-4bfe-9410-e5f38714c063.png">


