### PR TITLE
chore: add codeowners file for auto PR assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ithaka/pharos-maintainers


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**

We want to minimize manual work, including assigning reviewers for code changes. Especially right now, all changes are always reviewed by the same group (@ithaka/pharos-maintainers).

**How does this change work?**

Add a [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file that points all changes to the Pharos maintainers.

**Additional context**

We may choose to automatically choose a subset of reviewers from the Pharos maintainers team using [automatic assignment](https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment).
