### PR TITLE
Feat(toast): add info variation

### DIFF
--- a/.changeset/quick-fireants-cheer.md
+++ b/.changeset/quick-fireants-cheer.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add info variation to toast

--- a/packages/pharos/src/components/toast/pharos-toast.scss
+++ b/packages/pharos/src/components/toast/pharos-toast.scss
@@ -54,6 +54,10 @@
   fill: var(--pharos-color-feedback-error);
 }
 
+.toast--info .toast__icon {
+  fill: var(--pharos-color-feedback-info);
+}
+
 :host([open]) .toast {
   opacity: 1;
   transform: translateY(0);

--- a/packages/pharos/src/components/toast/pharos-toast.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.test.ts
@@ -55,6 +55,14 @@ describe('pharos-toast', () => {
     expect(icon?.name).to.equal('exclamation-inverse');
   });
 
+  it('renders an exclamation icon with info status', async () => {
+    component.status = 'info';
+    await component.updateComplete;
+
+    const icon = component.renderRoot.querySelector('pharos-icon') as PharosIcon;
+    expect(icon?.name).to.equal('exclamation-inverse');
+  });
+
   it('fires a custom event pharos-toast-close after closing', async () => {
     let detail = null;
     const handleClose = (e: Event): void => {

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -12,14 +12,15 @@ import ScopedRegistryMixin from '../../utils/mixins/scoped-registry';
 import { PharosIcon } from '../icon/pharos-icon';
 import { PharosToastButton } from './pharos-toast-button';
 
-export type ToastStatus = 'success' | 'error';
+export type ToastStatus = 'success' | 'error' | 'info';
 
 export enum TOAST_ICON {
   ERROR = 'exclamation-inverse',
   SUCCESS = 'checkmark-inverse',
+  INFO = 'exclamation-inverse',
 }
 
-const STATUSES = ['success', 'error'];
+const STATUSES = ['success', 'error', 'info'];
 
 const TOAST_LIFE = 6000;
 

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
@@ -114,3 +114,35 @@ import { GuidelineLink } from '@config/GuidelineLink';
     }}
   </Story>
 </Canvas>
+
+## Info Toast
+
+<Canvas>
+  <Story name="Info">
+    {() => {
+      const effect = () => {
+        useEffect(() => {
+          document.querySelector('#info-toast-button').click();
+        });
+      };
+      effect();
+      return html`
+        <pharos-button
+          id="info-toast-button"
+          @click="${() => {
+            const event = new CustomEvent('pharos-toast-open', {
+              detail: {
+                status: 'info',
+                content: 'We are working on your request.',
+              },
+            });
+            document.dispatchEvent(event);
+          }}"
+        >
+          Click me to know more
+        </pharos-button>
+        <pharos-toaster></pharos-toaster>
+      `;
+    }}
+  </Story>
+</Canvas>


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**

Resolves #318

Add an info variation to toast. This will be used for showing the progress to users when we are working on their requests.

**How does this change work?**
Add "info" as a valid status for toast and use the exclamation icon with feedback info color.


