### PR TITLE
ImageCard: remove event.stopPropagation from _cardToggleSelect

### DIFF
--- a/.changeset/light-cups-guess.md
+++ b/.changeset/light-cups-guess.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Remove event.stopPropagation from \_cardToggleSelect and logic updates

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -364,12 +364,13 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   private _cardToggleSelect(event: Event): void {
     if (
       !this.disabled &&
-      (this._isSelectableViaCard() || (event.target as Element)?.nodeName == 'PHAROS-CHECKBOX')
+      ((this._isSelectableViaCard() && (event.target as Element)?.nodeName != 'PHAROS-CHECKBOX') ||
+        (event.currentTarget as Element)?.nodeName == 'PHAROS-CHECKBOX')
     ) {
       // this is required to prevent navigation on the link click
       event.preventDefault();
-      event.stopPropagation();
       this._isSelected = !this._isSelected;
+
       this.dispatchEvent(
         new CustomEvent('pharos-image-card-selected', {
           bubbles: true,

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -392,11 +392,10 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   }
 
   private _cardToggleSelect(event: Event): void {
-    if (
-      !this.disabled &&
-      ((this._isSelectableViaCard() && (event.target as Element)?.nodeName != 'PHAROS-CHECKBOX') ||
-        (event.currentTarget as Element)?.nodeName == 'PHAROS-CHECKBOX')
-    ) {
+    const cardClicked = this._isSelectableViaCard() && event.target !== this._checkbox;
+    const checkboxClicked = event.currentTarget === this._checkbox;
+
+    if (!this.disabled && (cardClicked || checkboxClicked)) {
       // this is required to prevent navigation on the link click
       event.preventDefault();
       this._isSelected = !this._isSelected;


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Allows the click event on image cards to propagate in order to close modals on the same page.

**How does this change work?**
Removed event.stopPropagation from _cardToggleSelect, and added a check in order to prevent the main body of the function from being executed twice.
