### PR TITLE
ImageCard: Selectable Image card keyboard accessibility 

### DIFF
--- a/.changeset/spicy-geckos-worry.md
+++ b/.changeset/spicy-geckos-worry.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Adding keyboard accessibility to selectable iamge card variants

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -11,7 +11,7 @@
   width: 100%;
 }
 
-.card__link--container {
+.card__link-container {
   display: flex;
 }
 

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -11,6 +11,10 @@
   width: 100%;
 }
 
+.card__link--container {
+  display: flex;
+}
+
 .card__link--image {
   position: relative;
   height: 14rem;

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -609,4 +609,33 @@ describe('pharos-image-card', () => {
 
     expect(component.innerHTML).contains('Card overlay');
   });
+
+  it('the checkbox dispays when tab is pressed on the image link', async () => {
+    component = await fixture(html`<pharos-image-card
+      title="Card Title"
+      link="#"
+      variant="selectable"
+      subtle-select="true"
+    >
+      <img
+        slot="image"
+        alt="Card Title"
+        src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
+      />
+      <strong slot="metadata">100 items</strong>
+      <div slot="metadata">Description of collection.</div>
+    </pharos-image-card>`);
+
+    const imageLink = component.renderRoot.querySelector('.card__link--image');
+
+    imageLink?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    let checkboxElement = null;
+    imageLink?.parentElement?.dispatchEvent(new MouseEvent('mouseenter'));
+
+    await aTimeout(100);
+    await elementUpdated(component);
+
+    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    expect(checkboxElement).not.to.be.null;
+  });
 });

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -610,7 +610,7 @@ describe('pharos-image-card', () => {
     expect(component.innerHTML).contains('Card overlay');
   });
 
-  it('the checkbox dispays when tab is pressed on the image link', async () => {
+  it('displays checkbox when tab is pressed on the image link', async () => {
     component = await fixture(html`<pharos-image-card
       title="Card Title"
       link="#"
@@ -629,13 +629,11 @@ describe('pharos-image-card', () => {
     const imageLink = component.renderRoot.querySelector('.card__link--image');
 
     imageLink?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-    let checkboxElement = null;
-    imageLink?.parentElement?.dispatchEvent(new MouseEvent('mouseenter'));
 
     await aTimeout(100);
     await elementUpdated(component);
 
-    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    const checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
     expect(checkboxElement).not.to.be.null;
   });
 });

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -1,5 +1,6 @@
 import { fixture, expect, aTimeout, elementUpdated } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
+import { sendKeys } from '@web/test-runner-commands';
 
 import type { PharosImageCard } from './pharos-image-card';
 import type { PharosButton } from '../button/pharos-button';
@@ -610,7 +611,7 @@ describe('pharos-image-card', () => {
     expect(component.innerHTML).contains('Card overlay');
   });
 
-  it('displays checkbox when tab is pressed on the image link', async () => {
+  it('can be navigated with a keyboard when subtle and selectable', async () => {
     component = await fixture(html`<pharos-image-card
       title="Card Title"
       link="#"
@@ -626,13 +627,8 @@ describe('pharos-image-card', () => {
       <div slot="metadata">Description of collection.</div>
     </pharos-image-card>`);
 
-    const imageLink = component.renderRoot.querySelector('.card__link--image');
-
-    imageLink?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-
-    await aTimeout(100);
-    await elementUpdated(component);
-
+    component.focus();
+    await sendKeys({ down: 'Tab' });
     const checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
     expect(checkboxElement).not.to.be.null;
   });

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -372,7 +372,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     }
 
     if (event.key == 'Tab' && event.shiftKey) {
-      console.log('HANDLE BACKWARD');
       this._isSelectableHovered = true;
     }
   }
@@ -383,7 +382,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     }
 
     if (event.key == 'Tab' && !event.shiftKey) {
-      console.log('HANDLE FORWARD');
       this._isSelectableHovered = true;
     }
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -209,7 +209,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderCollectionImage(): TemplateResult {
     return html`<div
-      class="card__link--container"
+      class="card__link-container"
       @keydown=${this._handleKeydown}
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
@@ -259,7 +259,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderBaseImage(): TemplateResult {
     return html`<div
-      class="card__link--container"
+      class="card__link-container"
       @keydown=${this._handleKeydown}
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -210,13 +210,12 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   private _renderCollectionImage(): TemplateResult {
     return html`<div
       class="card__link-container"
-      @keydown=${this._handleKeydown}
+      @keydown=${this._handleForwardNavigation}
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
       @click=${this._cardToggleSelect}
     >
       <pharos-link
-        id="card-image-link"
         class=${classMap({
           [`card__link--collection`]: true,
           [`card__link--selected`]: this._isSelected,
@@ -260,13 +259,12 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   private _renderBaseImage(): TemplateResult {
     return html`<div
       class="card__link-container"
-      @keydown=${this._handleKeydown}
+      @keydown=${this._handleForwardNavigation}
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
       @click=${this._cardToggleSelect}
     >
       <pharos-link
-        id="card-image-link"
         class=${classMap({
           [`card__link--image`]: true,
           [`card__link--selectable`]:
@@ -309,8 +307,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   protected get renderTitle(): TemplateResult {
     return html`<pharos-link
-      @keydown=${this._handleKeydown}
-      id="card-title"
+      @keydown=${this._handleBackwardNavigation}
       class="card__link--title"
       href="${this.link}"
       subtle
@@ -369,22 +366,24 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     </div>`;
   }
 
-  private _handleKeydown(event: KeyboardEvent): void {
-    if (!this.subtleSelect || this._checkboxDisplayed()) {
+  private _handleBackwardNavigation(event: KeyboardEvent): void {
+    if (!this.subtleSelect || this._isCheckboxDisplayed()) {
       return;
     }
 
-    // tabbing backwards
-    if (event.key == 'Tab' && event.shiftKey && (event.target as Element)?.id === 'card-title') {
+    if (event.key == 'Tab' && event.shiftKey) {
+      console.log('HANDLE BACKWARD');
       this._isSelectableHovered = true;
     }
+  }
 
-    //tabbing forwards
-    if (
-      event.key == 'Tab' &&
-      !event.shiftKey &&
-      (event.target as Element)?.id == 'card-image-link'
-    ) {
+  private _handleForwardNavigation(event: KeyboardEvent): void {
+    if (!this.subtleSelect || this._isCheckboxDisplayed()) {
+      return;
+    }
+
+    if (event.key == 'Tab' && !event.shiftKey) {
+      console.log('HANDLE FORWARD');
       this._isSelectableHovered = true;
     }
   }
@@ -435,7 +434,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return this.disabled && this.variant.includes('selectable');
   }
 
-  private _checkboxDisplayed() {
+  private _isCheckboxDisplayed() {
     return (
       this._isSubtleSelectHover() ||
       this._isSelectableViaCard() ||
@@ -445,7 +444,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _renderCheckbox(): TemplateResult | typeof nothing {
-    return this._checkboxDisplayed()
+    return this._isCheckboxDisplayed()
       ? html`<pharos-checkbox
           @blur=${this._handleMouseLeaveSelectable}
           class="card__checkbox"

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -141,6 +141,9 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   @query('.card__link--title')
   private _title!: PharosLink;
 
+  @query('.card__checkbox')
+  private _checkbox!: PharosLink;
+
   public static override get styles(): CSSResultArray {
     return [imageCardStyles];
   }
@@ -366,24 +369,26 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     </div>`;
   }
 
-  private _handleBackwardNavigation(event: KeyboardEvent): void {
+  private _handleNavigation(event: KeyboardEvent, directionMatches: boolean): void {
     if (!this.subtleSelect || this._isCheckboxDisplayed()) {
       return;
     }
 
-    if (event.key == 'Tab' && event.shiftKey) {
+    if (event.key == 'Tab' && directionMatches) {
+      event.preventDefault();
       this._isSelectableHovered = true;
+      new Promise((resolve) => requestAnimationFrame(resolve)).then(() => {
+        this._checkbox.focus();
+      });
     }
   }
 
-  private _handleForwardNavigation(event: KeyboardEvent): void {
-    if (!this.subtleSelect || this._isCheckboxDisplayed()) {
-      return;
-    }
+  private _handleBackwardNavigation(event: KeyboardEvent): void {
+    this._handleNavigation(event, event.shiftKey);
+  }
 
-    if (event.key == 'Tab' && !event.shiftKey) {
-      this._isSelectableHovered = true;
-    }
+  private _handleForwardNavigation(event: KeyboardEvent): void {
+    this._handleNavigation(event, !event.shiftKey);
   }
 
   private _cardToggleSelect(event: Event): void {

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -209,12 +209,14 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderCollectionImage(): TemplateResult {
     return html`<div
+      class="card__link--container"
+      @keydown=${this._handleKeydown}
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
       @click=${this._cardToggleSelect}
     >
-      ${this._renderCheckbox()}
       <pharos-link
+        id="card-image-link"
         class=${classMap({
           [`card__link--collection`]: true,
           [`card__link--selected`]: this._isSelected,
@@ -228,6 +230,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
         <svg class="card__svg" role="presentation" viewBox="0 0 4 3"></svg>
         <slot name="image"></slot>
       </pharos-link>
+      ${this._renderCheckbox()}
     </div>`;
   }
 
@@ -256,12 +259,14 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _renderBaseImage(): TemplateResult {
     return html`<div
+      class="card__link--container"
+      @keydown=${this._handleKeydown}
       @mouseenter=${this._handleImageMouseEnter}
       @mouseleave=${this._handleImageMouseLeave}
       @click=${this._cardToggleSelect}
     >
-      ${this._renderCheckbox()}
       <pharos-link
+        id="card-image-link"
         class=${classMap({
           [`card__link--image`]: true,
           [`card__link--selectable`]:
@@ -281,6 +286,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
         ${this._renderLinkContent()}${this._renderHoverMetadata()}
         <slot name="overlay"></slot>
       </pharos-link>
+      ${this._renderCheckbox()}
     </div>`;
   }
 
@@ -303,6 +309,8 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   protected get renderTitle(): TemplateResult {
     return html`<pharos-link
+      @keydown=${this._handleKeydown}
+      id="card-title"
       class="card__link--title"
       href="${this.link}"
       subtle
@@ -361,6 +369,22 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     </div>`;
   }
 
+  private _handleKeydown(event: KeyboardEvent): void {
+    if (!this.subtleSelect || this._checkboxDisplayed()) {
+      return;
+    }
+
+    // tabbing backwards
+    if (event.key == 'Tab' && event.shiftKey && event.target.id === 'card-title') {
+      this._isSelectableHovered = true;
+    }
+
+    //tabbing forwards
+    if (event.key == 'Tab' && !event.shiftKey && event.target.id == 'card-image-link') {
+      this._isSelectableHovered = true;
+    }
+  }
+
   private _cardToggleSelect(event: Event): void {
     if (
       !this.disabled &&
@@ -407,12 +431,19 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     return this.disabled && this.variant.includes('selectable');
   }
 
-  private _renderCheckbox(): TemplateResult | typeof nothing {
-    return this._isSubtleSelectHover() ||
+  private _checkboxDisplayed() {
+    return (
+      this._isSubtleSelectHover() ||
       this._isSelectableViaCard() ||
       this._isSelected ||
       (this.disabled && this.variant.includes('selectable'))
+    );
+  }
+
+  private _renderCheckbox(): TemplateResult | typeof nothing {
+    return this._checkboxDisplayed()
       ? html`<pharos-checkbox
+          @blur=${this._handleMouseLeaveSelectable}
           class="card__checkbox"
           hide-label="true"
           ?checked=${this._isSelected}

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -375,12 +375,16 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     }
 
     // tabbing backwards
-    if (event.key == 'Tab' && event.shiftKey && event.target.id === 'card-title') {
+    if (event.key == 'Tab' && event.shiftKey && (event.target as Element)?.id === 'card-title') {
       this._isSelectableHovered = true;
     }
 
     //tabbing forwards
-    if (event.key == 'Tab' && !event.shiftKey && event.target.id == 'card-image-link') {
+    if (
+      event.key == 'Tab' &&
+      !event.shiftKey &&
+      (event.target as Element)?.id == 'card-image-link'
+    ) {
       this._isSelectableHovered = true;
     }
   }

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -154,21 +154,21 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       );
     }
 
-    if (
-      changedProperties.has('subtleSelect') &&
-      this.subtleSelect &&
-      !this.variant.includes('selectable')
-    ) {
+    if (changedProperties.has('subtleSelect') && this.subtleSelect && !this._isSelectable()) {
       throw new Error(
         `${this.variant} is not a valid variant to use with subtle-select. Only the selectable variants can be used with subtle-select.}`
       );
     }
 
-    if (this.selected && this.variant.includes('selectable')) {
+    if (this.selected && this._isSelectable()) {
       throw new Error(
         `Image card with variant type ${this.variant} cannot be selected. Only the selectable variants can be selected.}`
       );
     }
+  }
+
+  private _isSelectable() {
+    return this.variant.includes('selectable');
   }
 
   private _handleClick(e: MouseEvent): void {
@@ -305,7 +305,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     }[this.variant] as HeadingPreset;
   }
 
-  protected get renderTitle(): TemplateResult {
+  private _renderTitle(): TemplateResult {
     return html`<pharos-link
       @keydown=${this._handleBackwardNavigation}
       class="card__link--title"
@@ -360,7 +360,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
         @mouseenter=${this._handleMouseEnterSelectable}
         @mouseleave=${this._handleMouseLeaveSelectable}
       >
-        ${this.renderTitle} ${this._renderActionButton()}
+        ${this._renderTitle()} ${this._renderActionButton()}
       </div>
       ${this._renderMetadata()}
     </div>`;
@@ -410,10 +410,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _isSubtleSelectHover(): boolean {
     return Boolean(
-      this.variant.includes('selectable') &&
-        this._isSelectableHovered &&
-        this.subtleSelect &&
-        !this.disabled
+      this._isSelectable() && this._isSelectableHovered && this.subtleSelect && !this.disabled
     );
   }
 
@@ -423,13 +420,13 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
 
   private _isSelectableViaCard(): boolean {
     return Boolean(
-      (this.variant.includes('selectable') && !this.subtleSelect && !this.disabled) ||
+      (this._isSelectable() && !this.subtleSelect && !this.disabled) ||
         (this.subtleSelect && this._isSelected && !this.disabled)
     );
   }
 
   private _isDisabledSelectable(): boolean {
-    return this.disabled && this.variant.includes('selectable');
+    return this.disabled && this._isSelectable();
   }
 
   private _isCheckboxDisplayed() {
@@ -437,7 +434,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       this._isSubtleSelectHover() ||
       this._isSelectableViaCard() ||
       this._isSelected ||
-      (this.disabled && this.variant.includes('selectable'))
+      (this.disabled && this._isSelectable())
     );
   }
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
This PR adds keyboard accessibility to the selectable pharos image card variants.
Tab 1 => focus to card 
Tab 2 => focus to checkbox
Spacebar => select checkbox 

**How does this change work?**
New function to handle keyboard events. Use various details from the keyboard event to determine if we should show the checkbox.
