### PR TITLE
fix(header): push navigation areas to boundaries

### DIFF
--- a/.changeset/wicked-actors-burn.md
+++ b/.changeset/wicked-actors-burn.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Ensure proper spacing of new end top/bottom area content

--- a/packages/pharos/src/components/header/pharos-header.scss
+++ b/packages/pharos/src/components/header/pharos-header.scss
@@ -51,12 +51,12 @@
 .header__content--end-top {
   grid-area: end-top;
   justify-self: end;
-  align-self: center;
+  align-self: start;
 }
 
 .header__content--end-bottom {
   grid-area: end-bottom;
   justify-self: end;
-  align-self: center;
+  align-self: end;
   display: flex;
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

The changes made in #295 kept the content centered within its respective grid row—however, we must ensure the content in the new top and bottom areas presses up against the top and bottom borders respectively to avoid gaps due to implicit space calculations during CSS grid layout.

**How does this change work?**

Change `align-self` from `center` to the appropriate `start`/`end` for each area.
