### PR TITLE
ImageCard: Selectable and disabled variants, new styling for error variant

### DIFF
--- a/.changeset/pink-needles-jump.md
+++ b/.changeset/pink-needles-jump.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add selectable card variants, add disabled card state, update styling of error state

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -21,7 +21,7 @@
   background-color: var(--pharos-color-marble-gray-94);
 }
 
-.card__strong-selectable-hover {
+.card__selectable-card-hover {
   background-color: var(--pharos-color-marble-gray-base);
 }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -21,6 +21,10 @@
   background-color: var(--pharos-color-marble-gray-94);
 }
 
+.card__strong-selectable-hover {
+  background-color: var(--pharos-color-marble-gray-base);
+}
+
 slot[name='image']::slotted(img) {
   height: 100%;
   width: 100%;
@@ -31,6 +35,7 @@ slot[name='image']::slotted(img) {
 .card__selected {
   background-color: var(--pharos-color-white);
   border: solid 2px var(--pharos-color-interactive-secondary);
+  box-sizing: border-box;
 
   slot[name='image']::slotted(img) {
     height: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -14,7 +14,11 @@
 .card__link--image {
   position: relative;
   height: 14rem;
-  margin: 0 auto var(--pharos-spacing-1-x);
+  justify-content: center;
+}
+
+.card__selected {
+  background-color: var(--pharos-color-marble-gray-94);
 }
 
 .card__link--image,
@@ -109,6 +113,9 @@
 
 .card__selector {
   position: absolute;
+  z-index: 1;
+  margin-top: var(--pharos-spacing-one-quarter-x);
+  margin-left: var(--pharos-spacing-one-quarter-x);
 }
 
 :host(:not([variant='promotional'])) {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -27,7 +27,7 @@
 
 .card__selected {
   background-color: var(--pharos-color-white);
-  border: solid 2px var(--pharos-color-interactive-secondary);
+  outline: solid 2px var(--pharos-color-interactive-secondary);
   box-sizing: border-box;
   transition: background-color var(--pharos-transition-duration-short) ease-in-out;
 
@@ -39,7 +39,7 @@
 }
 
 :host([disabled]) .card__selected {
-  border: solid 2px var(--pharos-color-marble-gray-50);
+  outline: solid 2px var(--pharos-color-marble-gray-50);
 }
 
 :host([disabled]) .card__link--image {
@@ -143,7 +143,7 @@ slot[name='image']::slotted(img) {
 .card__link--collection {
   display: grid;
   position: relative;
-  height: 9rem;
+  height: auto;
   margin-bottom: var(--pharos-spacing-1-x);
 }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -25,7 +25,7 @@
   min-width: 0;
 }
 
-.card__selected {
+@mixin card-selected {
   background-color: var(--pharos-color-white);
   outline: solid 2px var(--pharos-color-interactive-secondary);
   box-sizing: border-box;
@@ -38,7 +38,11 @@
   }
 }
 
-:host([disabled]) .card__selected {
+.card__link--image.card__link--selected {
+  @include card-selected;
+}
+
+:host([disabled]) .card__link--image.card__link--selected {
   outline: solid 2px var(--pharos-color-marble-gray-50);
 }
 
@@ -155,6 +159,14 @@ slot[name='image']::slotted(img) {
   position: relative;
   height: auto;
   margin-bottom: var(--pharos-spacing-1-x);
+}
+
+.card__link--collection.card__link--selected {
+  @include card-selected;
+}
+
+:host([disabled]) .card__link--collection.card__link--selected {
+  outline: solid 2px var(--pharos-color-marble-gray-50);
 }
 
 :host([disabled]) .card__link--collection {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -107,6 +107,10 @@
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
+.card__selector {
+  position: absolute;
+}
+
 :host(:not([variant='promotional'])) {
   .card__heading,
   .card__title--hover {
@@ -118,6 +122,13 @@
   display: block;
   height: 100%;
   width: 100%;
+}
+.checkboxNoHover {
+  display: none;
+}
+
+.checkboxHover {
+  display: inline;
 }
 
 :host([subtle]) .card__link--image {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -17,6 +17,41 @@
   justify-content: center;
 }
 
+.card__link--image,
+.card__link--title {
+  contain: unset;
+  display: inline-flex;
+  min-width: 0;
+}
+
+.card__selected {
+  background-color: var(--pharos-color-white);
+  border: solid 2px var(--pharos-color-interactive-secondary);
+  box-sizing: border-box;
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
+
+  slot[name='image']::slotted(*) {
+    height: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
+    width: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
+    padding: var(--pharos-spacing-three-quarters-x);
+  }
+}
+
+:host([disabled]) .card__selected {
+  border: solid 2px var(--pharos-color-marble-gray-50);
+}
+
+:host([disabled]) .card__link--image {
+  color: var(--pharos-color-marble-gray-50);
+  cursor: not-allowed;
+  text-decoration: none;
+  pointer-events: none;
+
+  slot[name='image']::slotted(*) {
+    opacity: 0.5;
+  }
+}
+
 slot[name='image']::slotted(img) {
   height: 100%;
   width: 100%;
@@ -24,11 +59,20 @@ slot[name='image']::slotted(img) {
   object-position: bottom;
 }
 
-.card__link--image,
-.card__link--title {
-  contain: unset;
-  display: inline-flex;
-  min-width: 0;
+:host([disabled]) .card__link--title {
+  color: var(--pharos-color-marble-gray-50);
+  cursor: not-allowed;
+  text-decoration: none;
+  pointer-events: none;
+}
+
+:host([disabled]) .card__heading {
+  color: var(--pharos-color-marble-gray-50);
+}
+
+:host([disabled]) slot[name='metadata']::slotted(*) {
+  pointer-events: none;
+  opacity: 0.5;
 }
 
 :host([variant='promotional']) .card__link--image {
@@ -141,19 +185,6 @@ slot[name='image']::slotted(img) {
 .card__selectable-card-hover {
   background-color: var(--pharos-color-marble-gray-base);
   transition: background-color var(--pharos-transition-duration-short) ease-in-out;
-}
-
-.card__selected {
-  background-color: var(--pharos-color-white);
-  border: solid 2px var(--pharos-color-interactive-secondary);
-  box-sizing: border-box;
-  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
-
-  slot[name='image']::slotted(*) {
-    height: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
-    width: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
-    padding: var(--pharos-spacing-three-quarters-x);
-  }
 }
 
 .card__container-selected--error {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -143,7 +143,7 @@ slot[name='image']::slotted(img) {
 .card__link--collection {
   display: grid;
   position: relative;
-  height: auto;
+  height: 9rem;
   margin-bottom: var(--pharos-spacing-1-x);
 }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -70,11 +70,6 @@ slot[name='image']::slotted(img) {
   color: var(--pharos-color-marble-gray-50);
 }
 
-:host([disabled]) slot[name='metadata']::slotted(*) {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
 :host([variant='promotional']) .card__link--image {
   height: unset;
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -17,8 +17,26 @@
   justify-content: center;
 }
 
-.card__selected {
+.card__selectable {
   background-color: var(--pharos-color-marble-gray-94);
+}
+
+slot[name='image']::slotted(img) {
+  height: 100%;
+  width: 100%;
+  object-fit: contain;
+  object-position: bottom;
+}
+
+.card__selected {
+  background-color: var(--pharos-color-white);
+  border: solid 2px var(--pharos-color-interactive-secondary);
+
+  slot[name='image']::slotted(img) {
+    height: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
+    width: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
+    padding: var(--pharos-spacing-three-quarters-x);
+  }
 }
 
 .card__link--image,
@@ -142,13 +160,6 @@
       pointer-events: auto;
     }
   }
-}
-
-slot[name='image']::slotted(img) {
-  height: 100%;
-  width: 100%;
-  object-fit: contain;
-  object-position: bottom;
 }
 
 slot[name='metadata']::slotted(*:not(:last-child)) {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -122,6 +122,16 @@ slot[name='image']::slotted(img) {
   }
 }
 
+.card__container--error.card__container--selectable-hover {
+  background-color: inherit;
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
+}
+
+.card__container--error.card__container--selected {
+  background-color: var(--pharos-color-white);
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
+}
+
 .card__source-type {
   @include mixins.font-base(
     $font-size: var(--pharos-font-size-small),
@@ -185,22 +195,12 @@ slot[name='image']::slotted(img) {
   margin-left: var(--pharos-spacing-one-quarter-x);
 }
 
-.card__selectable {
+.card__link--image.card__link--selectable {
   background-color: var(--pharos-color-marble-gray-94);
 }
 
-.card__selectable-card-hover {
+.card__link--image.card__link--select-hover {
   background-color: var(--pharos-color-marble-gray-base);
-  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
-}
-
-.card__container-selected--error {
-  background-color: var(--pharos-color-white);
-  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
-}
-
-.card__container-selectable-hover--error {
-  background-color: inherit;
   transition: background-color var(--pharos-transition-duration-short) ease-in-out;
 }
 
@@ -226,11 +226,13 @@ slot[name='metadata']::slotted(strong) {
   color: var(--pharos-color-text-base);
 }
 
-:host([variant*='collection']) .card__title {
+:host([variant='collection']) .card__title,
+:host([variant='selectable-collection']) .card__title {
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
-:host([variant*='collection']) .card__metadata {
+:host([variant='collection']) .card__metadata,
+:host([variant='selectable-collection']) .card__metadata {
   color: var(--pharos-color-text-20);
 }
 
@@ -238,7 +240,8 @@ slot[name='metadata']::slotted(strong) {
   @include mixins.font-base;
 }
 
-:host([variant*='collection']) slot[name='image']::slotted(img) {
+:host([variant='collection']) slot[name='image']::slotted(img),
+:host([variant='selectable-collection']) slot[name='image']::slotted(img) {
   position: absolute;
   object-fit: cover;
   object-position: 50% 30%;

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -38,7 +38,7 @@ slot[name='image']::slotted(img) {
   border: solid 2px var(--pharos-color-interactive-secondary);
   box-sizing: border-box;
 
-  slot[name='image']::slotted(img) {
+  slot[name='image']::slotted(*) {
     height: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
     width: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
     padding: var(--pharos-spacing-three-quarters-x);
@@ -88,7 +88,7 @@ slot[name='image']::slotted(img) {
 }
 
 .card__container--error {
-  border: 1px solid var(--pharos-color-ui-40);
+  background-color: var(--pharos-color-marble-gray-94);
   height: 12.5rem;
   display: flex;
   flex-direction: column;
@@ -101,6 +101,16 @@ slot[name='image']::slotted(img) {
   .unavailable-text {
     max-width: 9rem;
   }
+}
+
+.card__container-selected--error {
+  background-color: inherit;
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
+}
+
+.card__container-selectable-hover--error {
+  background-color: inherit;
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
 }
 
 .card__source-type {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -234,7 +234,7 @@ slot[name='metadata']::slotted(strong) {
   color: var(--pharos-color-text-20);
 }
 
-:host([varian='promotional']) .card__metadata {
+:host([variant='promotional']) .card__metadata {
   @include mixins.font-base;
 }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -23,6 +23,7 @@
 
 .card__selectable-card-hover {
   background-color: var(--pharos-color-marble-gray-base);
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
 }
 
 slot[name='image']::slotted(img) {

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -15,6 +15,7 @@
   position: relative;
   height: 14rem;
   justify-content: center;
+  margin-bottom: var(--pharos-spacing-1-x);
 }
 
 .card__link--image,
@@ -146,6 +147,17 @@ slot[name='image']::slotted(img) {
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
+:host([disabled]) .card__link--collection {
+  color: var(--pharos-color-marble-gray-50);
+  cursor: not-allowed;
+  text-decoration: none;
+  pointer-events: none;
+
+  slot[name='image']::slotted(*) {
+    opacity: 0.5;
+  }
+}
+
 .card__title--hover {
   @include mixins.font-base($font-weight: var(--pharos-font-weight-bold));
 
@@ -214,19 +226,19 @@ slot[name='metadata']::slotted(strong) {
   color: var(--pharos-color-text-base);
 }
 
-:host([variant='collection']) .card__title {
+:host([variant*='collection']) .card__title {
   margin-bottom: var(--pharos-spacing-1-x);
 }
 
-:host([variant='collection']) .card__metadata {
+:host([variant*='collection']) .card__metadata {
   color: var(--pharos-color-text-20);
 }
 
-:host([variant='promotional']) .card__metadata {
+:host([varian='promotional']) .card__metadata {
   @include mixins.font-base;
 }
 
-:host([variant='collection']) slot[name='image']::slotted(img) {
+:host([variant*='collection']) slot[name='image']::slotted(img) {
   position: absolute;
   object-fit: cover;
   object-position: 50% 30%;

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -123,13 +123,6 @@
   height: 100%;
   width: 100%;
 }
-.checkboxNoHover {
-  display: none;
-}
-
-.checkboxHover {
-  display: inline;
-}
 
 :host([subtle]) .card__link--image {
   position: relative;

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -17,32 +17,11 @@
   justify-content: center;
 }
 
-.card__selectable {
-  background-color: var(--pharos-color-marble-gray-94);
-}
-
-.card__selectable-card-hover {
-  background-color: var(--pharos-color-marble-gray-base);
-  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
-}
-
 slot[name='image']::slotted(img) {
   height: 100%;
   width: 100%;
   object-fit: contain;
   object-position: bottom;
-}
-
-.card__selected {
-  background-color: var(--pharos-color-white);
-  border: solid 2px var(--pharos-color-interactive-secondary);
-  box-sizing: border-box;
-
-  slot[name='image']::slotted(*) {
-    height: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
-    width: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
-    padding: var(--pharos-spacing-three-quarters-x);
-  }
 }
 
 .card__link--image,
@@ -103,16 +82,6 @@ slot[name='image']::slotted(img) {
   }
 }
 
-.card__container-selected--error {
-  background-color: inherit;
-  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
-}
-
-.card__container-selectable-hover--error {
-  background-color: inherit;
-  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
-}
-
 .card__source-type {
   @include mixins.font-base(
     $font-size: var(--pharos-font-size-small),
@@ -145,13 +114,6 @@ slot[name='image']::slotted(img) {
   margin-bottom: var(--pharos-spacing-one-half-x);
 }
 
-.card__selector {
-  position: absolute;
-  z-index: 1;
-  margin-top: var(--pharos-spacing-one-quarter-x);
-  margin-left: var(--pharos-spacing-one-quarter-x);
-}
-
 :host(:not([variant='promotional'])) {
   .card__heading,
   .card__title--hover {
@@ -163,6 +125,45 @@ slot[name='image']::slotted(img) {
   display: block;
   height: 100%;
   width: 100%;
+}
+
+.card__checkbox {
+  position: absolute;
+  z-index: 1;
+  margin-top: var(--pharos-spacing-one-quarter-x);
+  margin-left: var(--pharos-spacing-one-quarter-x);
+}
+
+.card__selectable {
+  background-color: var(--pharos-color-marble-gray-94);
+}
+
+.card__selectable-card-hover {
+  background-color: var(--pharos-color-marble-gray-base);
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
+}
+
+.card__selected {
+  background-color: var(--pharos-color-white);
+  border: solid 2px var(--pharos-color-interactive-secondary);
+  box-sizing: border-box;
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
+
+  slot[name='image']::slotted(*) {
+    height: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
+    width: calc(100% - 2 * var(--pharos-spacing-three-quarters-x));
+    padding: var(--pharos-spacing-three-quarters-x);
+  }
+}
+
+.card__container-selected--error {
+  background-color: var(--pharos-color-white);
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
+}
+
+.card__container-selectable-hover--error {
+  background-color: inherit;
+  transition: background-color var(--pharos-transition-duration-short) ease-in-out;
 }
 
 :host([subtle]) .card__link--image {

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -203,6 +203,25 @@ describe('pharos-image-card', () => {
     expect(component['_title']['_hover']).to.be.true;
   });
 
+  it('does not set the title link hover state when the card is disabled and the link title is hovered', async () => {
+    component = await fixture(html`<pharos-image-card disabled="true" link="#">
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <span slot="title">Card Title</span>
+      <div slot="metadata">Creator of the item</div>
+      <div slot="metadata">1990-2000</div>
+      <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
+    </pharos-image-card>`);
+    const imageLink = component.renderRoot.querySelector('.card__link--image');
+    imageLink?.dispatchEvent(new Event('mouseenter'));
+
+    await component.updateComplete;
+    expect(component['_title']['_hover']).to.be.false;
+  });
+
   it('renders an action button when an action menu id is provided', async () => {
     component.actionMenu = 'menu-id';
     await component.updateComplete;
@@ -496,6 +515,60 @@ describe('pharos-image-card', () => {
     await aTimeout(100);
     await elementUpdated(component);
     expect(selected).to.be.true;
+  });
+
+  it('does not dispatch pharos-image-card-selected when the disabled thumbnail of the select variant is clicked', async () => {
+    component = await fixture(html`<pharos-image-card variant="selectable" disabled="true" link="#">
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="overlay">Card overlay</div>
+    </pharos-image-card>`);
+
+    const title: PharosLink | null = component.renderRoot.querySelector(
+      'pharos-link.card__link--image'
+    );
+
+    let selected = false;
+    const onSelectCard = (): void => {
+      selected = true;
+    };
+    component.addEventListener('pharos-image-card-selected', onSelectCard);
+    title?.click();
+    await aTimeout(100);
+    await elementUpdated(component);
+    expect(selected).to.be.false;
+  });
+
+  it('does not dispatch pharos-image-card-selected when the disabled thumbnail of subtle-select is clicked', async () => {
+    component = await fixture(html`<pharos-image-card
+      variant="selectable"
+      subtle-select="true"
+      link="#"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="overlay">Card overlay</div>
+    </pharos-image-card>`);
+
+    const title: PharosLink | null = component.renderRoot.querySelector(
+      'pharos-link.card__link--image'
+    );
+
+    let selected = false;
+    const onSelectCard = (): void => {
+      selected = true;
+    };
+    component.addEventListener('pharos-image-card-selected', onSelectCard);
+    title?.click();
+    await aTimeout(100);
+    await elementUpdated(component);
+    expect(selected).to.be.false;
   });
 
   it('does not dispatch pharos-image-card-selected when the title of the select variant is clicked in subtle-select mode', async () => {

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -148,7 +148,7 @@ describe('pharos-image-card', () => {
     ).to.be.thrown;
   });
 
-  it('throws an error when using the select prop is used with a non-selectable variant', async () => {
+  it('throws an error when using the selected prop is used with a non-selectable variant', async () => {
     component = await fixture(html`
       <pharos-image-card
         title="Card Title"
@@ -417,16 +417,13 @@ describe('pharos-image-card', () => {
     </pharos-image-card>`);
 
     let checkboxElement = null;
-
-    const onMouseEnter = async (): Promise<void> => {
-      await component.updateComplete;
-      checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
-      expect(checkboxElement).not.to.be.null;
-    };
-
     const pharosLink = component.renderRoot.querySelector('pharos-link');
-    component.addEventListener('pharos-image-card-image-mouseenter', onMouseEnter);
     pharosLink?.dispatchEvent(new MouseEvent('mouseenter'));
+    await aTimeout(100);
+    await elementUpdated(component);
+
+    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    expect(checkboxElement).not.to.be.null;
   });
 
   it('dispatches the mouseleave event on pharos link mouseleave', async () => {

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -3,6 +3,7 @@ import { html } from 'lit/static-html.js';
 
 import type { PharosImageCard } from './pharos-image-card';
 import type { PharosButton } from '../button/pharos-button';
+import type { PharosLink } from '../link/pharos-link';
 
 describe('pharos-image-card', () => {
   let component: PharosImageCard;
@@ -74,11 +75,91 @@ describe('pharos-image-card', () => {
     await expect(component).to.be.accessible();
   });
 
+  it('is accessible as the selectable variant', async () => {
+    component = await fixture(html`<pharos-image-card
+      title="Card Title"
+      link="#"
+      variant="selectable"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <strong slot="metadata">100 items</strong>
+      <div slot="metadata">Description of collection.</div>
+    </pharos-image-card>`);
+    await expect(component).to.be.accessible();
+  });
+
+  it('is accessible as the selectable-collection variant', async () => {
+    component = await fixture(html`<pharos-image-card
+      title="Card Title"
+      link="#"
+      variant="selectable-collection"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <strong slot="metadata">100 items</strong>
+      <div slot="metadata">Description of collection.</div>
+    </pharos-image-card>`);
+    await expect(component).to.be.accessible();
+  });
+
+  it('is accessible as the selectable subtle-select variant', async () => {
+    component = await fixture(html`<pharos-image-card
+      title="Card Title"
+      link="#"
+      variant="selectable"
+      subtle-select="true"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <strong slot="metadata">100 items</strong>
+      <div slot="metadata">Description of collection.</div>
+    </pharos-image-card>`);
+    await expect(component).to.be.accessible();
+  });
+
   it('throws an error for an invalid variant value', async () => {
     component = await fixture(html`
       <pharos-image-card title="Card Title" link="#" variant="fake"></pharos-image-card>
     `).catch((e) => e);
     expect('fake is not a valid variant. Valid variants are: base, collection').to.be.thrown;
+  });
+
+  it('throws an error when using subtle-select with non-selectable variants', async () => {
+    component = await fixture(html`
+      <pharos-image-card
+        title="Card Title"
+        link="#"
+        subtle-select="true"
+        variant="collection"
+      ></pharos-image-card>
+    `).catch((e) => e);
+    expect(
+      'collection is not a valid variant to use with subtle-select. Only the selectable variants can be used with subtle-select.'
+    ).to.be.thrown;
+  });
+
+  it('throws an error when using the select prop is used with a non-selectable variant', async () => {
+    component = await fixture(html`
+      <pharos-image-card
+        title="Card Title"
+        link="#"
+        selected="true"
+        variant="collection"
+      ></pharos-image-card>
+    `).catch((e) => e);
+    expect(
+      'Image card with variant type collection cannot be selected. Only the selectable variants can be selected.'
+    ).to.be.thrown;
   });
 
   it('opens the provided dropdown menu when the action button is clicked', async () => {
@@ -262,6 +343,24 @@ describe('pharos-image-card', () => {
     expect(link?.getAttribute('label')).to.equal('Label for card image link');
   });
 
+  it('renders a checkbox for the selectable variant', async () => {
+    component.variant = 'selectable';
+    component.title = 'pick me';
+    await component.updateComplete;
+
+    const checkbox = component.renderRoot.querySelector('pharos-checkbox.card__checkbox');
+    expect(checkbox?.getAttribute('name')).to.equal('Select pick me');
+  });
+
+  it('renders a checkbox for the selectable-collection variant', async () => {
+    component.variant = 'selectable-collection';
+    component.title = 'pick me';
+    await component.updateComplete;
+    const checkbox = component.renderRoot.querySelector('pharos-checkbox.card__checkbox');
+
+    expect(checkbox?.getAttribute('name')).to.equal('Select pick me');
+  });
+
   it('dispatches the mouseenter event on pharos link mouseenter', async () => {
     component = await fixture(html`<pharos-image-card link="#">
       <img
@@ -284,6 +383,52 @@ describe('pharos-image-card', () => {
     expect(hovered).to.be.true;
   });
 
+  it('will show not show a checkbox when subtle-select is true', async () => {
+    component = await fixture(html`<pharos-image-card
+      variant="selectable"
+      subtle-select="true"
+      link="#"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="overlay">Card overlay</div>
+    </pharos-image-card>`);
+
+    let checkboxElement = null;
+    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    expect(checkboxElement).to.be.null;
+  });
+
+  it('will show a checkbox when hovered and subtle-select is true', async () => {
+    component = await fixture(html`<pharos-image-card
+      variant="selectable"
+      subtle-select="true"
+      link="#"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="overlay">Card overlay</div>
+    </pharos-image-card>`);
+
+    let checkboxElement = null;
+
+    const onMouseEnter = async (): Promise<void> => {
+      await component.updateComplete;
+      checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+      expect(checkboxElement).not.to.be.null;
+    };
+
+    const pharosLink = component.renderRoot.querySelector('pharos-link');
+    component.addEventListener('pharos-image-card-image-mouseenter', onMouseEnter);
+    pharosLink?.dispatchEvent(new MouseEvent('mouseenter'));
+  });
+
   it('dispatches the mouseleave event on pharos link mouseleave', async () => {
     component = await fixture(html`<pharos-image-card link="#">
       <img
@@ -304,6 +449,81 @@ describe('pharos-image-card', () => {
     pharosLink?.dispatchEvent(new Event('mouseleave'));
 
     expect(hovered).to.be.false;
+  });
+
+  it('dispatches pharos-image-card-selected when the title of the select variant is clicked', async () => {
+    component = await fixture(html`<pharos-image-card variant="selectable" link="#">
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="overlay">Card overlay</div>
+    </pharos-image-card>`);
+
+    const title: PharosLink | null = component.renderRoot.querySelector(
+      'pharos-link.card__link--title'
+    );
+
+    let selected = false;
+    const onSelectCard = (): void => {
+      selected = true;
+    };
+    component.addEventListener('pharos-image-card-selected', onSelectCard);
+    title?.click();
+    await aTimeout(100);
+    await elementUpdated(component);
+    expect(selected).to.be.true;
+  });
+
+  it('dispatches pharos-image-card-selected when the thumbnail of the select variant is clicked', async () => {
+    component = await fixture(html`<pharos-image-card variant="selectable" link="#">
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="overlay">Card overlay</div>
+    </pharos-image-card>`);
+
+    const title: PharosLink | null = component.renderRoot.querySelector(
+      'pharos-link.card__link--image'
+    );
+
+    let selected = false;
+    const onSelectCard = (): void => {
+      selected = true;
+    };
+    component.addEventListener('pharos-image-card-selected', onSelectCard);
+    title?.click();
+    await aTimeout(100);
+    await elementUpdated(component);
+    expect(selected).to.be.true;
+  });
+
+  it('does not dispatch pharos-image-card-selected when the title of the select variant is clicked in subtle-select mode', async () => {
+    component = await fixture(html`<pharos-image-card variant="selectable" subtle-select link="#">
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <div slot="overlay">Card overlay</div>
+    </pharos-image-card>`);
+
+    const title: PharosLink | null = component.renderRoot.querySelector(
+      'pharos-link.card__link--image'
+    );
+
+    let selected = false;
+    const onSelectCard = (): void => {
+      selected = true;
+    };
+    component.addEventListener('pharos-image-card-selected', onSelectCard);
+    title?.click();
+    await aTimeout(100);
+    await elementUpdated(component);
+    expect(selected).to.be.false;
   });
 
   it('renders the overlay slot content', async () => {

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -1,5 +1,6 @@
 import { PharosElement } from '../base/pharos-element';
 import { html, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { state } from 'lit/decorators.js';
 import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -195,7 +196,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderBaseImage(): TemplateResult {
     return html`<pharos-link
-      class="card__link--image"
+      class=${classMap({
+        [`card__link--image`]: true,
+        [`card__selected`]: this._isSelectHover(),
+      })}
       href="${this.link}"
       label=${ifDefined(this.imageLinkLabel)}
       subtle
@@ -269,8 +273,13 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     </div>`;
   }
 
+  private _isSelectHover(): boolean {
+    console.log('HOV: ', Boolean(this.selectable && this._isHovered));
+    return Boolean(this.selectable && this._isHovered);
+  }
+
   private _renderCheckbox(): TemplateResult | typeof nothing {
-    return this.selectable && this._isHovered
+    return this._isSelectHover()
       ? html`<pharos-checkbox class="card__selector"></pharos-checkbox>`
       : nothing;
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -115,7 +115,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   public headingLevel?: HeadingLevel;
 
   /**
-   * Indicates subtler styling for the selectable card variant and that the card is only selectable by click on the checkbox.
+   * Indicates subtler styling for the selectable card variant and that the card is only selectable by clicking on the checkbox.
    * @attr subtle-select
    */
   @property({ type: Boolean, reflect: true, attribute: 'subtle-select' })
@@ -136,7 +136,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   public disabled = false;
 
   @state()
-  private _isHovered = false;
+  private _isSelectableHovered = false;
 
   @query('.card__link--title')
   private _title!: PharosLink;
@@ -160,15 +160,13 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       !this.variant.includes('selectable')
     ) {
       throw new Error(
-        `${this.variant} is not a valid variant to use with subtle-select. Only the selectable variant can be used with subtle-select.}`
+        `${this.variant} is not a valid variant to use with subtle-select. Only the selectable variants can be used with subtle-select.}`
       );
     }
 
     if (this.selected && this.variant.includes('selectable')) {
       throw new Error(
-        `Image card with variant type ${
-          this.variant ? this.variant : 'base'
-        } cannot be selected. Only the selectable variant can be selected.}`
+        `Image card with variant type ${this.variant} cannot be selected. Only the selectable variants can be selected.}`
       );
     }
   }
@@ -195,15 +193,14 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
     const mouseEvent = new CustomEvent('pharos-image-card-image-mouseleave');
     this.dispatchEvent(mouseEvent);
-    this._renderCheckbox();
   }
 
   private _handleMouseEnterSelectable(): void {
-    this._isHovered = true;
+    this._isSelectableHovered = true;
   }
 
   private _handleMouseLeaveSelectable(): void {
-    this._isHovered = false;
+    this._isSelectableHovered = false;
   }
 
   private _renderCollectionImage(): TemplateResult {
@@ -289,7 +286,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       >${this.title
         ? html`<pharos-heading
             class="card__heading"
-            })}
             preset="${this._chooseHeadingPreset()}"
             level="${this.headingLevel || DEFAULT_HEADING_LEVEL}"
             no-margin
@@ -360,12 +356,15 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _isSubtleSelectHover(): boolean {
     return Boolean(
-      this.variant.includes('selectable') && this._isHovered && this.subtleSelect && !this.disabled
+      this.variant.includes('selectable') &&
+        this._isSelectableHovered &&
+        this.subtleSelect &&
+        !this.disabled
     );
   }
 
   private _isSelectableCardHover(): boolean {
-    return Boolean(this._isSelectableViaCard() && this._isHovered);
+    return Boolean(this._isSelectableViaCard() && this._isSelectableHovered);
   }
 
   private _isSelectableViaCard(): boolean {
@@ -373,11 +372,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
-    console.log('--START--');
-    console.log('variant: ', this.variant);
-    console.log('disabled: ', this.disabled);
-    console.log('this._isSelectableViaCard(): ', this._isSelectableViaCard());
-    console.log('--END----');
     return this._isSubtleSelectHover() || this._isSelectableViaCard() || this._isSelected
       ? html`<pharos-checkbox
           class="card__checkbox"

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -110,30 +110,21 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   public headingLevel?: HeadingLevel;
 
   /**
-   * Indicates the link should not have text decoration by default.
+   * Indicates the subtle styling and hover behavior of a selectable  image card
    * @attr subtle-select
    */
   @property({ type: Boolean, reflect: true, attribute: 'subtle-select' })
   public subtleSelect?: boolean;
 
-  // /**
-  //  * Indicates if the image can be selected
-  //  * @attr selectable
-  //  */
-  // @property({ type: String, reflect: true, attribute: 'selectable' })
-  // public selectable?: string;
-
-  @state()
-  private _isHovered = false;
-
-  // @state()
-  // private _isSelected = false;
   /**
    * Indicates if the image card is selected
    * @attr selected
    */
   @property({ type: Boolean, reflect: true, attribute: 'selected' })
   public _isSelected = false;
+
+  @state()
+  private _isHovered = false;
 
   @query('.card__link--title')
   private _title!: PharosLink;
@@ -232,9 +223,9 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return html`<pharos-link
       class=${classMap({
         [`card__link--image`]: true,
-        [`card__selectable`]: this._isSubtleSelectHover() || this._isStronglySelectable(),
+        [`card__selectable`]: this._isSubtleSelectHover() || this._isSelectableViaCard(),
         [`card__selected`]: this._isSelected,
-        [`card__strong-selectable-hover`]: this._isStrongSelectHover(),
+        [`card__selectable-card-hover`]: this._isSelectableCardHover(),
       })}
       href="${this.link}"
       label=${ifDefined(this.imageLinkLabel)}
@@ -323,7 +314,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _cardToggleSelect(event: Event): void {
-    if (this._isStronglySelectable() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX') {
+    if (this._isSelectableViaCard() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX') {
       // this is required to prevent navigation on the link click
       event.preventDefault();
       this._isSelected = !this._isSelected;
@@ -344,16 +335,16 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return Boolean(this.variant == 'selectable' && this._isHovered && this.subtleSelect);
   }
 
-  private _isStrongSelectHover(): boolean {
-    return Boolean(this._isStronglySelectable() && this._isHovered);
+  private _isSelectableCardHover(): boolean {
+    return Boolean(this._isSelectableViaCard() && this._isHovered);
   }
 
-  private _isStronglySelectable(): boolean {
+  private _isSelectableViaCard(): boolean {
     return Boolean(this.variant == 'selectable' && !this.subtleSelect);
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
-    return this._isSubtleSelectHover() || this._isStronglySelectable()
+    return this._isSubtleSelectHover() || this._isSelectableViaCard()
       ? html`<pharos-checkbox
           class="card__selector"
           ?checked=${this._isSelected}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -1,5 +1,6 @@
 import { PharosElement } from '../base/pharos-element';
 import { html, nothing } from 'lit';
+import { state } from 'lit/decorators.js';
 import { property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit';
@@ -15,6 +16,7 @@ import { PharosHeading } from '../heading/pharos-heading';
 import { PharosLink } from '../link/pharos-link';
 import { PharosIcon } from '../icon/pharos-icon';
 import { PharosButton } from '../button/pharos-button';
+import { PharosCheckbox } from '../checkbox/pharos-checkbox';
 
 export type ImageCardVariant = 'base' | 'collection' | 'promotional';
 
@@ -39,6 +41,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     'pharos-link': PharosLink,
     'pharos-icon': PharosIcon,
     'pharos-button': PharosButton,
+    'pharos-checkbox': PharosCheckbox,
   };
 
   /**
@@ -105,6 +108,16 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   @property({ type: Number, reflect: true, attribute: 'heading-level' })
   public headingLevel?: HeadingLevel;
 
+  /**
+   * Indicates if the image can be selected
+   * @attr selectable
+   */
+  @property({ type: String, reflect: true, attribute: 'selectable' })
+  public selectable?: string;
+
+  @state()
+  private _isHovered = false;
+
   @query('.card__link--title')
   private _title!: PharosLink;
 
@@ -131,17 +144,22 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _handleImageMouseEnter(): void {
+    console.log('ENTER');
     this._title['_hover'] = true;
+    this._isHovered = true;
 
     const mouseEvent = new CustomEvent('pharos-image-card-image-mouseenter');
     this.dispatchEvent(mouseEvent);
   }
 
   private _handleImageMouseLeave(): void {
+    console.log('EXIT');
     this._title['_hover'] = false;
+    this._isHovered = false;
 
     const mouseEvent = new CustomEvent('pharos-image-card-image-mouseleave');
     this.dispatchEvent(mouseEvent);
+    this._renderCheckbox();
   }
 
   private _renderCollectionImage(): TemplateResult {
@@ -245,9 +263,15 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   protected override render(): TemplateResult {
     return html`<div class="card">
-      ${this._renderImage()} ${this._renderSourceType()}
+      ${this._renderCheckbox()} ${this._renderImage()} ${this._renderSourceType()}
       <div class="card__title">${this.renderTitle} ${this._renderActionButton()}</div>
       ${this._renderMetadata()}
     </div>`;
+  }
+
+  private _renderCheckbox(): TemplateResult | typeof nothing {
+    return this.selectable && this._isHovered
+      ? html`<pharos-checkbox class="card__selector"></pharos-checkbox>`
+      : nothing;
   }
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -251,9 +251,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return html`<pharos-link
       class=${classMap({
         [`card__link--image`]: true,
-        [`card__selectable`]: this._isSubtleSelectHover() || this._isSelectableViaCard(),
+        [`card__selectable`]:
+          (this._isSubtleSelectHover() || this._isSelectableViaCard()) && !this._isSelected,
         [`card__selected`]: this._isSelected,
-        [`card__selectable-card-hover`]: this._isSelectableCardHover(),
+        [`card__selectable-card-hover`]: this._isSelectableCardHover() && !this._isSelected,
       })}
       href="${this.link}"
       label=${ifDefined(this.imageLinkLabel)}
@@ -375,15 +376,21 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isSelectableCardHover(): boolean {
-    return Boolean(this._isSelectableViaCard() && this._isSelectableHovered);
+    return Boolean(this._isSelectableViaCard() && this._isSelectableHovered) && !this.disabled;
   }
 
   private _isSelectableViaCard(): boolean {
-    return Boolean(this.variant.includes('selectable') && !this.subtleSelect);
+    return Boolean(
+      (this.variant.includes('selectable') && !this.subtleSelect && !this.disabled) ||
+        (this.disabled && this.variant.includes('selectable'))
+    );
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
-    return this._isSubtleSelectHover() || this._isSelectableViaCard() || this._isSelected
+    return this._isSubtleSelectHover() ||
+      this._isSelectableViaCard() ||
+      this._isSelected ||
+      (this.disabled && this.variant.includes('selectable'))
       ? html`<pharos-checkbox
           class="card__checkbox"
           hide-label="true"

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -180,19 +180,22 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _handleImageMouseEnter(): void {
-    this._title['_hover'] = true;
-    this._handleMouseEnterSelectable();
-
-    const mouseEvent = new CustomEvent('pharos-image-card-image-mouseenter');
-    this.dispatchEvent(mouseEvent);
+    if (!this.disabled) {
+      this._title['_hover'] = true;
+      this._handleMouseEnterSelectable();
+      const mouseEvent = new CustomEvent('pharos-image-card-image-mouseenter');
+      this.dispatchEvent(mouseEvent);
+    }
   }
 
   private _handleImageMouseLeave(): void {
-    this._title['_hover'] = false;
-    this._handleMouseLeaveSelectable();
+    if (!this.disabled) {
+      this._title['_hover'] = false;
+      this._handleMouseLeaveSelectable();
 
-    const mouseEvent = new CustomEvent('pharos-image-card-image-mouseleave');
-    this.dispatchEvent(mouseEvent);
+      const mouseEvent = new CustomEvent('pharos-image-card-image-mouseleave');
+      this.dispatchEvent(mouseEvent);
+    }
   }
 
   private _handleMouseEnterSelectable(): void {
@@ -342,7 +345,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _cardToggleSelect(event: Event): void {
-    if (this._isSelectableViaCard() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX') {
+    if (
+      !this.disabled &&
+      (this._isSelectableViaCard() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX')
+    ) {
       // this is required to prevent navigation on the link click
       event.preventDefault();
       this._isSelected = !this._isSelected;

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -128,6 +128,13 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   @property({ type: Boolean, reflect: true, attribute: 'selected' })
   public _isSelected = false;
 
+  /**
+   * Indicates if the image card is in a disabled state
+   * @attr selected
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'disabled' })
+  public disabled = false;
+
   @state()
   private _isHovered = false;
 
@@ -278,15 +285,11 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   protected get renderTitle(): TemplateResult {
-    return html`<pharos-link
-      class="card__link--title"
-      href="${this.link}"
-      @click=${this._cardToggleSelect}
-      subtle
-      flex
+    return html`<pharos-link class="card__link--title" href="${this.link}" subtle flex
       >${this.title
         ? html`<pharos-heading
             class="card__heading"
+            })}
             preset="${this._chooseHeadingPreset()}"
             level="${this.headingLevel || DEFAULT_HEADING_LEVEL}"
             no-margin
@@ -356,7 +359,9 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isSubtleSelectHover(): boolean {
-    return Boolean(this.variant.includes('selectable') && this._isHovered && this.subtleSelect);
+    return Boolean(
+      this.variant.includes('selectable') && this._isHovered && this.subtleSelect && !this.disabled
+    );
   }
 
   private _isSelectableCardHover(): boolean {
@@ -368,10 +373,16 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
+    console.log('--START--');
+    console.log('variant: ', this.variant);
+    console.log('disabled: ', this.disabled);
+    console.log('this._isSelectableViaCard(): ', this._isSelectableViaCard());
+    console.log('--END----');
     return this._isSubtleSelectHover() || this._isSelectableViaCard() || this._isSelected
       ? html`<pharos-checkbox
           class="card__checkbox"
           ?checked=${this._isSelected}
+          ?disabled=${this.disabled}
           @mouseenter=${this._handleMouseEnterSelectable}
           @mouseleave=${this._handleMouseLeaveSelectable}
           @click="${this._cardToggleSelect}"

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -19,9 +19,9 @@ import { PharosIcon } from '../icon/pharos-icon';
 import { PharosButton } from '../button/pharos-button';
 import { PharosCheckbox } from '../checkbox/pharos-checkbox';
 
-export type ImageCardVariant = 'base' | 'collection' | 'promotional';
+export type ImageCardVariant = 'base' | 'collection' | 'promotional' | 'selectable';
 
-const VARIANTS = ['base', 'collection', 'promotional'];
+const VARIANTS = ['base', 'collection', 'promotional', 'selectable'];
 
 const DEFAULT_HEADING_LEVEL = 3;
 
@@ -110,11 +110,11 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   public headingLevel?: HeadingLevel;
 
   /**
-   * Indicates if the image can be selected
-   * @attr selectable
+   * Indicates the link should not have text decoration by default.
+   * @attr subtleselect
    */
-  @property({ type: String, reflect: true, attribute: 'selectable' })
-  public selectable?: string;
+  @property({ type: Boolean, reflect: true })
+  public subtleselect?: Boolean;
 
   @state()
   private _isHovered = false;
@@ -203,10 +203,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   private _renderBaseImage(): TemplateResult {
     return html`<pharos-link
       class=${classMap({
-        [`card__link--image`]: true,
-        [`card__selectable`]: this._isSelectHover(),
-        [`card__selected`]: this._isSelected,
-      })}
+      [`card__link--image`]: true,
+      [`card__selectable`]: this._isSelectHover(),
+      [`card__selected`]: this._isSelected,
+    })}
       href="${this.link}"
       label=${ifDefined(this.imageLinkLabel)}
       subtle
@@ -228,6 +228,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       collection: '2',
       promotional: '4',
       base: '1--bold',
+      selectable: '1--bold',
     }[this.variant] as HeadingPreset;
   }
 
@@ -281,7 +282,8 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isSelectHover(): boolean {
-    return Boolean(this.selectable && this._isHovered);
+    console.log("subtleselect: ", this.subtleselect);
+    return Boolean(this.variant == "selectable" && this._isHovered && this.subtleselect);
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -221,7 +221,13 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderLinkContent(): TemplateResult {
     return this.error
-      ? html`<div class="card__container--error">
+      ? html`<div
+          class=${classMap({
+            [`card__container--error`]: true,
+            [`card__container-selected--error`]: this._isSelected,
+            [`card__container-selectable-hover--error`]: this._isSelectableCardHover(),
+          })}
+        >
           <pharos-icon name="exclamation-inverse"></pharos-icon>
           <span class="unavailable-text">Preview not available</span>
         </div>`
@@ -360,11 +366,11 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isSelectableViaCard(): boolean {
-    return Boolean(this.variant == 'selectable' && !this.subtleSelect);
+    return Boolean(this.variant.includes('selectable') && !this.subtleSelect);
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
-    return this._isSubtleSelectHover() || this._isSelectableViaCard()
+    return this._isSubtleSelectHover() || this._isSelectableViaCard() || this._isSelected
       ? html`<pharos-checkbox
           class="card__selector"
           ?checked=${this._isSelected}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -203,7 +203,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return html`<pharos-link
       class=${classMap({
         [`card__link--collection`]: true,
-        [`card__selectable`]: this._isSubtleSelectHover() || this._isSelectableViaCard(),
         [`card__selected`]: this._isSelected,
         [`card__selectable-card-hover`]: this._isSelectableCardHover(),
       })}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -110,7 +110,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   public headingLevel?: HeadingLevel;
 
   /**
-   * Indicates the subtle styling and hover behavior of a selectable  image card
+   * Indicates subtler styling for the selectable card variant and that the card is only selectable by click on the checkbox.
    * @attr subtle-select
    */
   @property({ type: Boolean, reflect: true, attribute: 'subtle-select' })
@@ -143,14 +143,20 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     }
 
     if (
-      changedProperties.has('variant') &&
-      this.variant &&
       changedProperties.has('subtleSelect') &&
       this.subtleSelect &&
       this.variant !== 'selectable'
     ) {
       throw new Error(
-        `${this.variant} is not a valid variant to use with subtle-select. Only the selectable variant can be used with subtle-select}`
+        `${this.variant} is not a valid variant to use with subtle-select. Only the selectable variant can be used with subtle-select.}`
+      );
+    }
+
+    if (this.selected && this.variant !== 'selectable') {
+      throw new Error(
+        `Image card with variant type ${
+          this.variant ? this.variant : 'base'
+        } cannot be selected. Only the selectable variant can be selected.}`
       );
     }
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -119,6 +119,9 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   @state()
   private _isHovered = false;
 
+  @state()
+  private _isSelected = false;
+
   @query('.card__link--title')
   private _title!: PharosLink;
 
@@ -144,8 +147,12 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     menu?.openWithTrigger(trigger);
   }
 
+  private _handleCheckboxClick(e: MouseEvent): void {
+    e.preventDefault();
+    this._isSelected = !this._isSelected;
+  }
+
   private _handleImageMouseEnter(): void {
-    console.log('ENTER');
     this._title['_hover'] = true;
     this._isHovered = true;
 
@@ -154,7 +161,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _handleImageMouseLeave(): void {
-    console.log('EXIT');
     this._title['_hover'] = false;
     this._isHovered = false;
 
@@ -198,7 +204,8 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return html`<pharos-link
       class=${classMap({
         [`card__link--image`]: true,
-        [`card__selected`]: this._isSelectHover(),
+        [`card__selectable`]: this._isSelectHover(),
+        [`card__selected`]: this._isSelected,
       })}
       href="${this.link}"
       label=${ifDefined(this.imageLinkLabel)}
@@ -274,13 +281,18 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isSelectHover(): boolean {
-    console.log('HOV: ', Boolean(this.selectable && this._isHovered));
     return Boolean(this.selectable && this._isHovered);
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
     return this._isSelectHover()
-      ? html`<pharos-checkbox class="card__selector"></pharos-checkbox>`
+      ? html`<pharos-checkbox
+          class="card__selector"
+          ?checked=${this._isSelected}
+          @mouseenter=${this._handleImageMouseEnter}
+          @mouseleave=${this._handleImageMouseLeave}
+          @click=${this._handleCheckboxClick}
+        ></pharos-checkbox>`
       : nothing;
   }
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -210,7 +210,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return html`<pharos-link
       class=${classMap({
         [`card__link--collection`]: true,
-        [`card__selected`]: this._isSelected,
+        [`card__link--selected`]: this._isSelected,
       })}
       href="${this.link}"
       label="${ifDefined(this.imageLinkLabel)}"
@@ -253,7 +253,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
         [`card__link--image`]: true,
         [`card__link--selectable`]:
           (this._isSubtleSelectHover() || this._isSelectableViaCard()) && !this._isSelected,
-        [`card__selected`]: this._isSelected,
+        [`card__link--selected`]: this._isSelected,
         [`card__link--select-hover`]: this._isSelectableCardHover() && !this._isSelected,
       })}
       href="${this.link}"

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -111,10 +111,11 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   /**
    * Indicates the link should not have text decoration by default.
-   * @attr subtleselect
+   * @attr subtle-select
    */
-  @property({ type: Boolean, reflect: true })
-  public subtleselect?: boolean;
+  @property({ type: Boolean, reflect: true, attribute: 'subtle-select' })
+  public subtleSelect?: boolean;
+
   // /**
   //  * Indicates if the image can be selected
   //  * @attr selectable
@@ -149,6 +150,18 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
         `${this.variant} is not a valid variant. Valid variants are: ${VARIANTS.join(', ')}`
       );
     }
+
+    if (
+      changedProperties.has('variant') &&
+      this.variant &&
+      changedProperties.has('subtleSelect') &&
+      this.subtleSelect &&
+      this.variant !== 'selectable'
+    ) {
+      throw new Error(
+        `${this.variant} is not a valid variant to use with subtle-select. Only the selectable variant can be used with subtle-select}`
+      );
+    }
   }
 
   private _handleClick(e: MouseEvent): void {
@@ -158,11 +171,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     );
     menu?.openWithTrigger(trigger);
   }
-
-  // private _handleCheckboxClick(e: MouseEvent): void {
-  //   e.preventDefault();
-  //   this._isSelected = !this._isSelected;
-  // }
 
   private _handleImageMouseEnter(): void {
     this._title['_hover'] = true;
@@ -235,7 +243,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       no-hover
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
-      @click=${this._cardSelected}
+      @click=${this._cardToggleSelect}
       >${this._renderLinkContent()}${this._renderHoverMetadata()} <slot name="overlay"></slot
     ></pharos-link>`;
   }
@@ -258,7 +266,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return html`<pharos-link
       class="card__link--title"
       href="${this.link}"
-      @click=${this._cardSelected}
+      @click=${this._cardToggleSelect}
       subtle
       flex
       >${this.title
@@ -314,11 +322,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     </div>`;
   }
 
-  private _cardSelected(event: Event): void {
+  private _cardToggleSelect(event: Event): void {
     if (this._isStronglySelectable() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX') {
       // this is required to prevent navigation on the link click
       event.preventDefault();
-      console.log('should fire event');
       this._isSelected = !this._isSelected;
       this.dispatchEvent(
         new CustomEvent('pharos-image-card-selected', {
@@ -334,7 +341,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isSubtleSelectHover(): boolean {
-    return Boolean(this.variant == 'selectable' && this._isHovered && this.subtleselect);
+    return Boolean(this.variant == 'selectable' && this._isHovered && this.subtleSelect);
   }
 
   private _isStrongSelectHover(): boolean {
@@ -342,7 +349,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isStronglySelectable(): boolean {
-    return Boolean(this.variant == 'selectable' && !this.subtleselect);
+    return Boolean(this.variant == 'selectable' && !this.subtleSelect);
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
@@ -352,7 +359,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
           ?checked=${this._isSelected}
           @mouseenter=${this._handleMouseEnterSelectable}
           @mouseleave=${this._handleMouseLeaveSelectable}
-          @click="${this._cardSelected}"
+          @click="${this._cardToggleSelect}"
         ></pharos-checkbox>`
       : nothing;
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -204,7 +204,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       class=${classMap({
         [`card__link--collection`]: true,
         [`card__selected`]: this._isSelected,
-        [`card__selectable-card-hover`]: this._isSelectableCardHover(),
       })}
       href="${this.link}"
       label="${ifDefined(this.imageLinkLabel)}"

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -282,7 +282,12 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   protected get renderTitle(): TemplateResult {
-    return html`<pharos-link class="card__link--title" href="${this.link}" subtle flex
+    return html`<pharos-link
+      class="card__link--title"
+      href="${this.link}"
+      subtle
+      flex
+      @click=${this._cardToggleSelect}
       >${this.title
         ? html`<pharos-heading
             class="card__heading"
@@ -375,12 +380,15 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return this._isSubtleSelectHover() || this._isSelectableViaCard() || this._isSelected
       ? html`<pharos-checkbox
           class="card__checkbox"
+          hide-label="true"
           ?checked=${this._isSelected}
           ?disabled=${this.disabled}
+          name="Select ${this.title}"
           @mouseenter=${this._handleMouseEnterSelectable}
           @mouseleave=${this._handleMouseLeaveSelectable}
           @click="${this._cardToggleSelect}"
-        ></pharos-checkbox>`
+          ><span slot="label">Select ${this.title}</span></pharos-checkbox
+        >`
       : nothing;
   }
 }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -157,7 +157,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       );
     }
 
-    if (this.selected && this.variant !== 'selectable') {
+    if (this.selected && this.variant.includes('selectable')) {
       throw new Error(
         `Image card with variant type ${
           this.variant ? this.variant : 'base'
@@ -370,7 +370,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   private _renderCheckbox(): TemplateResult | typeof nothing {
     return this._isSubtleSelectHover() || this._isSelectableViaCard() || this._isSelected
       ? html`<pharos-checkbox
-          class="card__selector"
+          class="card__checkbox"
           ?checked=${this._isSelected}
           @mouseenter=${this._handleMouseEnterSelectable}
           @mouseleave=${this._handleMouseLeaveSelectable}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -19,9 +19,14 @@ import { PharosIcon } from '../icon/pharos-icon';
 import { PharosButton } from '../button/pharos-button';
 import { PharosCheckbox } from '../checkbox/pharos-checkbox';
 
-export type ImageCardVariant = 'base' | 'collection' | 'promotional' | 'selectable';
+export type ImageCardVariant =
+  | 'base'
+  | 'collection'
+  | 'promotional'
+  | 'selectable'
+  | 'selectable-collection';
 
-const VARIANTS = ['base', 'collection', 'promotional', 'selectable'];
+const VARIANTS = ['base', 'collection', 'promotional', 'selectable', 'selectable-collection'];
 
 const DEFAULT_HEADING_LEVEL = 3;
 
@@ -145,7 +150,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     if (
       changedProperties.has('subtleSelect') &&
       this.subtleSelect &&
-      this.variant !== 'selectable'
+      !this.variant.includes('selectable')
     ) {
       throw new Error(
         `${this.variant} is not a valid variant to use with subtle-select. Only the selectable variant can be used with subtle-select.}`
@@ -196,7 +201,12 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderCollectionImage(): TemplateResult {
     return html`<pharos-link
-      class="card__link--collection"
+      class=${classMap({
+        [`card__link--collection`]: true,
+        [`card__selectable`]: this._isSubtleSelectHover() || this._isSelectableViaCard(),
+        [`card__selected`]: this._isSelected,
+        [`card__selectable-card-hover`]: this._isSelectableCardHover(),
+      })}
       href="${this.link}"
       label="${ifDefined(this.imageLinkLabel)}"
       subtle
@@ -204,6 +214,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       no-hover
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
+      @click=${this._cardToggleSelect}
       ><svg class="card__svg" role="presentation" viewBox="0 0 4 3"></svg> <slot name="image"></slot
     ></pharos-link>`;
   }
@@ -247,12 +258,15 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderImage(): TemplateResult {
     // TODO: Refactor with _renderCollectionImage and _renderBaseImage when Playwright/Webkit is updated
-    return this.variant === 'collection' ? this._renderCollectionImage() : this._renderBaseImage();
+    return this.variant.includes('collection')
+      ? this._renderCollectionImage()
+      : this._renderBaseImage();
   }
 
   private _chooseHeadingPreset(): HeadingPreset {
     return {
       collection: '2',
+      'selectable-collection': '2',
       promotional: '4',
       base: '1--bold',
       selectable: '1--bold',
@@ -338,7 +352,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _isSubtleSelectHover(): boolean {
-    return Boolean(this.variant == 'selectable' && this._isHovered && this.subtleSelect);
+    return Boolean(this.variant.includes('selectable') && this._isHovered && this.subtleSelect);
   }
 
   private _isSelectableCardHover(): boolean {

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -229,8 +229,8 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       ? html`<div
           class=${classMap({
             [`card__container--error`]: true,
-            [`card__container-selected--error`]: this._isSelected,
-            [`card__container-selectable-hover--error`]: this._isSelectableCardHover(),
+            [`card__container--selected`]: this._isSelected,
+            [`card__container--selectable-hover`]: this._isSelectableCardHover(),
           })}
         >
           <pharos-icon name="exclamation-inverse"></pharos-icon>
@@ -251,10 +251,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return html`<pharos-link
       class=${classMap({
         [`card__link--image`]: true,
-        [`card__selectable`]:
+        [`card__link--selectable`]:
           (this._isSubtleSelectHover() || this._isSelectableViaCard()) && !this._isSelected,
         [`card__selected`]: this._isSelected,
-        [`card__selectable-card-hover`]: this._isSelectableCardHover() && !this._isSelected,
+        [`card__link--select-hover`]: this._isSelectableCardHover() && !this._isSelected,
       })}
       href="${this.link}"
       label=${ifDefined(this.imageLinkLabel)}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -382,7 +382,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   private _isSelectableViaCard(): boolean {
     return Boolean(
       (this.variant.includes('selectable') && !this.subtleSelect && !this.disabled) ||
-        (this.disabled && this.variant.includes('selectable'))
+        (this.subtleSelect && this._isSelected && !this.disabled)
     );
   }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -128,7 +128,7 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
     return html`<li style="grid-column: span 2">
       <pharos-image-card
         id="card-${index}"
-        title="Card Title"
+        title="Select Me!"
         link="#"
         source-type="Image"
         variant="selectable"

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -290,6 +290,7 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
         link="https://www.jstor.org/stable/10.2307/community.26220188"
         variant="selectable"
         subtle-select
+        error="true"
         style="grid-column: span 2"
       >
         <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -123,10 +123,17 @@ export const PromotionalTemplate = () => html`<pharos-layout style="margin: 1rem
   </div>
 </pharos-layout>`;
 
-export const SelectableTemplate = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
+export const Bruh = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
   ${items.map((item, index) => {
     return html`<li style="grid-column: span 2">
-      <pharos-image-card id="card-${index}" title="Card Title" link="#" source-type="Image">
+      <pharos-image-card
+        id="card-${index}"
+        title="Card Title"
+        link="#"
+        source-type="Image"
+        variant="selectable"
+        subtleselect
+      >
         <img
           id="image-${index}"
           src="./images/item-detail/${item.image}"
@@ -271,12 +278,19 @@ export const SelectableTemplate = () => html`<pharos-layout tag="ol" style="marg
 # Selectable
 
 <Canvas>
+  <Story name="bruh">{Bruh.bind({})}</Story>
+</Canvas>
+
+# Subtle Select
+
+<Canvas>
   <Story name="Selectable">
     {html`
       <pharos-image-card
         title="South Hall but you can select it"
         link="https://www.jstor.org/stable/10.2307/community.26220188"
-        selectable="True"
+        variant="selectable"
+        subtleselect
         style="grid-column: span 2"
       >
         <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
@@ -288,7 +302,7 @@ export const SelectableTemplate = () => html`<pharos-layout tag="ol" style="marg
             >Pratt Institute Buildings Image Collection</pharos-link
           >
         </div>
-      </pharos-image-card>
+      </pharos-image-card>  
     `}
   </Story>
 </Canvas>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -123,7 +123,7 @@ export const PromotionalTemplate = () => html`<pharos-layout style="margin: 1rem
   </div>
 </pharos-layout>`;
 
-export const Bruh = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
+export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
   ${items.map((item, index) => {
     return html`<li style="grid-column: span 2">
       <pharos-image-card
@@ -277,19 +277,19 @@ export const Bruh = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
 # Selectable
 
 <Canvas>
-  <Story name="bruh">{Bruh.bind({})}</Story>
+  <Story name="Selectable">{Selectable.bind({})}</Story>
 </Canvas>
 
 # Subtle Select
 
 <Canvas>
-  <Story name="Selectable">
+  <Story name="Selectable (Subtle)">
     {html`
       <pharos-image-card
         title="South Hall but you can select it"
         link="https://www.jstor.org/stable/10.2307/community.26220188"
         variant="selectable"
-        subtleselect
+        subtle-select
         style="grid-column: span 2"
       >
         <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -316,7 +316,7 @@ export const SelectableCollectionsTemplate = () => html` <pharos-layout
   style="margin: 1rem 0"
 >
   <li class="image-card-example__card--collection">
-    <pharos-image-card title="Selectalbe" link="#" variant="selectable-collection">
+    <pharos-image-card title="Selectable" link="#" variant="selectable-collection">
       <img src="./images/item-detail/collection_1.png" slot="image" />
       <strong slot="metadata">50 items</strong>
       <div slot="metadata">Selections from the global permanent collection.</div>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -324,7 +324,6 @@ export const SelectableCollectionsTemplate = () => html`<pharos-layout
         title="${collection.title}"
         link="#"
         variant="selectable-collection"
-        subtle-select
       >
         <img
           id="image-${index}"

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -124,33 +124,58 @@ export const PromotionalTemplate = () => html`<pharos-layout style="margin: 1rem
 </pharos-layout>`;
 
 export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
-  ${items.map((item, index) => {
-    return html`<li style="grid-column: span 2">
-      <pharos-image-card
-        id="card-${index}"
-        title="Select Me!"
-        link="#"
-        source-type="Image"
-        variant="selectable"
-      >
-        <img
-          id="image-${index}"
-          src="./images/item-detail/${item.image}"
-          alt="Card Title ${index}"
-          slot="image"
-        />
-        <div id="creator-${index}" slot="metadata">Creator of the item</div>
-        <div id="item-date-${index}" slot="metadata">1990-2000</div>
-        <div id="collection-${index}" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >An Example Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    </li>`;
-  })}</pharos-layout
->`;
+  <li style="grid-column: span 3">
+    <pharos-image-card title="Selectable" link="#" source-type="Image" variant="selectable">
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+  <li style="grid-column: span 3">
+    <pharos-image-card
+      title="Subtle select"
+      link="#"
+      source-type="Image"
+      variant="selectable"
+      subtle-select="true"
+    >
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+  <li style="grid-column: span 3">
+    <pharos-image-card
+      title="Selected Disabled"
+      link="#"
+      source-type="Image"
+      variant="selectable"
+      disabled="true"
+      selected="true"
+    >
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+  <li style="grid-column: span 3">
+    <pharos-image-card
+      title="Selectable Error State"
+      link="#"
+      source-type="Image"
+      variant="selectable"
+      error="true"
+    >
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+  <li style="grid-column: span 3">
+    <pharos-image-card
+      title="Subtle Select Error State"
+      link="#"
+      source-type="Image"
+      variant="selectable"
+      error="true"
+      subtle-select="true"
+    >
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+</pharos-layout>`;
 
 <Canvas>
   <Story name="Base">{MultipleTemplate.bind({})}</Story>
@@ -280,519 +305,83 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
   <Story name="Selectable">{Selectable.bind({})}</Story>
 </Canvas>
 
-# Subtle Select Error
-
-<Canvas>
-  <Story name="Selectable (Subtle)">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="collection"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
 # Selectable Collection
 
 <Canvas>
   <Story name="Selectable Collection">{SelectableCollectionsTemplate.bind({})}</Story>
 </Canvas>
 
-export const SelectableCollectionsTemplate = () => html`<pharos-layout
+export const SelectableCollectionsTemplate = () => html` <pharos-layout
   tag="ol"
   style="margin: 1rem 0"
 >
-  ${collections.map((collection, index) => {
-    return html`<li class="image-card-example__card--collection">
-      <pharos-image-card
-        id="card-${index}"
-        title="${collection.title}"
-        link="#"
-        variant="selectable-collection"
-        subtle-select
-      >
-        <img
-          id="image-${index}"
-          src="./images/item-detail/${collection.image}"
-          alt="${collection.title}"
-          slot="image"
-        />
-        <strong id="items-${index}" slot="metadata">${collection.items} items</strong>
-        <div id="description-${index}" slot="metadata">
-          Selections from the global permanent collection.
-        </div>
-      </pharos-image-card>
-    </li>`;
-  })}</pharos-layout
->`;
+  <li class="image-card-example__card--collection">
+    <pharos-image-card title="Selectalbe" link="#" variant="selectable-collection">
+      <img src="./images/item-detail/collection_1.png" slot="image" />
+      <strong slot="metadata">50 items</strong>
+      <div slot="metadata">Selections from the global permanent collection.</div>
+    </pharos-image-card>
+  </li>
+  <li class="image-card-example__card--collection">
+    <pharos-image-card
+      title="Subtle Select"
+      link="#"
+      variant="selectable-collection"
+      subtle-select="true"
+    >
+      <img src="./images/item-detail/collection_2.png" slot="image" />
+      <strong slot="metadata">50 items</strong>
+      <div slot="metadata">Selections from the global permanent collection.</div>
+    </pharos-image-card>
+  </li>
+  <li class="image-card-example__card--collection">
+    <pharos-image-card
+      title="Selected Disabled"
+      link="#"
+      variant="selectable-collection"
+      disabled="true"
+      selected="true"
+    >
+      <img src="./images/item-detail/collection_2.png" slot="image" />
+      <strong slot="metadata">50 items</strong>
+      <div slot="metadata">Selections from the global permanent collection.</div>
+    </pharos-image-card>
+  </li>
+</pharos-layout>`;
 
 # Disabled
 
 <Canvas>
-  <Story name="Disabled">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        disabled="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
+  <Story name="Disabled">{Disabled.bind({})}</Story>
 </Canvas>
 
-# Disabled Error
-
-<Canvas>
-  <Story name="Disabled Error">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        disabled="true"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable Disabled
-
-<Canvas>
-  <Story name="Selectable Disabled">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        disabled="true"
-        variant="selectable"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable Selected
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable Selected">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        selected="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable Error
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable Error">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable Subtle Select
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable Subtle Select ">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        subtle-select="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable disabled selected
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable disabled selected">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        disabled="true"
-        selected="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable disabled error
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable disabled error">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        disabled="true"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable disabled selected error subtle-select
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable disabled selected error subtle-select">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        disabled="true"
-        selected="true"
-        error="true"
-        subtle-select="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable disabled subtle-select Error
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable disabled subtle-select error">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        disabled="true"
-        subtle-select="true"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable disabled selected error
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable disabled  subtle-select">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        disabled="true"
-        selected="true"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable disabled selected subtle-select
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable disabled selected subtle-select">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        disabled="true"
-        selected="true"
-        subtle-select="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable selected error
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable selected error">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        selected="true"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable selected subtle-select
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable selected  subtle-select">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        selected="true"
-        subtle-select="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable selected error subtle-select
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable selected error subtle-select">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        selected="true"
-        error="true"
-        subtle-select="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
-# Selectable error subtle-select
-
-{' '}
-
-<Canvas>
-  <Story name="Selectable error subtle-select">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        error="true"
-        subtle-select="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
+export const Disabled = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
+  <li style="grid-column: span 3">
+    <pharos-image-card title="Disabled" link="#" source-type="Image" disabled="true">
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+  <li style="grid-column: span 3">
+    <pharos-image-card
+      title="Selectable Disabled"
+      link="#"
+      source-type="Image"
+      disabled="true"
+      variant="selectable"
+    >
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+  <li style="grid-column: span 3">
+    <pharos-image-card
+      title="Selected Disabled"
+      link="#"
+      source-type="Image"
+      variant="selectable"
+      disabled="true"
+      selected="true"
+    >
+      <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
+    </pharos-image-card>
+  </li>
+</pharos-layout>`;

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -305,3 +305,37 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
     `}
   </Story>
 </Canvas>
+
+# Selectable Collection
+
+<Canvas>
+  <Story name="Selectable Collection">{SelectableCollectionsTemplate.bind({})}</Story>
+</Canvas>
+
+export const SelectableCollectionsTemplate = () => html`<pharos-layout
+  tag="ol"
+  style="margin: 1rem 0"
+>
+  ${collections.map((collection, index) => {
+    return html`<li class="image-card-example__card--collection">
+      <pharos-image-card
+        id="card-${index}"
+        title="${collection.title}"
+        link="#"
+        variant="selectable-collection"
+        subtle-select
+      >
+        <img
+          id="image-${index}"
+          src="./images/item-detail/${collection.image}"
+          alt="${collection.title}"
+          slot="image"
+        />
+        <strong id="items-${index}" slot="metadata">${collection.items} items</strong>
+        <div id="description-${index}" slot="metadata">
+          Selections from the global permanent collection.
+        </div>
+      </pharos-image-card>
+    </li>`;
+  })}</pharos-layout
+>`;

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -280,7 +280,33 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
   <Story name="Selectable">{Selectable.bind({})}</Story>
 </Canvas>
 
-# Subtle Select
+# Select Error
+
+<Canvas>
+  <Story name="Selectable Error">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        error="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Subtle Select Error
 
 <Canvas>
   <Story name="Selectable (Subtle)">
@@ -324,6 +350,7 @@ export const SelectableCollectionsTemplate = () => html`<pharos-layout
         title="${collection.title}"
         link="#"
         variant="selectable-collection"
+        subtle-select
       >
         <img
           id="image-${index}"

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -123,6 +123,29 @@ export const PromotionalTemplate = () => html`<pharos-layout style="margin: 1rem
   </div>
 </pharos-layout>`;
 
+export const SelectableTemplate = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
+  ${items.map((item, index) => {
+    return html`<li style="grid-column: span 2">
+      <pharos-image-card id="card-${index}" title="Card Title" link="#" source-type="Image">
+        <img
+          id="image-${index}"
+          src="./images/item-detail/${item.image}"
+          alt="Card Title ${index}"
+          slot="image"
+        />
+        <div id="creator-${index}" slot="metadata">Creator of the item</div>
+        <div id="item-date-${index}" slot="metadata">1990-2000</div>
+        <div id="collection-${index}" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >An Example Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    </li>`;
+  })}</pharos-layout
+>`;
+
 <Canvas>
   <Story name="Base">{MultipleTemplate.bind({})}</Story>
 </Canvas>
@@ -243,4 +266,36 @@ export const PromotionalTemplate = () => html`<pharos-layout style="margin: 1rem
 
 <Canvas>
   <Story name="Promotional">{PromotionalTemplate.bind({})}</Story>
+</Canvas>
+
+# Selectable
+
+<Canvas>
+  <Story name="Selectable">
+    {html`
+      <pharos-layout ">
+        <pharos-image-card
+          title="South Hall but you can select it"
+          link="https://www.jstor.org/stable/10.2307/community.26220188"
+          selectable="True"
+          style="grid-column: span 2"
+        >
+          <img
+            id="image"
+            src="./images/item-detail/collection_5.png"
+            alt="south hall"
+            slot="image"
+          />
+          <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+          <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+          <div id="collection" slot="metadata">
+            Part of
+            <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+              >Pratt Institute Buildings Image Collection</pharos-link
+            >
+          </div>
+        </pharos-image-card>
+      </pharos-layout>
+    `}
+  </Story>
 </Canvas>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -132,7 +132,6 @@ export const Bruh = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
         link="#"
         source-type="Image"
         variant="selectable"
-        subtleselect
       >
         <img
           id="image-${index}"
@@ -302,7 +301,7 @@ export const Bruh = () => html`<pharos-layout tag="ol" style="margin: 1rem 0">
             >Pratt Institute Buildings Image Collection</pharos-link
           >
         </div>
-      </pharos-image-card>  
+      </pharos-image-card>
     `}
   </Story>
 </Canvas>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -317,7 +317,7 @@ export const SelectableCollectionsTemplate = () => html` <pharos-layout
 >
   <li class="image-card-example__card--collection">
     <pharos-image-card title="Selectable" link="#" variant="selectable-collection">
-      <img src="./images/item-detail/collection_1.png" slot="image" />
+      <img src="./images/item-detail/open_collection_1.png" slot="image" />
       <strong slot="metadata">50 items</strong>
       <div slot="metadata">Selections from the global permanent collection.</div>
     </pharos-image-card>
@@ -329,7 +329,7 @@ export const SelectableCollectionsTemplate = () => html` <pharos-layout
       variant="selectable-collection"
       subtle-select="true"
     >
-      <img src="./images/item-detail/collection_2.png" slot="image" />
+      <img src="./images/item-detail/open_collection_2.png" slot="image" />
       <strong slot="metadata">50 items</strong>
       <div slot="metadata">Selections from the global permanent collection.</div>
     </pharos-image-card>
@@ -342,7 +342,7 @@ export const SelectableCollectionsTemplate = () => html` <pharos-layout
       disabled="true"
       selected="true"
     >
-      <img src="./images/item-detail/collection_2.png" slot="image" />
+      <img src="./images/item-detail/open_collection_3.png" slot="image" />
       <strong slot="metadata">50 items</strong>
       <div slot="metadata">Selections from the global permanent collection.</div>
     </pharos-image-card>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -280,32 +280,6 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
   <Story name="Selectable">{Selectable.bind({})}</Story>
 </Canvas>
 
-# Select Error
-
-<Canvas>
-  <Story name="Selectable Error">
-    {html`
-      <pharos-image-card
-        title="South Hall but you can select it"
-        link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        error="true"
-        style="grid-column: span 2"
-      >
-        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
-        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-        <div id="collection" slot="metadata">
-          Part of
-          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-            >Pratt Institute Buildings Image Collection</pharos-link
-          >
-        </div>
-      </pharos-image-card>
-    `}
-  </Story>
-</Canvas>
-
 # Subtle Select Error
 
 <Canvas>
@@ -314,8 +288,7 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
       <pharos-image-card
         title="South Hall but you can select it"
         link="https://www.jstor.org/stable/10.2307/community.26220188"
-        variant="selectable"
-        subtle-select
+        variant="collection"
         error="true"
         style="grid-column: span 2"
       >
@@ -366,3 +339,460 @@ export const SelectableCollectionsTemplate = () => html`<pharos-layout
     </li>`;
   })}</pharos-layout
 >`;
+
+# Disabled
+
+<Canvas>
+  <Story name="Disabled">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        disabled="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Disabled Error
+
+<Canvas>
+  <Story name="Disabled Error">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        disabled="true"
+        error="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable Disabled
+
+<Canvas>
+  <Story name="Selectable Disabled">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        disabled="true"
+        variant="selectable"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable Selected
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable Selected">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        selected="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable Error
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable Error">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        error="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable Subtle Select
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable Subtle Select ">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        subtle-select="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable disabled selected
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable disabled selected">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        disabled="true"
+        selected="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable disabled error
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable disabled error">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        disabled="true"
+        error="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable disabled selected error subtle-select
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable disabled selected error subtle-select">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        disabled="true"
+        selected="true"
+        error="true"
+        subtle-select="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable disabled subtle-select Error
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable disabled subtle-select error">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        disabled="true"
+        subtle-select="true"
+        error="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable disabled selected error
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable disabled  subtle-select">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        disabled="true"
+        selected="true"
+        error="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable disabled selected subtle-select
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable disabled selected subtle-select">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        disabled="true"
+        selected="true"
+        subtle-select="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable selected error
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable selected error">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        selected="true"
+        error="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable selected subtle-select
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable selected  subtle-select">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        selected="true"
+        subtle-select="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable selected error subtle-select
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable selected error subtle-select">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        selected="true"
+        error="true"
+        subtle-select="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>
+
+# Selectable error subtle-select
+
+{' '}
+
+<Canvas>
+  <Story name="Selectable error subtle-select">
+    {html`
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        variant="selectable"
+        error="true"
+        subtle-select="true"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
+    `}
+  </Story>
+</Canvas>

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -273,29 +273,22 @@ export const SelectableTemplate = () => html`<pharos-layout tag="ol" style="marg
 <Canvas>
   <Story name="Selectable">
     {html`
-      <pharos-layout ">
-        <pharos-image-card
-          title="South Hall but you can select it"
-          link="https://www.jstor.org/stable/10.2307/community.26220188"
-          selectable="True"
-          style="grid-column: span 2"
-        >
-          <img
-            id="image"
-            src="./images/item-detail/collection_5.png"
-            alt="south hall"
-            slot="image"
-          />
-          <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
-          <div id="item-date" slot="metadata">1889-1892 (creation)</div>
-          <div id="collection" slot="metadata">
-            Part of
-            <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-              >Pratt Institute Buildings Image Collection</pharos-link
-            >
-          </div>
-        </pharos-image-card>
-      </pharos-layout>
+      <pharos-image-card
+        title="South Hall but you can select it"
+        link="https://www.jstor.org/stable/10.2307/community.26220188"
+        selectable="True"
+        style="grid-column: span 2"
+      >
+        <img id="image" src="./images/item-detail/collection_5.png" alt="south hall" slot="image" />
+        <div id="creator" slot="metadata">Tubby, William Bunker (American architect,...</div>
+        <div id="item-date" slot="metadata">1889-1892 (creation)</div>
+        <div id="collection" slot="metadata">
+          Part of
+          <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+            >Pratt Institute Buildings Image Collection</pharos-link
+          >
+        </div>
+      </pharos-image-card>
     `}
   </Story>
 </Canvas>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13091,9 +13091,9 @@ joycon@^3.0.1:
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
 jpeg-js@^0.4.0:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
-  integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
+  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
 
 js-levenshtein-esm@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
This PR adds three new features to the image card:

1. New `selectable` and `collection-selectable` image card variants. There is also a `subtle-select` prop that more discretely shows the card's selectability.
2. New image card 'disables' states
3. New styling for the error state

All three of these (and some of their combinations) are visible here:

<img width="672" alt="Screen Shot 2022-07-07 at 4 52 51 PM" src="https://user-images.githubusercontent.com/64924035/177869357-6e297b2d-0b3b-41dc-8be1-c28da4316d21.png">


**How does this change work?**

- Added new selectable variants to image card
- Added props for disabled and sublte-select
- Used variants and props to render checkbox
- Added onMouseEnter/Exit listeners to handle those events
- Use events, props, and classMap to use relevant classes for each variant's events


**Additional context**
Add any other context here.
