### PR TITLE
TextInput: explicitly set margin to avoid undesired user agent styles

### DIFF
--- a/.changeset/tender-ways-impress.md
+++ b/.changeset/tender-ways-impress.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Explicitly set input element margins to avoid undesired user agent styling

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -10,6 +10,7 @@
 @mixin input-base {
   @include font-base;
 
+  margin: 0;
   padding: var(--pharos-spacing-one-half-x) var(--pharos-spacing-three-quarters-x);
   width: 100%;
   display: block;


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Safari in particular puts margin on some form control elements, and we hadn't addressed the default vertical margin for text inputs, meaning the inputs could (and do) look different depending on the user agent.

**How does this change work?**

This change explicitly sets that margin to 0, allowing all browsers to be consistent.
