### PR TITLE
Toast: Make updateable

### DIFF
--- a/.changeset/bright-socks-fold.md
+++ b/.changeset/bright-socks-fold.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add updateable toasts for async actions

--- a/packages/pharos/src/components/toast/pharos-toast.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.test.ts
@@ -1,6 +1,5 @@
 import { fixture, expect, aTimeout } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
-
 import type { PharosToast } from './pharos-toast';
 import type { PharosIcon } from '../icon/pharos-icon';
 

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -65,7 +65,7 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
    * @attr id
    */
   @property({ type: String, reflect: true })
-  public id = DEFAULT_ID;
+  public override id = DEFAULT_ID;
 
   /**
    * Indicates if the toast should persist indefinitely
@@ -133,9 +133,9 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
         role="alert"
         id="${this.id}"
         class="${classMap({
-      [`toast`]: true,
-      [`toast--${this.status}`]: this.status,
-    })}"
+          [`toast`]: true,
+          [`toast--${this.status}`]: this.status,
+        })}"
         tabindex="0"
       >
         <pharos-icon class="toast__icon" name="${this._getIcon()}"></pharos-icon>

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -22,9 +22,13 @@ export enum TOAST_ICON {
 
 const STATUSES = ['success', 'error', 'info'];
 
-const TOAST_LIFE = 6000;
+const TOAST_LIFE = 30000;
 
 export const DEFAULT_STATUS = 'success';
+
+export const DEFAULT_ID = 'toast';
+
+export const DEFAULT_INDEFINITE = false;
 
 /**
  * Pharos toast component.
@@ -56,6 +60,20 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
   @property({ type: Boolean, reflect: true })
   public open = false;
 
+  /**
+   * The optional id passed to the toast. Used as a handle to update for later.
+   * @attr id
+   */
+  @property({ type: String, reflect: true })
+  public id = DEFAULT_ID;
+
+  /**
+   * Indicates if the toast should persist indefinitely
+   * @attr indefinite
+   */
+  @property({ type: Boolean, reflect: true })
+  public indefinite = false;
+
   private _timer: number | void = 0;
   private _debouncer: Procedure = debounce(() => {
     this.close();
@@ -66,9 +84,10 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
   }
 
   protected override firstUpdated(): void {
-    this.addEventListener('focusin', this._handleTimer);
-    this.addEventListener('focusout', this._handleTimer);
-
+    if (!this.indefinite) {
+      this.addEventListener('focusin', this._handleTimer);
+      this.addEventListener('focusout', this._handleTimer);
+    }
     this.open = true;
   }
 
@@ -112,10 +131,11 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
     return html`
       <div
         role="alert"
+        id="${this.id}"
         class="${classMap({
-          [`toast`]: true,
-          [`toast--${this.status}`]: this.status,
-        })}"
+      [`toast`]: true,
+      [`toast--${this.status}`]: this.status,
+    })}"
         tabindex="0"
       >
         <pharos-icon class="toast__icon" name="${this._getIcon()}"></pharos-icon>

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -22,7 +22,7 @@ export enum TOAST_ICON {
 
 const STATUSES = ['success', 'error', 'info'];
 
-const TOAST_LIFE = 30000;
+const TOAST_LIFE = 6000;
 
 export const DEFAULT_STATUS = 'success';
 
@@ -61,7 +61,7 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
   public open = false;
 
   /**
-   * The optional id passed to the toast. Used as a handle to update for later.
+   * The optional id passed to the toast. Can be used as a handle so the toast can be updated.
    * @attr id
    */
   @property({ type: String, reflect: true })

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
@@ -147,3 +147,54 @@ import { GuidelineLink } from '@config/GuidelineLink';
     }}
   </Story>
 </Canvas>
+
+<Canvas>
+  <Story name="Updateable Toast">
+    {() => {
+      const effect = () => {
+        useEffect(() => {
+          document.querySelector('#info-toast-button').click();
+        });
+      };
+      effect();
+      return html`
+        <pharos-button
+          id="info-toast-button"
+          @click="${() => {
+            console.log("click");
+            const event = new CustomEvent('pharos-toast-open', {
+              detail: {
+                status: 'info',
+                id: 'my-updateable-toast',
+                content: 'Saving 15 items to your Workspace',
+                indefinite: true,
+              },
+            });
+            document.dispatchEvent(event);
+            setTimeout(() => {
+              const updateEvnt = new CustomEvent('pharos-toast-update', {
+                detail: {
+                  status: 'success',
+                  id: 'my-updateable-toast',
+                  content: '15 items succsessfully saved',
+                },
+              });
+              document.dispatchEvent(updateEvnt);
+            }, '3000');
+            setTimeout(() => {
+              const updateEvnt = new CustomEvent('pharos-toast-dismiss', {
+                detail: {
+                  id: 'my-updateable-toast',
+                },
+              });
+              document.dispatchEvent(updateEvnt);
+            }, '6000');
+          }}"
+        >
+          Save items to Workspace
+        </pharos-button>
+        <pharos-toaster></pharos-toaster>
+      `;
+    }}
+  </Story>
+</Canvas>

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
@@ -170,17 +170,17 @@ import { GuidelineLink } from '@config/GuidelineLink';
             });
             document.dispatchEvent(event);
             setTimeout(() => {
-              const updateEvnt = new CustomEvent('pharos-toast-update', {
+              const updateEvent = new CustomEvent('pharos-toast-update', {
                 detail: {
                   status: 'success',
                   content: '15 items succsessfully saved',
                 },
               });
-              document.dispatchEvent(updateEvnt);
+              document.dispatchEvent(updateEvent);
             }, '3000');
             setTimeout(() => {
-              const updateEvnt = new CustomEvent('pharos-toast-close', {});
-              document.dispatchEvent(updateEvnt);
+              const updateEvent = new CustomEvent('pharos-toast-close', {});
+              document.dispatchEvent(updateEvent);
             }, '6000');
           }}"
         >

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
@@ -164,7 +164,6 @@ import { GuidelineLink } from '@config/GuidelineLink';
             const event = new CustomEvent('pharos-toast-open', {
               detail: {
                 status: 'info',
-                id: 'my-updateable-toast',
                 content: 'Saving 15 items to your Workspace',
                 indefinite: true,
               },
@@ -174,18 +173,13 @@ import { GuidelineLink } from '@config/GuidelineLink';
               const updateEvnt = new CustomEvent('pharos-toast-update', {
                 detail: {
                   status: 'success',
-                  id: 'my-updateable-toast',
                   content: '15 items succsessfully saved',
                 },
               });
               document.dispatchEvent(updateEvnt);
             }, '3000');
             setTimeout(() => {
-              const updateEvnt = new CustomEvent('pharos-toast-close', {
-                detail: {
-                  id: 'my-updateable-toast',
-                },
-              });
+              const updateEvnt = new CustomEvent('pharos-toast-close', {});
               document.dispatchEvent(updateEvnt);
             }, '6000');
           }}"

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.mdx
@@ -161,7 +161,6 @@ import { GuidelineLink } from '@config/GuidelineLink';
         <pharos-button
           id="info-toast-button"
           @click="${() => {
-            console.log("click");
             const event = new CustomEvent('pharos-toast-open', {
               detail: {
                 status: 'info',
@@ -182,7 +181,7 @@ import { GuidelineLink } from '@config/GuidelineLink';
               document.dispatchEvent(updateEvnt);
             }, '3000');
             setTimeout(() => {
-              const updateEvnt = new CustomEvent('pharos-toast-dismiss', {
+              const updateEvnt = new CustomEvent('pharos-toast-close', {
                 detail: {
                   id: 'my-updateable-toast',
                 },

--- a/packages/pharos/src/components/toast/pharos-toaster.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.test.ts
@@ -140,7 +140,7 @@ describe('pharos-toaster', () => {
     expect(toast).to.be.null;
   });
 
-  it('can update a toast', async () => {
+  it('can update an existing toast', async () => {
     const trigger = document.createElement('button');
     trigger.addEventListener('click', fireOpenUpdateableToastEvent);
     document.body.appendChild(trigger);

--- a/packages/pharos/src/components/toast/pharos-toaster.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.test.ts
@@ -1,6 +1,5 @@
 import { fixture, expect, nextFrame } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
-
 import type { PharosToaster } from './pharos-toaster';
 import type { PharosToast } from './pharos-toast';
 
@@ -11,6 +10,27 @@ describe('pharos-toaster', () => {
     const event = new CustomEvent('pharos-toast-open', {
       detail: {
         content: 'I am a toast',
+      },
+    });
+    document.dispatchEvent(event);
+  };
+  const fireOpenUpdateableToastEvent = () => {
+    const event = new CustomEvent('pharos-toast-open', {
+      detail: {
+        content: 'I am imortal toast',
+        indefinite: true,
+        id: 'my-updateable-toast',
+      },
+    });
+    document.dispatchEvent(event);
+  };
+
+  const fireUpdateToastEvent = () => {
+    const event = new CustomEvent('pharos-toast-update', {
+      detail: {
+        status: 'success',
+        id: 'my-updateable-toast',
+        content: 'Toast has been updated',
       },
     });
     document.dispatchEvent(event);
@@ -59,8 +79,8 @@ describe('pharos-toaster', () => {
 
     expect(component).dom.to.equal(`
       <pharos-toaster data-pharos-component="PharosToaster">
-        <pharos-toast data-pharos-component="PharosToast" open="" status="success">I am a toast</pharos-toast>
-        <pharos-toast data-pharos-component="PharosToast" open="" status="success">I am a toast</pharos-toast>
+        <pharos-toast data-pharos-component="PharosToast" id="toast" open="" status="success">I am a toast</pharos-toast>
+        <pharos-toast data-pharos-component="PharosToast" id="toast" open="" status="success">I am a toast</pharos-toast>
       </pharos-toaster>
     `);
   });
@@ -117,5 +137,26 @@ describe('pharos-toaster', () => {
 
     const toast = component.querySelector('pharos-toast');
     expect(toast).to.be.null;
+  });
+
+  it('does a things', async () => {
+    const trigger = document.createElement('button');
+    trigger.addEventListener('click', fireOpenUpdateableToastEvent);
+    document.body.appendChild(trigger);
+    trigger.click();
+    await component.updateComplete;
+    await nextFrame();
+    const triggerUpdate = document.createElement('button');
+    triggerUpdate.addEventListener('click', fireUpdateToastEvent);
+    document.body.appendChild(triggerUpdate);
+    triggerUpdate.click();
+    await component.updateComplete;
+    await nextFrame();
+
+    expect(component).dom.to.equal(`
+      <pharos-toaster data-pharos-component="PharosToaster">
+        <pharos-toast data-pharos-component="PharosToast" id="my-updateable-toast" indefinite="" open="" status="success">Toast has been updated</pharos-toast>
+      </pharos-toaster>
+    `);
   });
 });

--- a/packages/pharos/src/components/toast/pharos-toaster.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.test.ts
@@ -152,7 +152,6 @@ describe('pharos-toaster', () => {
     document.body.appendChild(triggerUpdate);
     triggerUpdate.click();
     await component.updateComplete;
-    await nextFrame();
 
     expect(component).dom.to.equal(`
       <pharos-toaster data-pharos-component="PharosToaster">

--- a/packages/pharos/src/components/toast/pharos-toaster.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.test.ts
@@ -139,7 +139,7 @@ describe('pharos-toaster', () => {
     expect(toast).to.be.null;
   });
 
-  it('does a things', async () => {
+  it('can update a toast', async () => {
     const trigger = document.createElement('button');
     trigger.addEventListener('click', fireOpenUpdateableToastEvent);
     document.body.appendChild(trigger);

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -50,6 +50,10 @@ export class PharosToaster extends PharosElement {
     super.disconnectedCallback && super.disconnectedCallback();
   }
 
+  private _getToastID(id: string | null) {
+    return id || DEFAULT_ID;
+  }
+
   private async _openToast(event: Event): Promise<void> {
     const toastTag = this.localName.split('pharos-toaster')[0] + 'pharos-toast';
     const toast = document.createElement(toastTag) as PharosToast;
@@ -57,7 +61,7 @@ export class PharosToaster extends PharosElement {
 
     toast.innerHTML = content;
     toast.status = status || DEFAULT_STATUS;
-    toast.id = id || DEFAULT_ID;
+    toast.id = this._getToastID(id);
     toast.indefinite = indefinite || DEFAULT_INDEFINITE;
     this.insertBefore(toast, this.childNodes[0] || null);
     await this.updateComplete;
@@ -66,7 +70,7 @@ export class PharosToaster extends PharosElement {
 
   private _updateToast(event: CustomEvent): void {
     const { content, status, id } = (<CustomEvent>event).detail;
-    const toast = document.getElementById(id || DEFAULT_ID);
+    const toast = document.getElementById(this._getToastID(id));
     if (toast) {
       toast.innerHTML = content;
       toast.status = status;
@@ -74,8 +78,8 @@ export class PharosToaster extends PharosElement {
   }
 
   private _closeToast(event: CustomEvent): void {
-    const { id } = (<CustomEvent>event).detail;
-    const toast = document.getElementById(id || DEFAULT_ID);
+    const { id } = (<CustomEvent>event).detail || {};
+    const toast = document.getElementById(this._getToastID(id));
     if (toast) {
       this.removeChild(toast);
     }

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -4,8 +4,7 @@ import type { TemplateResult, CSSResultArray } from 'lit';
 import { toasterStyles } from './pharos-toaster.css';
 
 import type { PharosToast } from './pharos-toast';
-import { DEFAULT_INDEFINITE } from './pharos-toast';
-import { DEFAULT_STATUS, DEFAULT_ID } from './pharos-toast';
+import { DEFAULT_STATUS, DEFAULT_ID, DEFAULT_INDEFINITE } from './pharos-toast';
 
 /**
  * pharos-toast-open event.

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -40,14 +40,12 @@ export class PharosToaster extends PharosElement {
     super.connectedCallback && super.connectedCallback();
     document.addEventListener('pharos-toast-open', this._openToast as EventListener);
     document.addEventListener('pharos-toast-update', this._updateToast as EventListener);
-    document.addEventListener('pharos-toast-dismiss', this._dismissToast as EventListener);
     document.addEventListener('pharos-toast-close', this._closeToast as EventListener);
   }
 
   override disconnectedCallback(): void {
     document.removeEventListener('pharos-toast-open', this._openToast as EventListener);
     document.removeEventListener('pharos-toast-update', this._updateToast as EventListener);
-    document.removeEventListener('pharos-toast-dismiss', this._dismissToast as EventListener);
     document.removeEventListener('pharos-toast-close', this._closeToast as EventListener);
     super.disconnectedCallback && super.disconnectedCallback();
   }
@@ -75,16 +73,12 @@ export class PharosToaster extends PharosElement {
     }
   }
 
-  private _dismissToast(event: CustomEvent): void {
+  private _closeToast(event: CustomEvent): void {
     const { id } = (<CustomEvent>event).detail;
     const toast = document.getElementById(id || DEFAULT_ID);
     if (toast) {
-      toast.open = false;
+      this.removeChild(toast);
     }
-  }
-
-  private _closeToast(event: CustomEvent): void {
-    this.removeChild(event.detail);
   }
 
   protected override render(): TemplateResult {


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
[PLATO-2561](https://jira.jstor.org/browse/PLATO-2561)
This PR addresses this pharos issue: #378

**How does this change work?**

- Added new events for toast updates and programatic dismissal.
- Provide option for toast to stay open indefinitely.
- Added id prop so if there are multiple toasts, the consuming app can maintain them independently.

**Additional context**
Add any other context here.
