### PR TITLE
fix(dropdown-menu-item): pass rel attribute from menu item to anchor tag

### DIFF
--- a/.changeset/cuddly-rabbits-attack.md
+++ b/.changeset/cuddly-rabbits-attack.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+pass rel attribute from menu item to underlying anchor tag

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.test.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.test.ts
@@ -51,6 +51,18 @@ describe('pharos-dropdown-menu-item', () => {
     expect(link.getAttribute('href')).to.equal(href);
   });
 
+  it('passes rel attribute from dropdown menu item to anchor tag', async () => {
+    const href = 'https://www.google.com';
+    component.link = href;
+    component.setAttribute('rel', 'noopener');
+    await component.updateComplete;
+    const link = component.renderRoot.querySelector(
+      '.dropdown-menu-item__link'
+    ) as HTMLAnchorElement;
+    expect(link).not.to.be.null;
+    expect(link.getAttribute('rel')).to.equal('noopener');
+  });
+
   it('renders an icon when the icon attribute is set', async () => {
     component.icon = 'download';
     await component.updateComplete;

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
@@ -58,7 +58,7 @@ export class PharosDropdownMenuItem extends ScopedRegistryMixin(FocusMixin(Pharo
   public target: '_blank' | '_parent' | '_self' | '_top' = '_self';
 
   /**
-   * Indicates the type of link.
+   * Indicates the relationship of the resource to the current document.
    * @attr rel
    */
   @property({ type: String, reflect: true })

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
@@ -3,6 +3,7 @@ import { html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type { TemplateResult, CSSResultArray } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { dropdownMenuItemStyles } from './pharos-dropdown-menu-item.css';
 import type { PharosDropdownMenu } from './pharos-dropdown-menu';
 
@@ -55,6 +56,13 @@ export class PharosDropdownMenuItem extends ScopedRegistryMixin(FocusMixin(Pharo
    */
   @property({ type: String, reflect: true })
   public target: '_blank' | '_parent' | '_self' | '_top' = '_self';
+
+  /**
+   * Indicates the type of link.
+   * @attr rel
+   */
+  @property({ type: String, reflect: true })
+  public rel?: string;
 
   /**
    * Indicates if the item is disabled.
@@ -165,6 +173,7 @@ export class PharosDropdownMenuItem extends ScopedRegistryMixin(FocusMixin(Pharo
               role="menuitem"
               href="${this.link}"
               target="${this.target}"
+              rel=${ifDefined(this.rel)}
               class="dropdown-menu-item__link"
             >
               ${this.itemContent}


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

Fixes #279

**How does this change work?**
Whenever we assign `rel` attribute to DropdownMenuItem, attribute value will be passed to underlying anchor tag
