### PR TITLE
fix(toggle-button-group): not consistently applying initial selected state

### DIFF
--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -39,14 +39,12 @@ export class PharosToggleButtonGroup extends PharosElement {
     const selected: PharosToggleButton | null = this.querySelector(
       `[data-pharos-component="PharosToggleButton"][selected]`
     );
-
     const selectedButton: PharosToggleButton = selected ? selected : toggleButtons[0];
 
     selectedButton.selected = true;
   }
 
   private _handleButtonSelected(event: Event): void {
-    console.log('handling select');
     const selected = event.target as PharosToggleButton;
 
     const previous: PharosToggleButton | null = this.querySelector(

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -25,7 +25,7 @@ export class PharosToggleButtonGroup extends PharosElement {
     const toggleButtons: NodeListOf<PharosToggleButton> = this.querySelectorAll(
       `[data-pharos-component="PharosToggleButton"]`
     );
-    this._selectInitialToggleButton(toggleButtons);
+    setTimeout(() => this._selectInitialToggleButton(toggleButtons));
 
     const maxIdx = toggleButtons.length - 1;
     toggleButtons.forEach((button, idx) => {
@@ -38,12 +38,19 @@ export class PharosToggleButtonGroup extends PharosElement {
     const selected: PharosToggleButton | null = this.querySelector(
       `[data-pharos-component="PharosToggleButton"][selected]`
     );
+    console.log('WHAT IS SELECTED');
+    console.log(selected);
+    console.log(toggleButtons);
+    console.log(toggleButtons[1]);
+    console.log(toggleButtons[1].hasAttribute('selected'));
+
     const selectedButton: PharosToggleButton = selected ? selected : toggleButtons[0];
 
     selectedButton.selected = true;
   }
 
   private _handleButtonSelected(event: Event): void {
+    console.log('handling select');
     const selected = event.target as PharosToggleButton;
 
     const previous: PharosToggleButton | null = this.querySelector(

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -17,15 +17,16 @@ export class PharosToggleButtonGroup extends PharosElement {
     return [toggleButtonGroupStyles];
   }
 
-  protected override firstUpdated(): void {
+  protected override async firstUpdated(): Promise<void> {
     this.addEventListener('pharos-toggle-button-selected', this._handleButtonSelected);
     this.addEventListener('keydown', this._handleKeydown);
     this.addEventListener('focusout', this._handleFocusout);
 
-    const toggleButtons: NodeListOf<PharosToggleButton> = this.querySelectorAll(
-      `[data-pharos-component="PharosToggleButton"]`
+    const toggleButtons: PharosToggleButton[] = Array.from(
+      this.querySelectorAll(`[data-pharos-component="PharosToggleButton"]`)
     );
-    setTimeout(() => this._selectInitialToggleButton(toggleButtons));
+    await Promise.all(toggleButtons.map((el) => el.updateComplete));
+    this._selectInitialToggleButton(toggleButtons);
 
     const maxIdx = toggleButtons.length - 1;
     toggleButtons.forEach((button, idx) => {
@@ -34,15 +35,10 @@ export class PharosToggleButtonGroup extends PharosElement {
     });
   }
 
-  private _selectInitialToggleButton(toggleButtons: NodeListOf<PharosToggleButton>): void {
+  private _selectInitialToggleButton(toggleButtons: PharosToggleButton[]): void {
     const selected: PharosToggleButton | null = this.querySelector(
       `[data-pharos-component="PharosToggleButton"][selected]`
     );
-    console.log('WHAT IS SELECTED');
-    console.log(selected);
-    console.log(toggleButtons);
-    console.log(toggleButtons[1]);
-    console.log(toggleButtons[1].hasAttribute('selected'));
 
     const selectedButton: PharosToggleButton = selected ? selected : toggleButtons[0];
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
#404 

**How does this change work?**
On first render, the `toggle-button-group` will wait for all child `toggle-button` elements to have finished updating as determined by their `updateComplete` promise resolution. This allows us to deterministically know that the buttons are all initialized and we can make the necessary DOM queries to make the first button as `selected`, if none was explicitly defined. 

**Additional context**
[Add any other context here.](https://stackoverflow.com/questions/67489384/wait-for-customelement-children-to-render-to-position-them-imperatively/67499234#67499234)
