### PR TITLE
Checkbox, RadioButton: allow for scoped pharos links

### DIFF
--- a/.changeset/stupid-ravens-rest.md
+++ b/.changeset/stupid-ravens-rest.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Allow scoped Pharos Link elements to be clickable within a Pharos Checkbox or RadioButton

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.ts
@@ -11,7 +11,7 @@ import checkmarkSmall from '../../styles/icons/checkmark-small';
 import { FormElement } from '../base/form-element';
 import FormMixin from '../../utils/mixins/form';
 
-const LINKS = `a[href],pharos-link[href]`;
+const LINKS = `a[href],pharos-link[href],[data-pharos-component='PharosLink'][href]`;
 
 /**
  * Pharos checkbox component.

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.ts
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.ts
@@ -5,7 +5,7 @@ import { radioButtonStyles } from './pharos-radio-button.css';
 import { FormElement } from '../base/form-element';
 import FormMixin from '../../utils/mixins/form';
 
-const LINKS = `a[href],pharos-link[href]`;
+const LINKS = `a[href],pharos-link[href],[data-pharos-component='PharosLink'][href]`;
 
 /**
  * Pharos radio button component.


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Only native `<a>` tags and unscoped `<pharos-link>` tags were clickable in these form controls; scoped tags were not.

**How does this change work?**

Include scoped Pharos Link elements in the link selector.
