### PR TITLE
docs: add bundlephobia shield to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,10 @@
 > to change the world for the better.
 
 <p align="center">
-  <a href=".github/CODE_OF_CONDUCT.md">
-    <img src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg" alt="Contributor Covenant" />
-  </a>
-  <a href="./LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Pharos is released under the MIT license" />
-  </a>
-  <a href="#contributors-">
-    <img src="https://img.shields.io/badge/all_contributors-20-orange.svg?style=flat-square" alt="All Contributors" />
-  </a>
+  <a href=".github/CODE_OF_CONDUCT.md"><img src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg" alt="Contributor Covenant" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Pharos is released under the MIT license" /></a>
+  <a href="#contributors-"><img src="https://img.shields.io/badge/all_contributors-20-orange.svg?style=flat-square" alt="All Contributors" /></a>
+  <a href="https://bundlephobia.com/package/@ithaka/pharos"><img src="https://img.shields.io/bundlephobia/min/@ithaka/pharos" alt="Bundlephobia stats" /></a>
 </p>
 
 ## Getting Started


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

People like to know how big NPM packages currently are, and how they've changed in size over time. Bundlephobia is a good source of this information, automatically maintaining this record for packages published publicly to NPM.

**How does this change work?**

Add a Bundlephobia shield near the top of the README next to the other shields. The shield image links to the Bundlephobia page for the package.

**Additional context**

I put all the linked shields on a single line each to remove hyperlinked whitespace.

<img width="1122" alt="Screen Shot 2021-12-07 at 15 22 05" src="https://user-images.githubusercontent.com/1808306/145100631-3af16ebd-a76f-4091-a97f-e9fd10cfd1d7.png">
