### PR TITLE
fix(link): check href prop for render

### DIFF
--- a/.changeset/happy-seas-fix.md
+++ b/.changeset/happy-seas-fix.md
@@ -1,0 +1,6 @@
+---
+'@ithaka/pharos': patch
+'@ithaka/pharos-site': patch
+---
+
+check href prop for rendering links

--- a/packages/pharos-site/src/pages/getting-started.mdx
+++ b/packages/pharos-site/src/pages/getting-started.mdx
@@ -48,7 +48,7 @@ To register components, you can use the `registerComponents` utility to define a
 import { PharosAlert, PharosButton, PharosIcon } from '@ithaka/pharos';
 import registerComponents from '@ithaka/pharos/lib/utils/registerComponents';
 
-registerComponents('{prefix}', [PharosAlert, PharosButton, PharosIcon]);
+registerComponents('homepage', [PharosAlert, PharosButton, PharosIcon]);
 ```
 
 To manually register a component, import the classes you wish to use in your application's entrypoint and define the custom element with a tag name in the form of `{app/bundle}-pharos-{component}` and a trivial subclass that extends the Pharos class wrapped in the `PharosComponentMixin`:

--- a/packages/pharos/README.md
+++ b/packages/pharos/README.md
@@ -35,7 +35,7 @@ $ npm install @ithaka/pharos
 import { PharosAlert, PharosButton, PharosIcon } from '@ithaka/pharos';
 import registerComponents from '@ithaka/pharos/lib/utils/registerComponents';
 
-registerComponents('{prefix}', [PharosAlert, PharosButton, PharosIcon]);
+registerComponents('homepage', [PharosAlert, PharosButton, PharosIcon]);
 ```
 
 **Note: When using module federation, you may only share Pharos successfully by using the `registerComponents` utility. This avoids registering elements with the same underlying class instance, which would result in an error.**

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -5,7 +5,6 @@
 }
 
 #link-element {
-  @include mixins.font-base;
   @include mixins.link-base;
   @include mixins.link-hover;
   @include mixins.interactive-focus;

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -5,6 +5,7 @@
 }
 
 #link-element {
+  @include mixins.font-base;
   @include mixins.link-base;
   @include mixins.link-hover;
   @include mixins.interactive-focus;

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -100,7 +100,7 @@ export class PharosLink extends FocusMixin(AnchorElement) {
   }
 
   protected override render(): TemplateResult {
-    return this.hasAttribute('href')
+    return this.href !== undefined
       ? html`<a
           id="link-element"
           class="${classMap({

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -343,6 +343,7 @@
   @include font-base($font-size: inherit, $line-height: inherit);
   @include underline;
 
+  letter-spacing: inherit;
   color: var(--pharos-color-interactive-secondary);
   transition-property: color, text-decoration-color;
   transition-duration: 200ms;


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
When testing the latest release in a Vue 3 app, all links with a `href` attribute were rendering as buttons. This is likely because attribute checks do not cause a re-render and a timing issue with Vue's lifecycle handling. So instead we can check if the component's `href` property is undefined to determine if it contains the `href` attribute or not.

**How does this change work?**

- Check `href` prop for render

**Additional context**
Noticed the link buttons also had a different letter-spacing so updated the `link-base` mixin