### PR TITLE
fix(card): restructure cards to avoid extra mouse events preventing selection in Safari

### DIFF
--- a/.changeset/beige-oranges-walk.md
+++ b/.changeset/beige-oranges-walk.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Restructure card dom and remove checkbox mouseevent listeners to enable subtle selection in Safari

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -16,6 +16,7 @@
   height: 14rem;
   justify-content: center;
   margin-bottom: var(--pharos-spacing-1-x);
+  width: 100%;
 }
 
 .card__link--image,

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -197,9 +197,9 @@ describe('pharos-image-card', () => {
 
   it('sets title link hover state when the card image link is hovered', async () => {
     const imageLink = component.renderRoot.querySelector('.card__link--image');
-    imageLink?.dispatchEvent(new Event('mouseenter'));
-    await component.updateComplete;
+    imageLink?.parentElement?.dispatchEvent(new Event('mouseenter'));
 
+    await component.updateComplete;
     expect(component['_title']['_hover']).to.be.true;
   });
 
@@ -216,7 +216,7 @@ describe('pharos-image-card', () => {
       <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
     </pharos-image-card>`);
     const imageLink = component.renderRoot.querySelector('.card__link--image');
-    imageLink?.dispatchEvent(new Event('mouseenter'));
+    imageLink?.parentElement?.dispatchEvent(new Event('mouseenter'));
 
     await component.updateComplete;
     expect(component['_title']['_hover']).to.be.false;
@@ -396,8 +396,8 @@ describe('pharos-image-card', () => {
     };
     component.addEventListener('pharos-image-card-image-mouseenter', onMouseEnter);
 
-    const pharosLink = component.renderRoot.querySelector('pharos-link');
-    pharosLink?.dispatchEvent(new MouseEvent('mouseenter'));
+    const imageLink = component.renderRoot.querySelector('.card__link--image');
+    imageLink?.parentElement?.dispatchEvent(new MouseEvent('mouseenter'));
 
     expect(hovered).to.be.true;
   });
@@ -436,8 +436,9 @@ describe('pharos-image-card', () => {
     </pharos-image-card>`);
 
     let checkboxElement = null;
-    const pharosLink = component.renderRoot.querySelector('pharos-link');
-    pharosLink?.dispatchEvent(new MouseEvent('mouseenter'));
+    const imageLink = component.renderRoot.querySelector('.card__link--image');
+    imageLink?.parentElement?.dispatchEvent(new MouseEvent('mouseenter'));
+
     await aTimeout(100);
     await elementUpdated(component);
 
@@ -461,8 +462,8 @@ describe('pharos-image-card', () => {
     };
     component.addEventListener('pharos-image-card-image-mouseleave', onMouseLeave);
 
-    const pharosLink = component.renderRoot.querySelector('pharos-link');
-    pharosLink?.dispatchEvent(new Event('mouseleave'));
+    const imageLink = component.renderRoot.querySelector('.card__link--image');
+    imageLink?.parentElement?.dispatchEvent(new Event('mouseleave'));
 
     expect(hovered).to.be.false;
   });

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -183,6 +183,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     if (!this.disabled) {
       this._title['_hover'] = true;
       this._handleMouseEnterSelectable();
+
       const mouseEvent = new CustomEvent('pharos-image-card-image-mouseenter');
       this.dispatchEvent(mouseEvent);
     }
@@ -267,8 +268,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
       @click=${this._cardToggleSelect}
-      >${this._renderLinkContent()}${this._renderHoverMetadata()} <slot name="overlay"></slot
-    ></pharos-link>`;
+    >
+      ${this._renderCheckbox()} ${this._renderLinkContent()}${this._renderHoverMetadata()}
+      <slot name="overlay"></slot>
+    </pharos-link>`;
   }
 
   private _renderImage(): TemplateResult {
@@ -335,8 +338,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   protected override render(): TemplateResult {
+    console.log('Render');
+
     return html`<div class="card">
-      ${this._renderCheckbox()} ${this._renderImage()} ${this._renderSourceType()}
+      ${this._renderImage()} ${this._renderSourceType()}
       <div
         class="card__title"
         @mouseenter=${this._handleMouseEnterSelectable}
@@ -349,13 +354,23 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _cardToggleSelect(event: Event): void {
+    console.log(new Date());
+    console.log('Clicked');
+    console.log(!this.disabled);
+    console.log(this._isSelectableViaCard());
+    console.log((event.target as Element)?.nodeName);
+
     if (
       !this.disabled &&
       (this._isSelectableViaCard() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX')
     ) {
       // this is required to prevent navigation on the link click
       event.preventDefault();
+      event.stopPropagation();
+      console.log('Select state');
+      console.log(this._isSelected);
       this._isSelected = !this._isSelected;
+      console.log(this._isSelected);
       this.dispatchEvent(
         new CustomEvent('pharos-image-card-selected', {
           bubbles: true,
@@ -394,6 +409,9 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
+    console.log('render checkbox');
+    console.log(this._isSelected);
+
     return this._isSubtleSelectHover() ||
       this._isSelectableViaCard() ||
       this._isSelected ||
@@ -404,8 +422,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
           ?checked=${this._isSelected}
           ?disabled=${this.disabled}
           name="Select ${this.title}"
-          @mouseenter=${this._handleMouseEnterSelectable}
-          @mouseleave=${this._handleMouseLeaveSelectable}
           @click="${this._cardToggleSelect}"
           ><span slot="label">Select ${this.title}</span></pharos-checkbox
         >`

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -208,21 +208,27 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _renderCollectionImage(): TemplateResult {
-    return html`<pharos-link
-      class=${classMap({
-        [`card__link--collection`]: true,
-        [`card__link--selected`]: this._isSelected,
-      })}
-      href="${this.link}"
-      label="${ifDefined(this.imageLinkLabel)}"
-      subtle
-      flex
-      no-hover
+    return html`<div
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
       @click=${this._cardToggleSelect}
-      ><svg class="card__svg" role="presentation" viewBox="0 0 4 3"></svg> <slot name="image"></slot
-    ></pharos-link>`;
+    >
+      ${this._renderCheckbox()}
+      <pharos-link
+        class=${classMap({
+          [`card__link--collection`]: true,
+          [`card__link--selected`]: this._isSelected,
+        })}
+        href="${this.link}"
+        label="${ifDefined(this.imageLinkLabel)}"
+        subtle
+        flex
+        no-hover
+      >
+        <svg class="card__svg" role="presentation" viewBox="0 0 4 3"></svg>
+        <slot name="image"></slot>
+      </pharos-link>
+    </div>`;
   }
 
   private _renderLinkContent(): TemplateResult {
@@ -249,29 +255,33 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _renderBaseImage(): TemplateResult {
-    return html`<pharos-link
-      class=${classMap({
-        [`card__link--image`]: true,
-        [`card__link--selectable`]:
-          (this._isSubtleSelectHover() ||
-            this._isSelectableViaCard() ||
-            this._isDisabledSelectable()) &&
-          !this._isSelected,
-        [`card__link--selected`]: this._isSelected,
-        [`card__link--select-hover`]: this._isSelectableCardHover() && !this._isSelected,
-      })}
-      href="${this.link}"
-      label=${ifDefined(this.imageLinkLabel)}
-      subtle
-      flex
-      no-hover
+    return html`<div
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
       @click=${this._cardToggleSelect}
     >
-      ${this._renderCheckbox()} ${this._renderLinkContent()}${this._renderHoverMetadata()}
-      <slot name="overlay"></slot>
-    </pharos-link>`;
+      ${this._renderCheckbox()}
+      <pharos-link
+        class=${classMap({
+          [`card__link--image`]: true,
+          [`card__link--selectable`]:
+            (this._isSubtleSelectHover() ||
+              this._isSelectableViaCard() ||
+              this._isDisabledSelectable()) &&
+            !this._isSelected,
+          [`card__link--selected`]: this._isSelected,
+          [`card__link--select-hover`]: this._isSelectableCardHover() && !this._isSelected,
+        })}
+        href="${this.link}"
+        label=${ifDefined(this.imageLinkLabel)}
+        subtle
+        flex
+        no-hover
+      >
+        ${this._renderLinkContent()}${this._renderHoverMetadata()}
+        <slot name="overlay"></slot>
+      </pharos-link>
+    </div>`;
   }
 
   private _renderImage(): TemplateResult {
@@ -338,8 +348,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   protected override render(): TemplateResult {
-    console.log('Render');
-
     return html`<div class="card">
       ${this._renderImage()} ${this._renderSourceType()}
       <div
@@ -354,12 +362,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _cardToggleSelect(event: Event): void {
-    console.log(new Date());
-    console.log('Clicked');
-    console.log(!this.disabled);
-    console.log(this._isSelectableViaCard());
-    console.log((event.target as Element)?.nodeName);
-
     if (
       !this.disabled &&
       (this._isSelectableViaCard() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX')
@@ -367,10 +369,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       // this is required to prevent navigation on the link click
       event.preventDefault();
       event.stopPropagation();
-      console.log('Select state');
-      console.log(this._isSelected);
       this._isSelected = !this._isSelected;
-      console.log(this._isSelected);
       this.dispatchEvent(
         new CustomEvent('pharos-image-card-selected', {
           bubbles: true,
@@ -409,9 +408,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
-    console.log('render checkbox');
-    console.log(this._isSelected);
-
     return this._isSubtleSelectHover() ||
       this._isSelectableViaCard() ||
       this._isSelected ||


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
#377 

**How does this change work?**
Moves the checkbox within the rest of the card element where it is visually contained
Remove mouse listener events on checkbox

**Additional context**
This also looks to remove re-render on mouse move when hovering the checkbox. If mouse is moving a lot that could add up to hundreds to thousands of re-renders in a short period of time. 

https://user-images.githubusercontent.com/13315416/181800423-a9c49d9b-685b-483a-94ab-358c96391e37.mov


