### PR TITLE
fix: use yarn in size limit action

### DIFF
--- a/.changeset/new-cameras-prove.md
+++ b/.changeset/new-cameras-prove.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Move size-limit checks up to the project root

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -18,9 +18,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Install Yarn
-        run: npm install --global yarn
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -38,4 +35,4 @@ jobs:
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          directory: packages/pharos/
+          build_script: 'build:core'

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: Install Yarn
+        run: npm install --global yarn
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -18,20 +18,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -18,6 +18,20 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@changesets/cli": "^2.18.0",
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-conventional": "^15.0.0",
+    "@size-limit/preset-small-lib": "^7.0.4",
     "@storybook/addon-a11y": "^6.5.0-alpha.5",
     "@storybook/addon-actions": "^6.5.0-alpha.5",
     "@storybook/addon-backgrounds": "^6.5.0-alpha.5",
@@ -111,6 +112,7 @@
     "react-dom": "^17.0.1",
     "sass": "^1.42.1",
     "sass-loader": "^12.3.0",
+    "size-limit": "^7.0.4",
     "style-loader": "^3.3.1",
     "stylelint": "^14.0.0",
     "stylelint-config-prettier": "^9.0.3",
@@ -141,5 +143,10 @@
     "trim": "^0.0.3",
     "marked": "^0.7.0",
     "graphql-config": "^4.1.0"
-  }
+  },
+  "size-limit": [
+    {
+      "path": "packages/pharos/lib/index.js"
+    }
+  ]
 }

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -63,7 +63,6 @@
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.5.6",
     "@open-wc/testing": "^3.0.1",
-    "@size-limit/preset-small-lib": "^7.0.4",
     "@types/react-dom": "^17.0.0",
     "@types/react": "^17.0.1",
     "@web/test-runner": "^0.13.16",
@@ -82,7 +81,6 @@
     "sass": "^1.42.1",
     "sassdoc": "^2.7.3",
     "sinon": "^12.0.1",
-    "size-limit": "^7.0.4",
     "style-dictionary": "^3.0.1",
     "ts-lit-plugin": "^1.2.1",
     "typescript": "^4.5.2"

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -85,10 +85,5 @@
     "ts-lit-plugin": "^1.2.1",
     "typescript": "^4.5.2"
   },
-  "customElements": "custom-elements.json",
-  "size-limit": [
-    {
-      "path": "lib/index.js"
-    }
-  ]
+  "customElements": "custom-elements.json"
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**

Fixes #337 (maybe)

**How does this change work?**

The size limit action checks if Yarn is available and uses it if so. I see it's using npm when it runs, though, so Yarn is not available. Installing it prior to the action running might make things happier.
