### PR TITLE
feat(site): add last updated column to status page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 - [ ] Test suite(s) passing?
 - [ ] Code coverage maximal?
 - [ ] Changeset added?
+- [ ] Component status page up to date?
 
 **What does this change address?**
 A clear and concise description or a direct link to an issue [e.g. #15]

--- a/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
+++ b/packages/pharos-site/src/components/statics/component-status/StatusTable.tsx
@@ -22,7 +22,15 @@ const StatusTable: FC = () => {
   const [StateTable, setStateTable] = useState<ReactElement[] | null>(null);
   const [IsStuck, setIsStuck] = useState(false);
 
-  const columns = ['Component', 'Design', 'Development', 'Tests', 'Documentation', 'Released In'];
+  const columns = [
+    'Component',
+    'Design',
+    'Development',
+    'Tests',
+    'Documentation',
+    'Released in',
+    'Last updated',
+  ];
 
   const Pharos =
     typeof window !== `undefined` ? require('@ithaka/pharos/lib/react-components') : null;
@@ -62,15 +70,25 @@ const StatusTable: FC = () => {
             const component = statuses[key as keyof typeof statuses];
             const status = component[lifecycle as keyof typeof component].status;
             const description = component[lifecycle as keyof typeof component].description;
+            const changelogUrl =
+              'https://github.com/ithaka/pharos/blob/develop/packages/pharos/CHANGELOG.md';
 
             return (
               <td key={j} className={table__cell}>
                 {legend[status as keyof typeof legend] ? (
                   <StatusIcon status={status} index={`${i}` + `${j}`} />
                 ) : (
-                  <strong>{status}</strong>
+                  <div>
+                    {['released', 'updated'].includes(lifecycle) ? (
+                      <PharosLink href={`${changelogUrl}#${status.replaceAll('.', '')}`}>
+                        <strong>{status}</strong>
+                      </PharosLink>
+                    ) : (
+                      <strong>{status}</strong>
+                    )}
+                  </div>
                 )}
-                {description ? <span className={status__description}>{description}</span> : null}
+                {description ? <div className={status__description}>{description}</div> : null}
               </td>
             );
           })}

--- a/packages/pharos-site/src/pages/components/component-status/status.json
+++ b/packages/pharos-site/src/pages/components/component-status/status.json
@@ -19,6 +19,10 @@
     "released": {
       "status": "na",
       "description": ""
+    },
+    "updated": {
+      "status": "na",
+      "description": ""
     }
   },
   "alert": {
@@ -40,6 +44,10 @@
     },
     "released": {
       "status": "0.0.4",
+      "description": ""
+    },
+    "updated": {
+      "status": "10.6.0",
       "description": ""
     }
   },
@@ -63,6 +71,10 @@
     "released": {
       "status": "7.22.0",
       "description": ""
+    },
+    "updated": {
+      "status": "10.6.1",
+      "description": ""
     }
   },
   "button": {
@@ -85,27 +97,9 @@
     "released": {
       "status": "7.0.0",
       "description": ""
-    }
-  },
-  "callout": {
-    "design": {
-      "status": "na",
-      "description": "Not doing"
     },
-    "development": {
-      "status": "deprecated",
-      "description": "Use alerts instead"
-    },
-    "tests": {
-      "status": "na",
-      "description": ""
-    },
-    "documentation": {
-      "status": "na",
-      "description": "Not doing"
-    },
-    "released": {
-      "status": "na",
+    "updated": {
+      "status": "11.2.0",
       "description": ""
     }
   },
@@ -129,6 +123,10 @@
     "released": {
       "status": "1.0.0",
       "description": ""
+    },
+    "updated": {
+      "status": "7.0.0",
+      "description": ""
     }
   },
   "checkbox-group": {
@@ -150,6 +148,10 @@
     },
     "released": {
       "status": "1.2.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "6.0.0",
       "description": ""
     }
   },
@@ -173,6 +175,10 @@
     "released": {
       "status": "3.1.0",
       "description": ""
+    },
+    "updated": {
+      "status": "10.6.0",
+      "description": ""
     }
   },
   "dropdown-menu": {
@@ -194,6 +200,10 @@
     },
     "released": {
       "status": "5.0.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "12.0.0",
       "description": ""
     }
   },
@@ -217,6 +227,10 @@
     "released": {
       "status": "7.7.0",
       "description": ""
+    },
+    "updated": {
+      "status": "7.23.3",
+      "description": ""
     }
   },
   "footer": {
@@ -238,6 +252,10 @@
     },
     "released": {
       "status": "7.10.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "10.8.0",
       "description": ""
     }
   },
@@ -261,6 +279,10 @@
     "released": {
       "status": "7.11.0",
       "description": ""
+    },
+    "updated": {
+      "status": "12.0.0",
+      "description": ""
     }
   },
   "heading": {
@@ -282,6 +304,10 @@
     },
     "released": {
       "status": "0.0.4",
+      "description": ""
+    },
+    "updated": {
+      "status": "10.0.0",
       "description": ""
     }
   },
@@ -305,6 +331,10 @@
     "released": {
       "status": "7.0.0",
       "description": ""
+    },
+    "updated": {
+      "status": "12.6.0",
+      "description": "New icon added"
     }
   },
   "image-card": {
@@ -326,6 +356,10 @@
     },
     "released": {
       "status": "9.2.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "10.6.0",
       "description": ""
     }
   },
@@ -349,6 +383,10 @@
     "released": {
       "status": "7.6.0",
       "description": ""
+    },
+    "updated": {
+      "status": "10.7.0",
+      "description": ""
     }
   },
   "layout": {
@@ -370,6 +408,10 @@
     },
     "released": {
       "status": "9.1.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "12.0.0",
       "description": ""
     }
   },
@@ -393,6 +435,10 @@
     "released": {
       "status": "7.0.0",
       "description": ""
+    },
+    "updated": {
+      "status": "11.2.1",
+      "description": ""
     }
   },
   "loading-spinner": {
@@ -414,6 +460,10 @@
     },
     "released": {
       "status": "4.1.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "4.3.2",
       "description": ""
     }
   },
@@ -437,6 +487,10 @@
     "released": {
       "status": "4.3.0",
       "description": ""
+    },
+    "updated": {
+      "status": "11.1.0",
+      "description": ""
     }
   },
   "pagination": {
@@ -459,6 +513,10 @@
     "released": {
       "status": "7.12.0",
       "description": ""
+    },
+    "updated": {
+      "status": "7.20.0",
+      "description": ""
     }
   },
   "progress-bar": {
@@ -479,6 +537,10 @@
       "description": ""
     },
     "released": {
+      "status": "7.0.0",
+      "description": ""
+    },
+    "updated": {
       "status": "7.0.0",
       "description": ""
     }
@@ -503,6 +565,10 @@
     "released": {
       "status": "1.0.0",
       "description": ""
+    },
+    "updated": {
+      "status": "5.0.0",
+      "description": ""
     }
   },
   "radio-group": {
@@ -524,6 +590,10 @@
     },
     "released": {
       "status": "1.1.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "6.0.0",
       "description": ""
     }
   },
@@ -547,6 +617,10 @@
     "released": {
       "status": "1.2.0",
       "description": ""
+    },
+    "updated": {
+      "status": "7.6.0",
+      "description": ""
     }
   },
   "sidenav": {
@@ -568,6 +642,10 @@
     },
     "released": {
       "status": "7.19.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "9.3.0",
       "description": ""
     }
   },
@@ -591,6 +669,10 @@
     "released": {
       "status": "7.3.0",
       "description": ""
+    },
+    "updated": {
+      "status": "12.2.3",
+      "description": ""
     }
   },
   "textarea": {
@@ -612,6 +694,10 @@
     },
     "released": {
       "status": "1.2.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "7.24.0",
       "description": ""
     }
   },
@@ -635,6 +721,10 @@
     "released": {
       "status": "1.0.0",
       "description": ""
+    },
+    "updated": {
+      "status": "12.6.2",
+      "description": ""
     }
   },
   "toast": {
@@ -657,6 +747,10 @@
     "released": {
       "status": "7.21.0",
       "description": ""
+    },
+    "updated": {
+      "status": "12.2.0",
+      "description": ""
     }
   },
   "toggle-button-group": {
@@ -677,7 +771,11 @@
       "description": ""
     },
     "released": {
-      "status": "na",
+      "status": "9.2.0",
+      "description": ""
+    },
+    "updated": {
+      "status": "9.2.0",
       "description": ""
     }
   },
@@ -700,6 +798,10 @@
     },
     "released": {
       "status": "0.0.2",
+      "description": ""
+    },
+    "updated": {
+      "status": "10.1.0",
       "description": ""
     }
   }


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**

We would like a quick reference to understand when a component was last changed.

**How does this change work?**

- Remove obviated Callout row
- Add last updated versions to status.json
- Link version text to relevant changelog heading (this may not work for
  all versions as some changelog entries are in a legacy file)

**Additional context**

This will not be ideal to update, at the moment, but gives us a starting place. The main challenge being that, at the time that a change is merged, the release version number is not necessarily known. Multiple changes may be included in a release, and even though one change may be a patch another change may be a major bump, meaning the release version will be a major bump. One mitigation strategy is to release every change no matter how small; this has the added advantage of making all patch and minor changes available to consumers without having to deal with a major version upgrade, but also increases release management burden. Given the small volume of releases we have currently, this may be fine.

<img width="1271" alt="Screen Shot 2022-08-16 at 14 54 05" src="https://user-images.githubusercontent.com/1808306/184958080-704b3632-fd60-42f4-b709-4ec50c5744d6.png">
