### PR TITLE
ImageCard: Use gray background on selectable disabled card

### DIFF
--- a/.changeset/small-beers-double.md
+++ b/.changeset/small-beers-double.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Add background color to selectable disabled card

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -252,7 +252,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       class=${classMap({
         [`card__link--image`]: true,
         [`card__link--selectable`]:
-          (this._isSubtleSelectHover() || this._isSelectableViaCard()) && !this._isSelected,
+          (this._isSubtleSelectHover() ||
+            this._isSelectableViaCard() ||
+            this._isDisabledSelectable()) &&
+          !this._isSelected,
         [`card__link--selected`]: this._isSelected,
         [`card__link--select-hover`]: this._isSelectableCardHover() && !this._isSelected,
       })}
@@ -384,6 +387,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       (this.variant.includes('selectable') && !this.subtleSelect && !this.disabled) ||
         (this.subtleSelect && this._isSelected && !this.disabled)
     );
+  }
+
+  private _isDisabledSelectable(): boolean {
+    return this.disabled && this.variant.includes('selectable');
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
I released the selectable and disabled image cards recently, but the styling for the selectable card variant in a disabled state is not showing as desired. Currently it lacks the background color of a selectable card. This change fixes that issue. 
<img width="194" alt="Screen Shot 2022-07-13 at 4 09 09 PM" src="https://user-images.githubusercontent.com/64924035/179018970-defac04b-b18f-44f3-b8c5-ea4bebe37f6f.png">

**How does this change work?**
Updated the criteria to use the selectable css class.

**Additional context**
Add any other context here.
