### PR TITLE
fix(build): always build if the compared commits are the same

### DIFF
--- a/build-ignore.sh
+++ b/build-ignore.sh
@@ -2,6 +2,11 @@
 
 echo "Checking for files changed between $CACHED_COMMIT_REF and $COMMIT_REF..."
 
+# Build if the compared commits are identical
+if [ "$CACHED_COMMIT_REF" == "$COMMIT_REF" ]; then
+  exit 0
+fi
+
 if [ "$SITE_NAME" == "pharos-storybooks" ]
 then
   git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF packages/pharos/ .storybook/ package.json yarn.lock netlify.toml


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**

The Pharos Storybooks haven't been built since 2022-03-31.

**How does this change work?**

In #370 we determined that the $CACHED_COMMIT_REF is sometimes the same as the $COMMIT_REF. In the absence of other understanding of why that would be, we can ensure we run the build when these two values are the same.