### PR TITLE
feat(all): Preserve data-pharos-component attribute when Pharos class is subclassed

### DIFF
--- a/.changeset/polite-months-melt.md
+++ b/.changeset/polite-months-melt.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Preserve the original Pharos component name in the data-pharos-component attribute when subclassed

--- a/.changeset/rare-swans-admire.md
+++ b/.changeset/rare-swans-admire.md
@@ -1,5 +1,6 @@
 ---
 '@ithaka/pharos': minor
+'@ithaka/pharos-cli': minor
 ---
 
 Preserve the original Pharos component name in the data-pharos-component attribute when subclassed

--- a/docs/development/anatomy-of-a-component.md
+++ b/docs/development/anatomy-of-a-component.md
@@ -153,6 +153,8 @@ Now you've got all the ingredients needed to write the component definition. Add
 
 ```typescript
 export class PharosSparklyText extends PharosElement {
+  componentName = 'PharosSparklyText';
+
   public static override get styles(): CSSResultArray {
     return [sparklyTextStyles];
   }

--- a/packages/pharos-cli/src/templates/typescript-file-template.js
+++ b/packages/pharos-cli/src/templates/typescript-file-template.js
@@ -5,6 +5,8 @@ import type { TemplateResult, CSSResultArray } from 'lit';
 import { ${camelCaseName}Styles } from './pharos-${componentName}.css';
 
 export class Pharos${titleCaseName} extends PharosElement {
+  componentName = "Pharos${titleCaseName}";
+
   public static override get styles(): CSSResultArray {
     return [${camelCaseName}Styles];
   }

--- a/packages/pharos/README.md
+++ b/packages/pharos/README.md
@@ -29,15 +29,24 @@ $ npm install @ithaka/pharos
 
 ## Registering components
 
-1. To allow multiple versions of Pharos to exist on a page, this package only exports component classes for you to register on the [custom element registry](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry) in your application. To register a component, import the classes you wish to use in your application's entrypoint and define the component with a tag name in the form of `{app/bundle}-pharos-{component}`:
+1. To allow multiple versions of Pharos to exist on a page, this package only exports component classes for you to register on the [custom element registry](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry) in your application.
+   To register a component:
+   - Import the classes you wish to use in your application's entrypoint
+   - Declare a trivial subclass the Pharos component in the form of `{app/bundle}Pharos{component}`
+   - Define the component with a tag name in the form of `{app/bundle}-pharos-{component}`
 
 ```javascript
 import { PharosAlert } from '@ithaka/pharos/lib/components/alert/pharos-alert';
 
-customElements.define('homepage-pharos-alert', PharosAlert);
+class HomepagePharosAlert extends PharosAlert {}
+
+customElements.define('homepage-pharos-alert', HomepagePharosAlert);
 ```
 
-**Note: If you register a name that already exists the browser will throw an error about the duplicate.**
+> NOTE: Errors will occur in either of the following scenarios:
+>
+> - Define a tag name that has already been defined in the browser.
+> - Attempt to use the same `Pharos` component class to define custom elements with different names. This is especially important when the `@ithaka/pharos` dependency is shared across different apps on the page (ie. ModuleFederation).
 
 2. Internally, Pharos components that are composed of other Pharos components scope their registries to their shadow root to avoid duplicate registrations. Because the `Scoped Custom Element Registries` proposal is not yet finalized, you need to apply a [polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/scoped-custom-element-registry) to use our components.
 
@@ -150,7 +159,7 @@ Pharos also provides SASS mixins which are reusable styles shared across multipl
 ```scss
 /* example-page.scss */
 
-@use "@ithaka/pharos/lib/styles/pharos";
+@use '@ithaka/pharos/lib/styles/pharos';
 
 .some-text {
   @include pharos.font-base;
@@ -175,7 +184,7 @@ You can access all Pharos variables, mixins, and functions from a single `pharos
 ```scss
 /* example-page.scss */
 
-@use "@ithaka/pharos/lib/styles/pharos";
+@use '@ithaka/pharos/lib/styles/pharos';
 
 .some-text {
   @include pharos.font-base;

--- a/packages/pharos/README.md
+++ b/packages/pharos/README.md
@@ -43,10 +43,10 @@ class HomepagePharosAlert extends PharosAlert {}
 customElements.define('homepage-pharos-alert', HomepagePharosAlert);
 ```
 
-> NOTE: Errors will occur in either of the following scenarios:
+> NOTE: Issues arise when you:
 >
 > - Define a tag name that has already been defined in the browser.
-> - Attempt to use the same `Pharos` component class to define custom elements with different names. This is especially important when the `@ithaka/pharos` dependency is shared across different apps on the page (ie. ModuleFederation).
+> - Attempt to use the same Pharos component class to define custom elements with different names. This is especially important when the `@ithaka/pharos` dependency is shared across different applications on the same page, for example through Webpack's module federation.
 
 2. Internally, Pharos components that are composed of other Pharos components scope their registries to their shadow root to avoid duplicate registrations. Because the `Scoped Custom Element Registries` proposal is not yet finalized, you need to apply a [polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/scoped-custom-element-registry) to use our components.
 

--- a/packages/pharos/README.md
+++ b/packages/pharos/README.md
@@ -29,11 +29,12 @@ $ npm install @ithaka/pharos
 
 ## Registering components
 
-1. To allow multiple versions of Pharos to exist on a page, this package only exports component classes for you to register on the [custom element registry](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry) in your application.
-   To register a component:
+1. To allow multiple versions of Pharos to exist on a page, this package only exports component classes for you to register on the [custom element registry](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry) in your application. To register a component:
    - Import the classes you wish to use in your application's entrypoint
-   - Declare a trivial subclass the Pharos component in the form of `{app/bundle}Pharos{component}`
+   - Declare a trivial subclass of the Pharos component in the form of `{app/bundle}Pharos{component}`
    - Define the component with a tag name in the form of `{app/bundle}-pharos-{component}`
+   
+As an example, the following allows an Alert to be defined for use in a home page application that will not collide with other Alerts that are defined:
 
 ```javascript
 import { PharosAlert } from '@ithaka/pharos/lib/components/alert/pharos-alert';

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -45,6 +45,8 @@ const STATUSES = ['info', 'success', 'warning', 'error'];
  * @cssprop {Color} --pharos-alert-color-icon-error - The fill color for an error alert icon
  */
 export class PharosAlert extends ScopedRegistryMixin(FocusMixin(PharosElement)) {
+  componentName = 'PharosAlert';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
     'pharos-button': PharosButton,

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.ts
@@ -26,6 +26,8 @@ const MAX_LENGTH = 40;
  *
  */
 export class PharosBreadcrumbItem extends ScopedRegistryMixin(FocusMixin(AnchorElement)) {
+  componentName = 'PharosBreadcrumbItem';
+
   static elementDefinitions = {
     'pharos-tooltip': PharosTooltip,
     'pharos-link': PharosLink,

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.ts
@@ -18,6 +18,8 @@ import FocusMixin from '../../utils/mixins/focus';
  *
  */
 export class PharosBreadcrumb extends FocusMixin(PharosElement) {
+  componentName = 'PharosBreadcrumb';
+
   public static override get styles(): CSSResultArray {
     return [breadcrumbStyles];
   }

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -28,6 +28,8 @@ const VARIANTS = ['primary', 'secondary', 'subtle', 'overlay'];
  *
  */
 export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement)) {
+  componentName = 'PharosButton';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
   };

--- a/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.ts
+++ b/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.ts
@@ -15,6 +15,8 @@ import { FormElement } from '../base/form-element';
  * @fires change - Fires when the value has changed
  */
 export class PharosCheckboxGroup extends FormElement {
+  componentName = 'PharosCheckboxGroup';
+
   /**
    * Dictate if checkboxes should be displayed horizontally
    * @attr horizontal

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.ts
@@ -22,6 +22,8 @@ const LINKS = `a[href],pharos-link[href]`;
  * @fires change - Fires when the value has changed
  */
 export class PharosCheckbox extends FormMixin(FormElement) {
+  componentName = 'PharosCheckbox';
+
   /**
    * Indicates if checkbox is checked.
    * @attr checked

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -34,6 +34,8 @@ import { PharosButton } from '../button/pharos-button';
  * @cssprop {Color} --pharos-combobox-size-height-clear - Height of the clear button.
  */
 export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) {
+  componentName = 'PharosCombobox';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
     'pharos-tooltip': PharosTooltip,

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.ts
@@ -17,6 +17,8 @@ export type { LinkTarget };
  *
  */
 export class PharosDropdownMenuNavLink extends ScopedRegistryMixin(PharosLink) {
+  override componentName = 'PharosDropdownMenuNavLink';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
   };

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.ts
@@ -16,6 +16,8 @@ import FocusMixin from '../../utils/mixins/focus';
  *
  */
 export class PharosDropdownMenuNav extends FocusMixin(PharosElement) {
+  componentName = 'PharosDropdownMenuNav';
+
   /**
    * Indicates the aria label to apply to the nav.
    * @attr label

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
@@ -21,6 +21,8 @@ export type { IconName };
  *
  */
 export class PharosDropdownMenuItem extends ScopedRegistryMixin(FocusMixin(PharosElement)) {
+  componentName = 'PharosDropdownMenuItem';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
   };

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -29,6 +29,8 @@ export type { Placement, PositioningStrategy };
  *
  */
 export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayElement)) {
+  componentName = 'PharosDropdownMenu';
+
   static elementDefinitions = {
     'focus-trap': FocusTrap,
   };

--- a/packages/pharos/src/components/footer/pharos-footer.ts
+++ b/packages/pharos/src/components/footer/pharos-footer.ts
@@ -21,6 +21,8 @@ import { PharosHeading } from '../heading/pharos-heading';
  *
  */
 export class PharosFooter extends ScopedRegistryMixin(PharosElement) {
+  componentName = 'PharosFooter';
+
   static elementDefinitions = {
     'pharos-heading': PharosHeading,
   };

--- a/packages/pharos/src/components/header/pharos-header.ts
+++ b/packages/pharos/src/components/header/pharos-header.ts
@@ -13,6 +13,8 @@ import { headerStyles } from './pharos-header.css';
  *
  */
 export class PharosHeader extends PharosElement {
+  componentName = 'PharosHeader';
+
   public static override get styles(): CSSResultArray {
     return [headerStyles];
   }

--- a/packages/pharos/src/components/heading/pharos-heading.ts
+++ b/packages/pharos/src/components/heading/pharos-heading.ts
@@ -50,6 +50,8 @@ const PRESETS = [
  * @slot - Contains the heading text (the default slot).
  */
 export class PharosHeading extends PharosElement {
+  componentName = 'PharosHeading';
+
   /**
    * Indicates the heading tag level.
    * @attr level

--- a/packages/pharos/src/components/icon/pharos-icon.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.ts
@@ -16,6 +16,8 @@ const LARGE_ICON_SIZE = 24;
  * Pharos icon component.
  */
 export class PharosIcon extends PharosElement {
+  componentName = 'PharosIcon';
+
   /**
    * The name of the icon
    * @attr name

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -32,6 +32,8 @@ const DEFAULT_HEADING_LEVEL = 3;
  *
  */
 export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElement)) {
+  componentName = 'PharosImageCard';
+
   static elementDefinitions = {
     'pharos-heading': PharosHeading,
     'pharos-link': PharosLink,

--- a/packages/pharos/src/components/input-group/pharos-input-group-select.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group-select.ts
@@ -7,6 +7,8 @@ import { PharosSelect } from '../select/pharos-select';
  * Pharos input group select component.
  */
 export class PharosInputGroupSelect extends PharosSelect {
+  override componentName = 'PharosInputGroupSelect';
+
   public static override get styles(): CSSResultArray {
     return [super.styles, inputGroupSelectStyles];
   }

--- a/packages/pharos/src/components/input-group/pharos-input-group.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group.ts
@@ -15,6 +15,8 @@ export type { TextInputType, TextInputAutocomplete };
  * @slot prepend - Contains the elements to be prepended to the input group.
  */
 export class PharosInputGroup extends PharosTextInput {
+  override componentName = 'PharosInputGroup';
+
   @query('.input-group--append')
   private _appendGroup!: HTMLDivElement;
 

--- a/packages/pharos/src/components/layout/pharos-layout.ts
+++ b/packages/pharos/src/components/layout/pharos-layout.ts
@@ -18,6 +18,8 @@ const PRESETS = ['1-col', '1-col--sidenav', '1-col--sidenav-comfy', '2-col'];
  *
  */
 export class PharosLayout extends PharosElement {
+  componentName = 'PharosLayout';
+
   /**
    * Indicates the type of layout to use.
    * @attr preset

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -19,6 +19,8 @@ export type { LinkTarget };
  *
  */
 export class PharosLink extends FocusMixin(AnchorElement) {
+  componentName = 'PharosLink';
+
   /**
    * Indicates the MIME type of the target.
    * @attr type

--- a/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.ts
+++ b/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.ts
@@ -15,6 +15,8 @@ import {
  * @cssprop {Color} --pharos-loading-spinner-color-stroke-secondary - The secondary color of the spinner icon.
  */
 export class PharosLoadingSpinner extends PharosElement {
+  componentName = 'PharosLoadingSpinner';
+
   @query('.loading-spinner__icon')
   private _icon!: SVGElement;
 

--- a/packages/pharos/src/components/modal/pharos-modal.ts
+++ b/packages/pharos/src/components/modal/pharos-modal.ts
@@ -33,6 +33,8 @@ const SIZES = ['small', 'medium', 'large'];
  *
  */
 export class PharosModal extends ScopedRegistryMixin(PharosElement) {
+  componentName = 'PharosModal';
+
   static elementDefinitions = {
     'pharos-button': PharosButton,
     'pharos-heading': PharosHeading,

--- a/packages/pharos/src/components/pagination/pharos-pagination.ts
+++ b/packages/pharos/src/components/pagination/pharos-pagination.ts
@@ -15,6 +15,8 @@ import { PharosLink } from '../link/pharos-link';
  * @fires next-page - Fires when the next page link is clicked
  */
 export class PharosPagination extends ScopedRegistryMixin(PharosElement) {
+  componentName = 'PharosPagination';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
     'pharos-link': PharosLink,

--- a/packages/pharos/src/components/progress-bar/pharos-progress-bar.ts
+++ b/packages/pharos/src/components/progress-bar/pharos-progress-bar.ts
@@ -14,6 +14,8 @@ import { PharosColorGlacierBlueBase, PharosColorNightBlueBase } from '../../styl
  *
  */
 export class PharosProgressBar extends PharosElement {
+  componentName = 'PharosProgressBar';
+
   /**
    * Indicates the value for the progress bar.
    * @attr value

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.ts
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.ts
@@ -15,6 +15,8 @@ const LINKS = `a[href],pharos-link[href]`;
  * @fires change - Fires when the value has changed
  */
 export class PharosRadioButton extends FormMixin(FormElement) {
+  componentName = 'PharosRadioButton';
+
   /**
    * Indicates if radio is checked.
    * @attr checked

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.ts
@@ -16,6 +16,8 @@ import { FormElement } from '../base/form-element';
  * @fires change - Fires when the value has changed
  */
 export class PharosRadioGroup extends FormElement {
+  componentName = 'PharosRadioGroup';
+
   /**
    * Dictate if radio buttons should be displayed horizontally
    * @attr horizontal

--- a/packages/pharos/src/components/select/pharos-select.ts
+++ b/packages/pharos/src/components/select/pharos-select.ts
@@ -23,6 +23,8 @@ import { PharosIcon } from '../icon/pharos-icon';
 export class PharosSelect extends ScopedRegistryMixin(
   ObserveChildrenMixin(FormMixin(FormElement))
 ) {
+  componentName = 'PharosSelect';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
   };

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-button.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-button.ts
@@ -11,6 +11,8 @@ export type { LinkTarget, ButtonType, IconName, ButtonVariant };
  * Pharos sidenav button component.
  */
 export class PharosSidenavButton extends PharosButton {
+  override componentName = 'PharosSidenavButton';
+
   constructor() {
     super();
     this.icon = 'menu';

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
@@ -17,6 +17,8 @@ export type { LinkTarget };
  *
  */
 export class PharosSidenavLink extends ScopedRegistryMixin(PharosLink) {
+  override componentName = 'PharosSidenavLink';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
   };

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
@@ -17,6 +17,8 @@ import { PharosIcon } from '../icon/pharos-icon';
  *
  */
 export class PharosSidenavMenu extends ScopedRegistryMixin(FocusMixin(PharosElement)) {
+  componentName = 'PharosSidenavMenu';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
   };

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-section.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-section.ts
@@ -14,6 +14,8 @@ import { PharosHeading } from '../heading/pharos-heading';
  *
  */
 export class PharosSidenavSection extends ScopedRegistryMixin(PharosElement) {
+  componentName = 'PharosSidenavSection';
+
   static elementDefinitions = {
     'pharos-heading': PharosHeading,
   };

--- a/packages/pharos/src/components/sidenav/pharos-sidenav.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav.ts
@@ -18,6 +18,8 @@ import { PharosLink } from '../link/pharos-link';
  *
  */
 export class PharosSidenav extends ScopedRegistryMixin(FocusMixin(SideElement)) {
+  componentName = 'PharosSidenav';
+
   static elementDefinitions = {
     'pharos-button': PharosButton,
     'pharos-link': PharosLink,

--- a/packages/pharos/src/components/tabs/pharos-tab-panel.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab-panel.ts
@@ -12,6 +12,8 @@ import focusable from '../../utils/focusable';
  *
  */
 export class PharosTabPanel extends PharosElement {
+  componentName = 'PharosTabPanel';
+
   /**
    * Indicates if the panel is selected.
    * @attr selected

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -13,6 +13,8 @@ import { tabStyles } from './pharos-tab.css';
  *
  */
 export class PharosTab extends PharosElement {
+  componentName = 'PharosTab';
+
   /**
    * Indicates if the tab is selected.
    * @attr selected

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -14,6 +14,8 @@ import type { PharosTabPanel } from './pharos-tab-panel';
  *
  */
 export class PharosTabs extends PharosElement {
+  componentName = 'PharosTabs';
+
   public static override get styles(): CSSResultArray {
     return [tabsStyles];
   }

--- a/packages/pharos/src/components/text-input/pharos-text-input.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.ts
@@ -60,6 +60,8 @@ const BLOCKING = [
  * @cssprop {Color} --pharos-text-input-color-icon-invalid - Fill color for invalidated state icon.
  */
 export class PharosTextInput extends ScopedRegistryMixin(FormMixin(FormElement)) {
+  componentName = 'PharosTextInput';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
   };

--- a/packages/pharos/src/components/textarea/pharos-textarea.ts
+++ b/packages/pharos/src/components/textarea/pharos-textarea.ts
@@ -28,6 +28,8 @@ const WRAPS = ['soft', 'hard'];
  * @cssprop {Length} --pharos-textarea-size-text-base - Text input font size.
  */
 export class PharosTextarea extends FormMixin(FormElement) {
+  componentName = 'PharosTextarea';
+
   /**
    * Indicates textarea value.
    * @attr value

--- a/packages/pharos/src/components/toast/pharos-toast-button.ts
+++ b/packages/pharos/src/components/toast/pharos-toast-button.ts
@@ -11,6 +11,8 @@ export type { LinkTarget, ButtonType, IconName, ButtonVariant };
  * Pharos toast button component.
  */
 export class PharosToastButton extends PharosButton {
+  override componentName = 'PharosToastButton';
+
   constructor() {
     super();
     this.icon = 'close';

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -34,6 +34,8 @@ export const DEFAULT_STATUS = 'success';
  *
  */
 export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) {
+  componentName = 'PharosToast';
+
   static elementDefinitions = {
     'pharos-icon': PharosIcon,
     'pharos-toast-button': PharosToastButton,

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -23,6 +23,8 @@ import { DEFAULT_STATUS } from './pharos-toast';
  * @listens pharos-toast-open
  */
 export class PharosToaster extends PharosElement {
+  componentName = 'PharosToaster';
+
   constructor() {
     super();
     this._openToast = this._openToast.bind(this);

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -11,6 +11,8 @@ import type { PharosToggleButton } from './pharos-toggle-button';
  *
  */
 export class PharosToggleButtonGroup extends PharosElement {
+  componentName = 'PharosToggleButtonGroup';
+
   public static override get styles(): CSSResultArray {
     return [toggleButtonGroupStyles];
   }

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
@@ -13,6 +13,8 @@ export type { ButtonType, LinkTarget, IconName, ButtonVariant };
  *
  */
 export class PharosToggleButton extends PharosButton {
+  override componentName = 'PharosToggleButton';
+
   /**
    * Indicates that the button is currently toggled on and cannot be pressed or focused by the user.
    * @attr selected

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.ts
@@ -23,6 +23,8 @@ export type { Placement, PositioningStrategy };
  * @cssprop {Color} --pharos-tooltip-color-text-base - Font color for the text.
  */
 export class PharosTooltip extends OverlayElement {
+  componentName = 'PharosTooltip';
+
   /**
    * Indicates if the tooltip width should equal its target's width.
    * @attr full-width

--- a/packages/pharos/src/utils/mixins/pharos-component.ts
+++ b/packages/pharos/src/utils/mixins/pharos-component.ts
@@ -11,9 +11,11 @@ const PharosComponentImplementation = <T extends Constructor<LitElement>>(Base: 
    * A mixin class to handle pharos-specific logic.
    */
   class PharosComponent extends Base {
+    componentName = 'PharosComponent';
+
     override connectedCallback(): void {
       super.connectedCallback && super.connectedCallback();
-      this.dataset.pharosComponent = this.constructor.name;
+      this.dataset.pharosComponent = this.componentName;
     }
   }
   return PharosComponent;


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
When a Pharos component is subclassed, the subclassed name is placed in the `data-pharos-component` attribute. Instead, it would be better if the original class name was preserved.

Example:
```
class HomepagePharosButton extends PharosButton {}
```

results in `data-pharos-component=HomepagePharosButton`

This change alters the behavior so that the result is now: `data-pharos-component=PharosButton`

**How does this change work?**
Adds a static `componentName` variable to each component which preserves the original pharos component name. The consumer is then free to subclass the Pharos component for scoped registry purposes.


