### PR TITLE
fix(chromatic): update delays for visual snapshot tests

### DIFF
--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.wc.stories.mdx
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.wc.stories.mdx
@@ -8,7 +8,7 @@ import { GuidelineLink } from '@config/GuidelineLink';
   title="Components/Dropdown Menu"
   parameters={{
     options: { selectedPanel: 'addon-controls' },
-    chromatic: { delay: 700 },
+    chromatic: { delay: 800 },
   }}
 />
 

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
@@ -7,6 +7,7 @@ import { GuidelineLink } from '@config/GuidelineLink';
   title="Components/Toast"
   parameters={{
     options: { selectedPanel: 'addon-controls' },
+    chromatic: { delay: 500 },
   }}
 />
 

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.wc.stories.mdx
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.wc.stories.mdx
@@ -8,7 +8,7 @@ import { GuidelineLink } from '@config/GuidelineLink';
   title="Components/Tooltip"
   parameters={{
     options: { selectedPanel: 'addon-controls' },
-    chromatic: { delay: 700 },
+    chromatic: { delay: 800 },
   }}
 />
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**

The stories changed here have delays built into them using `setTimeout`, but they `delay` value for Chromatic was either unset or set to the same value as the timeout. This results regularly in snapshots where the component state has not yet reached the desired one for testing, leading to noisy snapshot diffs on each pull request.

**How does this change work?**

Updating the `delay` value to be longer than the `setTimeout` values should result in a more stable testing experience.
