### PR TITLE
feat(header): update slots and grid for new designs

### DIFF
--- a/.changeset/cuddly-owls-type.md
+++ b/.changeset/cuddly-owls-type.md
@@ -1,0 +1,6 @@
+---
+'@ithaka/pharos': major
+'@ithaka/pharos-site': minor
+---
+
+Update the grid layout and slots to accommodate the latest branded updates for the header

--- a/packages/pharos-site/static/styles/global.scss
+++ b/packages/pharos-site/static/styles/global.scss
@@ -208,10 +208,8 @@ p.alert-example__content + p.alert-example__content {
   }
 }
 
-@media (min-width: 1024px) {
-  .header-example__input-group {
-    max-width: 80%;
-  }
+.header-example__input-group {
+  padding-bottom: var(--pharos-spacing-1-x);
 }
 
 .layout-example__item {

--- a/packages/pharos-site/static/styles/global.scss
+++ b/packages/pharos-site/static/styles/global.scss
@@ -209,7 +209,7 @@ p.alert-example__content + p.alert-example__content {
 }
 
 .header-example__input-group {
-  padding-bottom: var(--pharos-spacing-1-x);
+  padding-bottom: var(--pharos-spacing-one-half-x);
 }
 
 .layout-example__item {

--- a/packages/pharos/src/components/header/PharosHeader.react.stories.mdx
+++ b/packages/pharos/src/components/header/PharosHeader.react.stories.mdx
@@ -23,130 +23,7 @@ import { PharosIcon } from '../../react-components/icon/pharos-icon';
 
 <GuidelineLink path="header" />
 
-<Canvas withToolbar>
-  <Story name="Base">
-    <PharosHeader>
-      <div id="pds" slot="top">
-        <i>Have library access? </i>
-        <PharosLink href="//jstor.org/institutionSearch" target="_blank">
-          Log in through your library
-        </PharosLink>
-      </div>
-      <PharosLink slot="start" href="/" id="jstor-logo">
-        <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
-      </PharosLink>
-      <div slot="center">
-        <div className="header-example__split-column">
-          <PharosDropdownMenuNav label="main navigation">
-            <PharosDropdownMenuNavLink
-              href="action/showAdvancedSearch"
-              id="adv-search-link"
-              className="hide-for-small"
-            >
-              Advanced Search
-            </PharosDropdownMenuNavLink>
-            <PharosDropdownMenuNavLink
-              href="/subjects"
-              id="browse-link"
-              data-dropdown-menu-id="browse-menu"
-              data-dropdown-menu-hover
-            >
-              Browse
-            </PharosDropdownMenuNavLink>
-            <PharosDropdownMenu id="browse-menu">
-              <PharosDropdownMenuItem link="/subjects">by Subject</PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/action/showJournals?browseType=title">
-                by Title
-              </PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/site/collection-list">
-                by Collections
-              </PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/publishers">by Publisher</PharosDropdownMenuItem>
-            </PharosDropdownMenu>
-            <PharosDropdownMenuNavLink
-              href="/account/workspace"
-              id="tools-link"
-              data-dropdown-menu-id="tools-menu"
-              data-dropdown-menu-hover
-              className="hide-for-small"
-            >
-              Tools
-            </PharosDropdownMenuNavLink>
-            <PharosDropdownMenu id="tools-menu">
-              <PharosDropdownMenuItem link="/account/workspace">Workspace</PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/analyze">Text Analyzer</PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/understand">
-                The JSTOR Understanding Series
-              </PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/dfr">Data for Research</PharosDropdownMenuItem>
-            </PharosDropdownMenu>
-          </PharosDropdownMenuNav>
-          <div
-            className="show-for-large"
-            style={{
-              columnGap: '0.5rem',
-              gridTemplateColumns: '1fr 1fr',
-              display: 'none',
-              justifySelf: 'end',
-              alignSelf: 'center',
-            }}
-          >
-            <PharosLink href="#" target="_blank" bold>
-              Log In
-            </PharosLink>
-            <PharosLink href="#" target="_blank" bold>
-              Register
-            </PharosLink>
-          </div>
-        </div>
-      </div>
-      <div
-        slot="end"
-        style={{
-          display: 'grid',
-          rowGap: '1.5rem',
-          gridTemplateRows: '1fr 1fr',
-        }}
-        className="hide-for-large"
-      >
-        <div
-          style={{
-            display: 'grid',
-            columnGap: '0.5rem',
-            gridTemplateColumns: '1fr 1fr',
-          }}
-        >
-          <PharosLink href="#" target="_blank">
-            Log In
-          </PharosLink>
-          <PharosLink href="#" target="_blank">
-            Register
-          </PharosLink>
-        </div>
-        <div
-          style={{
-            display: 'grid',
-            columnGap: '0.5rem',
-            gridTemplateColumns: '1fr 1fr',
-          }}
-        >
-          <PharosLink href="//about.jstor.org" target="_blank" bold>
-            About
-          </PharosLink>
-          <PharosLink href="//support.jstor.org" target="_blank" bold>
-            Support
-          </PharosLink>
-        </div>
-      </div>
-    </PharosHeader>
-  </Story>
-</Canvas>
-
-## API
-
-<ArgsTable of={PharosHeader} />
-
-# Composition
+# Base
 
 export const accountNav = (section) => (
   <PharosDropdownMenuNav label="profile">
@@ -185,7 +62,7 @@ export const accountNav = (section) => (
 );
 
 <Canvas withToolbar>
-  <Story name="Composition">
+  <Story name="Base">
     <PharosHeader>
       <div id="pds" slot="top" className="hide-for-small">
         <div
@@ -230,13 +107,7 @@ export const accountNav = (section) => (
       <PharosLink slot="start" href="/" id="jstor-logo">
         <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
       </PharosLink>
-      <div
-        slot="center"
-        style={{
-          display: 'grid',
-          gridTemplateRows: '1fr 1fr',
-        }}
-      >
+      <div slot="center">
         <PharosInputGroup
           name="my-input-group"
           hideLabel
@@ -251,92 +122,60 @@ export const accountNav = (section) => (
             label="search"
           ></PharosButton>
         </PharosInputGroup>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '3fr 1fr',
-          }}
-        >
-          <PharosDropdownMenuNav label="main navigation">
-            <PharosDropdownMenuNavLink
-              href="action/showAdvancedSearch"
-              id="adv-search-link"
-              className="hide-for-small"
-            >
-              Advanced Search
-            </PharosDropdownMenuNavLink>
-            <PharosDropdownMenuNavLink
-              href="/subjects"
-              id="browse-link"
-              data-dropdown-menu-id="browse-menu"
-              data-dropdown-menu-hover
-            >
-              Browse
-            </PharosDropdownMenuNavLink>
-            <PharosDropdownMenu id="browse-menu">
-              <PharosDropdownMenuItem link="/subjects">by Subject</PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/action/showJournals?browseType=title">
-                by Title
-              </PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/site/collection-list">
-                by Collections
-              </PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/publishers">by Publisher</PharosDropdownMenuItem>
-            </PharosDropdownMenu>
-            <PharosDropdownMenuNavLink
-              href="/account/workspace"
-              id="tools-link"
-              data-dropdown-menu-id="tools-menu"
-              data-dropdown-menu-hover
-              className="hide-for-small"
-            >
-              Tools
-            </PharosDropdownMenuNavLink>
-            <PharosDropdownMenu id="tools-menu">
-              <PharosDropdownMenuItem link="/account/workspace">Workspace</PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/analyze">Text Analyzer</PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/understand">
-                The JSTOR Understanding Series
-              </PharosDropdownMenuItem>
-              <PharosDropdownMenuItem link="/dfr">Data for Research</PharosDropdownMenuItem>
-            </PharosDropdownMenu>
-          </PharosDropdownMenuNav>
-          <div
-            className="show-for-large"
-            style={{
-              justifySelf: 'end',
-              display: 'none',
-            }}
-          >
-            {accountNav('center')}
-          </div>
-        </div>
+      </div>
+      <div slot="end-top">
+        <div>{accountNav('end')}</div>
       </div>
       <div
-        slot="end"
+        slot="end-bottom"
         style={{
-          display: 'grid',
-          gridTemplateRows: '1fr 1fr',
+          display: 'flex',
         }}
-        className="hide-for-large"
       >
-        <div>{accountNav('end')}</div>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr 1fr',
-            alignItems: 'center',
-            justifyItems: 'center',
-          }}
-        >
-          <PharosLink href="//about.jstor.org" target="_blank" bold>
-            About
-          </PharosLink>
-          <PharosLink href="//support.jstor.org" target="_blank" bold>
-            Support
-          </PharosLink>
-        </div>
+        <PharosDropdownMenuNav label="main navigation">
+          <PharosDropdownMenuNavLink href="action/showAdvancedSearch" id="adv-search-link">
+            Advanced Search
+          </PharosDropdownMenuNavLink>
+          <PharosDropdownMenuNavLink
+            href="/subjects"
+            id="browse-link"
+            data-dropdown-menu-id="browse-menu"
+            data-dropdown-menu-hover
+          >
+            Browse
+          </PharosDropdownMenuNavLink>
+          <PharosDropdownMenu id="browse-menu">
+            <PharosDropdownMenuItem link="/subjects">by Subject</PharosDropdownMenuItem>
+            <PharosDropdownMenuItem link="/action/showJournals?browseType=title">
+              by Title
+            </PharosDropdownMenuItem>
+            <PharosDropdownMenuItem link="/site/collection-list">
+              by Collections
+            </PharosDropdownMenuItem>
+            <PharosDropdownMenuItem link="/publishers">by Publisher</PharosDropdownMenuItem>
+          </PharosDropdownMenu>
+          <PharosDropdownMenuNavLink
+            href="/account/workspace"
+            id="tools-link"
+            data-dropdown-menu-id="tools-menu"
+            data-dropdown-menu-hover
+          >
+            Tools
+          </PharosDropdownMenuNavLink>
+          <PharosDropdownMenu id="tools-menu">
+            <PharosDropdownMenuItem link="/account/workspace">Workspace</PharosDropdownMenuItem>
+            <PharosDropdownMenuItem link="/analyze">Text Analyzer</PharosDropdownMenuItem>
+            <PharosDropdownMenuItem link="/understand">
+              The JSTOR Understanding Series
+            </PharosDropdownMenuItem>
+            <PharosDropdownMenuItem link="/dfr">Data for Research</PharosDropdownMenuItem>
+          </PharosDropdownMenu>
+        </PharosDropdownMenuNav>
       </div>
     </PharosHeader>
   </Story>
 </Canvas>
+
+## API
+
+<ArgsTable of={PharosHeader} />

--- a/packages/pharos/src/components/header/pharos-header.scss
+++ b/packages/pharos/src/components/header/pharos-header.scss
@@ -1,31 +1,30 @@
+@use '../../utils/scss/mixins';
+
 :host {
   display: block;
 }
 
-.header__container {
+.header__content {
+  grid-area: main;
   display: grid;
-  grid-template: '. main .' auto / minmax(1rem, 1fr) minmax(max-content, 70rem) minmax(1rem, 1fr);
-  padding-top: var(--pharos-spacing-one-half-x);
+  grid-template:
+    'start center end-top' auto
+    'start center end-bottom' auto
+    / 65px minmax(auto, 650px) auto;
+  column-gap: var(--pharos-spacing-1-x);
+  row-gap: var(--pharos-spacing-1-x);
+  padding: var(--pharos-spacing-one-half-x) var(--pharos-spacing-one-and-a-half-x) 0;
   border-top: 1px solid var(--pharos-color-ui-40);
   border-bottom: 1px solid var(--pharos-color-ui-40);
 }
 
-.header__content {
-  grid-area: main;
-  max-width: 70rem;
-  display: grid;
-  grid-template: 'start center end' auto / max-content 1fr max-content;
-  column-gap: var(--pharos-spacing-1-x);
-}
-
-@media (max-width: 1024px) {
-  .header__container {
-    grid-template-columns: 1rem auto 1rem;
-    grid-template-rows: auto;
-  }
-
+@include mixins.until(medium) {
   .header__content {
-    grid-template: 'start center' auto / max-content 8fr;
+    grid-template:
+      '. . end-top' auto
+      'start center center' auto
+      '. end-bottom end-bottom' auto
+      / 65px minmax(auto, 650px) auto;
   }
 
   .header__content--end {
@@ -50,8 +49,15 @@
   align-self: end;
 }
 
-.header__content--end {
-  grid-area: end;
+.header__content--end-top {
+  grid-area: end-top;
   justify-self: end;
   align-self: center;
+}
+
+.header__content--end-bottom {
+  grid-area: end-bottom;
+  justify-self: end;
+  align-self: center;
+  display: flex;
 }

--- a/packages/pharos/src/components/header/pharos-header.scss
+++ b/packages/pharos/src/components/header/pharos-header.scss
@@ -12,7 +12,6 @@
     'start center end-bottom' auto
     / 65px minmax(auto, 650px) auto;
   column-gap: var(--pharos-spacing-1-x);
-  row-gap: var(--pharos-spacing-1-x);
   padding: var(--pharos-spacing-one-half-x) var(--pharos-spacing-one-and-a-half-x) 0;
   border-top: 1px solid var(--pharos-color-ui-40);
   border-bottom: 1px solid var(--pharos-color-ui-40);

--- a/packages/pharos/src/components/header/pharos-header.ts
+++ b/packages/pharos/src/components/header/pharos-header.ts
@@ -25,17 +25,18 @@ export class PharosHeader extends PharosElement {
         <div class="header__top">
           <slot name="top"></slot>
         </div>
-        <div class="header__container">
-          <div class="header__content">
-            <div class="header__content--start">
-              <slot name="start"></slot>
-            </div>
-            <div class="header__content--center">
-              <slot name="center"></slot>
-            </div>
-            <div class="header__content--end">
-              <slot name="end"></slot>
-            </div>
+        <div class="header__content">
+          <div class="header__content--start">
+            <slot name="start"></slot>
+          </div>
+          <div class="header__content--center">
+            <slot name="center"></slot>
+          </div>
+          <div class="header__content--end-top">
+            <slot name="end-top"></slot>
+          </div>
+          <div class="header__content--end-bottom">
+            <slot name="end-bottom"></slot>
           </div>
         </div>
       </header>

--- a/packages/pharos/src/components/header/pharos-header.wc.stories.mdx
+++ b/packages/pharos/src/components/header/pharos-header.wc.stories.mdx
@@ -13,108 +13,10 @@ import { GuidelineLink } from '@config/GuidelineLink';
 
 <GuidelineLink path="header" />
 
-<Canvas>
-  <Story name="Base">
-    {() => {
-      return html`
-        <pharos-header>
-          <div id="pds" slot="top">
-            <i>Have library access? </i>
-            <pharos-link href="//jstor.org/institutionSearch" target="_blank"
-              >Log in through your library</pharos-link
-            >
-          </div>
-          <pharos-link slot="start" href="/" id="jstor-logo">
-            <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
-          </pharos-link>
-          <div slot="center">
-            <div class="header-example__split-column">
-              <pharos-dropdown-menu-nav label="main navigation">
-                <pharos-dropdown-menu-nav-link
-                  href="action/showAdvancedSearch"
-                  id="adv-search-link"
-                  class="hide-for-small"
-                  >Advanced Search</pharos-dropdown-menu-nav-link
-                >
-                <pharos-dropdown-menu-nav-link
-                  href="/subjects"
-                  id="browse-link"
-                  data-dropdown-menu-id="browse-menu"
-                  data-dropdown-menu-hover
-                  >Browse</pharos-dropdown-menu-nav-link
-                >
-                <pharos-dropdown-menu id="browse-menu">
-                  <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
-                  <pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
-                    >by Title</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/site/collection-list"
-                    >by Collections</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/publishers"
-                    >by Publisher</pharos-dropdown-menu-item
-                  >
-                </pharos-dropdown-menu>
-                <pharos-dropdown-menu-nav-link
-                  href="/account/workspace"
-                  id="tools-link"
-                  data-dropdown-menu-id="tools-menu"
-                  data-dropdown-menu-hover
-                  class="hide-for-small"
-                  >Tools</pharos-dropdown-menu-nav-link
-                >
-                <pharos-dropdown-menu id="tools-menu">
-                  <pharos-dropdown-menu-item link="/account/workspace"
-                    >Workspace</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/analyze"
-                    >Text Analyzer</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/understand"
-                    >The JSTOR Understanding Series</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/dfr"
-                    >Data for Research</pharos-dropdown-menu-item
-                  >
-                </pharos-dropdown-menu>
-              </pharos-dropdown-menu-nav>
-              <div
-                class="show-for-large"
-                style="grid-template-columns: 1fr 1fr; column-gap: 0.5rem; justify-self: end; align-self: center; display: none"
-              >
-                <pharos-link href="#" target="_blank" bold>Log In</pharos-link>
-                <pharos-link href="#" target="_blank" bold>Register</pharos-link>
-              </div>
-            </div>
-          </div>
-          <div
-            slot="end"
-            style="display: grid; grid-template-rows: 1fr 1fr; row-gap: 1.5rem"
-            class="hide-for-large"
-          >
-            <div style="display: grid; grid-template-columns: 1fr 1fr; column-gap: 0.5rem">
-              <pharos-link href="#" target="_blank">Log In</pharos-link>
-              <pharos-link href="#" target="_blank">Register</pharos-link>
-            </div>
-            <div style="display: grid; grid-template-columns: 1fr 1fr; column-gap: 0.5rem">
-              <pharos-link href="//about.jstor.org" target="_blank" bold>About</pharos-link>
-              <pharos-link href="//support.jstor.org" target="_blank" bold>Support</pharos-link>
-            </div>
-          </div>
-        </pharos-header>
-      `;
-    }}
-  </Story>
-</Canvas>
-
-## API
-
-<ArgsTable of="pharos-header" />
-
-# Composition
+# Base
 
 <Canvas>
-  <Story name="Composition" parameters={{ chromatic: { viewports: [320, 1200] } }}>
+  <Story name="Base" parameters={{ chromatic: { viewports: [320, 1200] } }}>
     {() => {
       const accountNav = (section) => html`
         <pharos-dropdown-menu-nav label="profile">
@@ -179,7 +81,7 @@ import { GuidelineLink } from '@config/GuidelineLink';
           <pharos-link slot="start" href="/" id="jstor-logo">
             <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
           </pharos-link>
-          <div slot="center" style="display: grid; grid-template-rows: 1fr 1fr;">
+          <div slot="center">
             <pharos-input-group
               name="my-input-group"
               hide-label
@@ -194,72 +96,65 @@ import { GuidelineLink } from '@config/GuidelineLink';
                 label="search"
               ></pharos-button>
             </pharos-input-group>
-            <div style="display: grid; grid-template-columns: 3fr 1fr">
-              <pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
-                <pharos-dropdown-menu-nav-link
-                  href="action/showAdvancedSearch"
-                  id="adv-search-link"
-                  class="hide-for-small"
-                  >Advanced Search</pharos-dropdown-menu-nav-link
-                >
-                <pharos-dropdown-menu-nav-link
-                  href="/subjects"
-                  id="browse-link"
-                  data-dropdown-menu-id="browse-menu"
-                  data-dropdown-menu-hover
-                  >Browse</pharos-dropdown-menu-nav-link
-                >
-                <pharos-dropdown-menu id="browse-menu">
-                  <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
-                  <pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
-                    >by Title</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/site/collection-list"
-                    >by Collections</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/publishers"
-                    >by Publisher</pharos-dropdown-menu-item
-                  >
-                </pharos-dropdown-menu>
-                <pharos-dropdown-menu-nav-link
-                  href="/account/workspace"
-                  id="tools-link"
-                  data-dropdown-menu-id="tools-menu"
-                  data-dropdown-menu-hover
-                  class="hide-for-small"
-                  >Tools</pharos-dropdown-menu-nav-link
-                >
-                <pharos-dropdown-menu id="tools-menu">
-                  <pharos-dropdown-menu-item link="/account/workspace"
-                    >Workspace</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/analyze"
-                    >Text Analyzer</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/understand"
-                    >The JSTOR Understanding Series</pharos-dropdown-menu-item
-                  >
-                  <pharos-dropdown-menu-item link="/dfr"
-                    >Data for Research</pharos-dropdown-menu-item
-                  >
-                </pharos-dropdown-menu>
-              </pharos-dropdown-menu-nav>
-              <div class="show-for-large" style="justify-self: end; display: none">
-                ${accountNav('center')}
-              </div>
-            </div>
           </div>
-          <div slot="end" style="display: grid; grid-template-rows: 1fr 1fr" class="hide-for-large">
+          <div slot="end-top"">
             <div>${accountNav('end')}</div>
-            <div
-              style="display: grid; grid-template-columns: 1fr 1fr; align-items: center; justify-items: center"
-            >
-              <pharos-link href="//about.jstor.org" target="_blank" bold>About</pharos-link>
-              <pharos-link href="//support.jstor.org" target="_blank" bold>Support</pharos-link>
-            </div>
+          </div>
+          <div slot="end-bottom" style="display: flex;">
+            <pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
+              <pharos-dropdown-menu-nav-link
+                href="action/showAdvancedSearch"
+                id="adv-search-link"
+                >Advanced Search</pharos-dropdown-menu-nav-link
+              >
+              <pharos-dropdown-menu-nav-link
+                href="/subjects"
+                id="browse-link"
+                data-dropdown-menu-id="browse-menu"
+                data-dropdown-menu-hover
+                >Browse</pharos-dropdown-menu-nav-link
+              >
+              <pharos-dropdown-menu id="browse-menu">
+                <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
+                <pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
+                  >by Title</pharos-dropdown-menu-item
+                >
+                <pharos-dropdown-menu-item link="/site/collection-list"
+                  >by Collections</pharos-dropdown-menu-item
+                >
+                <pharos-dropdown-menu-item link="/publishers"
+                  >by Publisher</pharos-dropdown-menu-item
+                >
+              </pharos-dropdown-menu>
+              <pharos-dropdown-menu-nav-link
+                href="/account/workspace"
+                id="tools-link"
+                data-dropdown-menu-id="tools-menu"
+                data-dropdown-menu-hover
+                >Tools</pharos-dropdown-menu-nav-link
+              >
+              <pharos-dropdown-menu id="tools-menu">
+                <pharos-dropdown-menu-item link="/account/workspace"
+                  >Workspace</pharos-dropdown-menu-item
+                >
+                <pharos-dropdown-menu-item link="/analyze"
+                  >Text Analyzer</pharos-dropdown-menu-item
+                >
+                <pharos-dropdown-menu-item link="/understand"
+                  >The JSTOR Understanding Series</pharos-dropdown-menu-item
+                >
+                <pharos-dropdown-menu-item link="/dfr"
+                  >Data for Research</pharos-dropdown-menu-item
+                >
+              </pharos-dropdown-menu>
+            </pharos-dropdown-menu-nav>
           </div>
         </pharos-header>
       `;
     }}
   </Story>
 </Canvas>
+
+## API
+
+<ArgsTable of="pharos-header" />

--- a/packages/pharos/src/pages/shared/react/Header.tsx
+++ b/packages/pharos/src/pages/shared/react/Header.tsx
@@ -82,13 +82,7 @@ export const Header: FC = () => (
     <PharosLink slot="start" href="/" id="jstor-logo">
       <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
     </PharosLink>
-    <div
-      slot="center"
-      style={{
-        display: 'grid',
-        gridTemplateRows: '1fr 1fr',
-      }}
-    >
+    <div slot="center">
       <PharosInputGroup
         name="my-input-group"
         hideLabel
@@ -103,91 +97,58 @@ export const Header: FC = () => (
           label="search"
         ></PharosButton>
       </PharosInputGroup>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '3fr 1fr',
-        }}
-      >
-        <PharosDropdownMenuNav label="main navigation">
-          <PharosDropdownMenuNavLink
-            href="action/showAdvancedSearch"
-            id="adv-search-menu-link"
-            className="hide-for-small"
-          >
-            Advanced Search
-          </PharosDropdownMenuNavLink>
-          <PharosDropdownMenuNavLink
-            href="/subjects"
-            id="browse-link"
-            data-dropdown-menu-id="browse-menu"
-            data-dropdown-menu-hover
-          >
-            Browse
-          </PharosDropdownMenuNavLink>
-          <PharosDropdownMenu id="browse-menu">
-            <PharosDropdownMenuItem link="/subjects">by Subject</PharosDropdownMenuItem>
-            <PharosDropdownMenuItem link="/action/showJournals?browseType=title">
-              by Title
-            </PharosDropdownMenuItem>
-            <PharosDropdownMenuItem link="/site/collection-list">
-              by Collections
-            </PharosDropdownMenuItem>
-            <PharosDropdownMenuItem link="/publishers">by Publisher</PharosDropdownMenuItem>
-          </PharosDropdownMenu>
-          <PharosDropdownMenuNavLink
-            href="/account/workspace"
-            id="tools-link"
-            data-dropdown-menu-id="tools-menu"
-            data-dropdown-menu-hover
-            className="hide-for-small"
-          >
-            Tools
-          </PharosDropdownMenuNavLink>
-          <PharosDropdownMenu id="tools-menu">
-            <PharosDropdownMenuItem link="/account/workspace">Workspace</PharosDropdownMenuItem>
-            <PharosDropdownMenuItem link="/analyze">Text Analyzer</PharosDropdownMenuItem>
-            <PharosDropdownMenuItem link="/understand">
-              The JSTOR Understanding Series
-            </PharosDropdownMenuItem>
-            <PharosDropdownMenuItem link="/dfr">Data for Research</PharosDropdownMenuItem>
-          </PharosDropdownMenu>
-        </PharosDropdownMenuNav>
-        <div
-          className="show-for-large"
-          style={{
-            justifySelf: 'end',
-            display: 'none',
-          }}
-        >
-          {accountNav('center')}
-        </div>
-      </div>
     </div>
+    <div slot="end-top">{accountNav('end')}</div>
     <div
-      slot="end"
+      slot="end-bottom"
       style={{
-        display: 'grid',
-        gridTemplateRows: '1fr 1fr',
+        display: 'flex',
       }}
-      className="hide-for-large"
     >
-      <div>{accountNav('end')}</div>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          alignItems: 'center',
-          justifyItems: 'center',
-        }}
-      >
-        <PharosLink href="//about.jstor.org" target="_blank" bold>
-          About
-        </PharosLink>
-        <PharosLink href="//support.jstor.org" target="_blank" bold>
-          Support
-        </PharosLink>
-      </div>
+      <PharosDropdownMenuNav label="main navigation">
+        <PharosDropdownMenuNavLink
+          href="action/showAdvancedSearch"
+          id="adv-search-menu-link"
+          className="hide-for-small"
+        >
+          Advanced Search
+        </PharosDropdownMenuNavLink>
+        <PharosDropdownMenuNavLink
+          href="/subjects"
+          id="browse-link"
+          data-dropdown-menu-id="browse-menu"
+          data-dropdown-menu-hover
+        >
+          Browse
+        </PharosDropdownMenuNavLink>
+        <PharosDropdownMenu id="browse-menu">
+          <PharosDropdownMenuItem link="/subjects">by Subject</PharosDropdownMenuItem>
+          <PharosDropdownMenuItem link="/action/showJournals?browseType=title">
+            by Title
+          </PharosDropdownMenuItem>
+          <PharosDropdownMenuItem link="/site/collection-list">
+            by Collections
+          </PharosDropdownMenuItem>
+          <PharosDropdownMenuItem link="/publishers">by Publisher</PharosDropdownMenuItem>
+        </PharosDropdownMenu>
+        <PharosDropdownMenuNavLink
+          href="/account/workspace"
+          id="tools-link"
+          data-dropdown-menu-id="tools-menu"
+          data-dropdown-menu-hover
+          className="hide-for-small"
+        >
+          Tools
+        </PharosDropdownMenuNavLink>
+        <PharosDropdownMenu id="tools-menu">
+          <PharosDropdownMenuItem link="/account/workspace">Workspace</PharosDropdownMenuItem>
+          <PharosDropdownMenuItem link="/analyze">Text Analyzer</PharosDropdownMenuItem>
+          <PharosDropdownMenuItem link="/understand">
+            The JSTOR Understanding Series
+          </PharosDropdownMenuItem>
+          <PharosDropdownMenuItem link="/dfr">Data for Research</PharosDropdownMenuItem>
+        </PharosDropdownMenu>
+      </PharosDropdownMenuNav>
     </div>
   </PharosHeader>
 );

--- a/packages/pharos/src/pages/shared/wc/header.ts
+++ b/packages/pharos/src/pages/shared/wc/header.ts
@@ -56,7 +56,7 @@ export const Header = (): TemplateResult => html`
     <pharos-link slot="start" href="/" id="jstor-logo">
       <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
     </pharos-link>
-    <div slot="center" style="display: grid; grid-template-rows: 1fr 1fr;">
+    <div slot="center">
       <pharos-input-group
         name="my-input-group"
         hide-label
@@ -71,63 +71,50 @@ export const Header = (): TemplateResult => html`
           label="search"
         ></pharos-button>
       </pharos-input-group>
-      <div style="display: grid; grid-template-columns: 3fr 1fr">
-        <pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
-          <pharos-dropdown-menu-nav-link
-            href="action/showAdvancedSearch"
-            id="adv-search-menu-link"
-            class="hide-for-small"
-            >Advanced Search</pharos-dropdown-menu-nav-link
-          >
-          <pharos-dropdown-menu-nav-link
-            href="/subjects"
-            id="browse-link"
-            data-dropdown-menu-id="browse-menu"
-            data-dropdown-menu-hover
-            >Browse</pharos-dropdown-menu-nav-link
-          >
-          <pharos-dropdown-menu id="browse-menu">
-            <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
-            <pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
-              >by Title</pharos-dropdown-menu-item
-            >
-            <pharos-dropdown-menu-item link="/site/collection-list"
-              >by Collections</pharos-dropdown-menu-item
-            >
-            <pharos-dropdown-menu-item link="/publishers">by Publisher</pharos-dropdown-menu-item>
-          </pharos-dropdown-menu>
-          <pharos-dropdown-menu-nav-link
-            href="/account/workspace"
-            id="tools-link"
-            data-dropdown-menu-id="tools-menu"
-            data-dropdown-menu-hover
-            class="hide-for-small"
-            >Tools</pharos-dropdown-menu-nav-link
-          >
-          <pharos-dropdown-menu id="tools-menu">
-            <pharos-dropdown-menu-item link="/account/workspace"
-              >Workspace</pharos-dropdown-menu-item
-            >
-            <pharos-dropdown-menu-item link="/analyze">Text Analyzer</pharos-dropdown-menu-item>
-            <pharos-dropdown-menu-item link="/understand"
-              >The JSTOR Understanding Series</pharos-dropdown-menu-item
-            >
-            <pharos-dropdown-menu-item link="/dfr">Data for Research</pharos-dropdown-menu-item>
-          </pharos-dropdown-menu>
-        </pharos-dropdown-menu-nav>
-        <div class="show-for-large" style="justify-self: end; display: none">
-          ${accountNav('center')}
-        </div>
-      </div>
     </div>
-    <div slot="end" style="display: grid; grid-template-rows: 1fr 1fr" class="hide-for-large">
-      <div>${accountNav('end')}</div>
-      <div
-        style="display: grid; grid-template-columns: 1fr 1fr; align-items: center; justify-items: center"
-      >
-        <pharos-link href="//about.jstor.org" target="_blank" bold>About</pharos-link>
-        <pharos-link href="//support.jstor.org" target="_blank" bold>Support</pharos-link>
-      </div>
+    <div slot="end-top">${accountNav('end')}</div>
+    <div slot="end-bottom" style="display: flex;">
+      <pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
+        <pharos-dropdown-menu-nav-link href="action/showAdvancedSearch" id="adv-search-menu-link">
+          Advanced Search
+        </pharos-dropdown-menu-nav-link>
+        <pharos-dropdown-menu-nav-link
+          href="/subjects"
+          id="browse-link"
+          data-dropdown-menu-id="browse-menu"
+          data-dropdown-menu-hover
+        >
+          Browse
+        </pharos-dropdown-menu-nav-link>
+        <pharos-dropdown-menu id="browse-menu">
+          <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
+          <pharos-dropdown-menu-item link="/action/showJournals?browseType=title">
+            by Title
+          </pharos-dropdown-menu-item>
+          <pharos-dropdown-menu-item link="/site/collection-list">
+            by Collections
+          </pharos-dropdown-menu-item>
+          <pharos-dropdown-menu-item link="/publishers">by Publisher</pharos-dropdown-menu-item>
+        </pharos-dropdown-menu>
+        <pharos-dropdown-menu-nav-link
+          href="/account/workspace"
+          id="tools-link"
+          data-dropdown-menu-id="tools-menu"
+          data-dropdown-menu-hover
+        >
+          Tools
+        </pharos-dropdown-menu-nav-link>
+        <pharos-dropdown-menu id="tools-menu">
+          <pharos-dropdown-menu-item link="/account/workspace">
+            Workspace
+          </pharos-dropdown-menu-item>
+          <pharos-dropdown-menu-item link="/analyze">Text Analyzer</pharos-dropdown-menu-item>
+          <pharos-dropdown-menu-item link="/understand">
+            The JSTOR Understanding Series
+          </pharos-dropdown-menu-item>
+          <pharos-dropdown-menu-item link="/dfr">Data for Research</pharos-dropdown-menu-item>
+        </pharos-dropdown-menu>
+      </pharos-dropdown-menu-nav>
     </div>
   </pharos-header>
 `;


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [x] Yes
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

The latest branded designs for the header need a more sophisticated change to the gridding at different breakpoints. Namely, the header should be a 3-column/2-row grid on large screens, but a 3-column/3-row grid on smaller screens.

**How does this change work?**

Update the CSS grid layout to add these new grid areas and corresponding slots to fill the content. The change keeps these areas named rather agnostically, for now, but we can consider whether the areas become more opinionated about the content that goes there if we only ever use it this one way, or we see that multiple usages keep the same pattern.

**Additional context**

Removed the existing "Base" story and made the "Composition" story the base, as it exercises all of the grid and is much more demonstrative of the capabilities.

Desired behavior and usage moving forward:

<img width="934" alt="Screen Shot 2022-01-07 at 19 50 31" src="https://user-images.githubusercontent.com/1808306/148624736-d70bc2a1-6620-4b1d-8e73-2cd0584f533b.png">
<img width="722" alt="Screen Shot 2022-01-07 at 19 50 42" src="https://user-images.githubusercontent.com/1808306/148624737-5093740e-1ecb-497d-92fb-b017cc0ca443.png">

