### PR TITLE
fix: use request name for dynamic import chunks

### DIFF
--- a/.changeset/lovely-mangos-cheer.md
+++ b/.changeset/lovely-mangos-cheer.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+use request name for dynamic import chunks

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -32,7 +32,7 @@
     "build:sassdoc": "node ./scripts/build-sassdoc.js",
     "build:tests": "tsc --project tsconfig.json",
     "build:replace": "replace-in-file \"/(import|from)( '[.]+/)(.*)(?<!.js)(';)/g\" \"\\$1\\$2\\$3.js\\$4\" \"lib/**/*.js, lib/**/*.d.ts\" --isRegex --verbose",
-    "build:replace:dynamic": "replace-in-file \"/(import[(].)([.]+/)(.*?)(?<!.js)(.[)])/g\" \"\\$1\\$2\\$3.js\\$4\" \"lib/**/*.js\" --isRegex --verbose",
+    "build:replace:dynamic": "replace-in-file \"/(import[(])(.)([.]+/)(.*?)(?<!.js)(.[)])/g\" \"\\$1/* webpackChunkName: '[request]' */ \\$2\\$3\\$4.js\\$5\" \"lib/**/*.js\" --isRegex --verbose",
     "build:replace:imports": "yarn build:replace && yarn build:replace:dynamic",
     "prepublishOnly": "yarn build",
     "clean": "rimraf lib src/react-components",


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
By default, Webpack uses an index as the id of dynamically imported chunks. This is why our icons show up as numerically named exports. We can use Webpack [magic comments](https://webpack.js.org/api/module-methods/#magic-comments) to use the resource's name instead.

**How does this change work?**

- Place magic comment `/* webpackChunkName: '[request]' */` within dynamic imports

**Additional context**
I solemnly swear that I am up to no good