### PR TITLE
Link: Allow for visited links styling

### DIFF
--- a/.changeset/nasty-rockets-confess.md
+++ b/.changeset/nasty-rockets-confess.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Supports visited links style on Pharos link component, when visited

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  ignorePatterns: ['**/*.css.ts'],
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   parser: '@babel/eslint-parser',
   parserOptions: {

--- a/packages/pharos/src/components/link/PharosLink.react.stories.mdx
+++ b/packages/pharos/src/components/link/PharosLink.react.stories.mdx
@@ -24,6 +24,18 @@ import { PharosLink } from '../../react-components/link/pharos-link';
 
 <ArgsTable of={PharosLink} />
 
+# Visited Link
+
+<Canvas withToolbar>
+  <Story name="Visited Link">
+    <div style={{ marginBottom: '1rem' }}>
+      <PharosLink href="https://www.google.com" target="_blank" indicateVisited>
+        Visited link
+      </PharosLink>
+    </div>
+  </Story>
+</Canvas>
+
 # Button
 
 <Canvas withToolbar>

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -95,6 +95,11 @@
   color: var(--pharos-color-interactive-secondary);
 }
 
+:host([visitable]) #link-element:visited {
+  color: var(--pharos-color-night-blue-base);
+  text-decoration-color: var(--pharos-color-night-blue-base);
+}
+
 :host([no-hover][subtle]) #link-element:hover {
   @include mixins.no-underline;
 }

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -9,8 +9,16 @@
   @include mixins.link-hover;
   @include mixins.interactive-focus;
 
-  &:active {
+  @at-root &:active {
     @include mixins.underline($text-decoration-color: var(--pharos-color-hover-primary));
+  }
+
+  @at-root &.link--alert:hover {
+    color: var(--pharos-color-interactive-secondary);
+  }
+
+  @at-root &.link--alert:active {
+    @include mixins.underline;
   }
 }
 
@@ -26,22 +34,37 @@
   cursor: pointer;
 }
 
-#link-element.link--alert:hover {
-  color: var(--pharos-color-interactive-secondary);
-}
-
-#link-element.link--alert:active {
-  @include mixins.underline;
-}
-
 :host([on-background]) #link-element {
   @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
 
   color: var(--pharos-color-interactive-tertiary);
+
+  @at-root &:hover {
+    color: var(--pharos-color-interactive-tertiary);
+    @include mixins.no-underline;
+  }
+
+  @at-root &:active {
+    @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
+  }
 }
 
 :host([subtle]) #link-element {
   @include mixins.no-underline;
+
+  @at-root &:hover {
+    @include mixins.underline($text-decoration-color: var(--pharos-color-hover-primary));
+  }
+
+  @at-root &:active {
+    @include mixins.no-underline;
+  }
+
+  @at-root &.link--hover {
+    @include mixins.underline($text-decoration-color: var(--pharos-color-hover-primary));
+
+    color: var(--pharos-color-hover-primary);
+  }
 }
 
 :host([bold]) #link-element {
@@ -53,36 +76,22 @@
   min-width: 0;
 }
 
-:host([on-background]) #link-element:hover {
-  @include mixins.no-underline;
-}
+:host([indicate-visited]) #link-element {
+  @at-root &:visited {
+    @include mixins.underline($text-decoration-color: var(--pharos-color-night-blue-base));
 
-:host([on-background]) #link-element:active {
-  @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
-}
+    color: var(--pharos-color-night-blue-base);
 
-:host([subtle]) #link-element:hover {
-  @include mixins.underline($text-decoration-color: var(--pharos-color-hover-primary));
-}
+    @at-root &:hover {
+      @include mixins.no-underline;
 
-:host([subtle]) #link-element:active {
-  @include mixins.no-underline;
-}
-
-:host([on-background]:not([href])) #link-element {
-  @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
-
-  color: var(--pharos-color-interactive-tertiary);
+      color: var(--pharos-color-hover-primary);
+    }
+  }
 }
 
 :host([subtle]:not([href])) #link-element {
   @include mixins.no-underline;
-}
-
-:host([subtle]) #link-element.link--hover {
-  @include mixins.underline($text-decoration-color: var(--pharos-color-hover-primary));
-
-  color: var(--pharos-color-hover-primary);
 }
 
 :host([skip]:not(:focus-within)) {
@@ -95,23 +104,16 @@
   color: var(--pharos-color-interactive-secondary);
 }
 
-:host([indicate-visited]) #link-element:visited {
-  color: var(--pharos-color-night-blue-base);
-  text-decoration-color: var(--pharos-color-night-blue-base);
+:host([on-background][subtle]) #link-element {
+  @at-root &:hover {
+    @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
+  }
+
+  @at-root &:active {
+    @include mixins.no-underline;
+  }
 }
 
 :host([no-hover][subtle]) #link-element:hover {
   @include mixins.no-underline;
-}
-
-:host([on-background][subtle]) #link-element:hover {
-  @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
-}
-
-:host([on-background][subtle]) #link-element:active {
-  @include mixins.no-underline;
-}
-
-:host([indicate-visited]) #link-element:visited:hover {
-  color: var(--pharos-color-hover-primary);
 }

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -53,16 +53,6 @@
   min-width: 0;
 }
 
-:host([on-background]:not([href])) #link-element {
-  @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
-
-  color: var(--pharos-color-interactive-tertiary);
-}
-
-:host([subtle]:not([href])) #link-element {
-  @include mixins.no-underline;
-}
-
 :host([on-background]) #link-element:hover {
   @include mixins.no-underline;
 }
@@ -76,6 +66,16 @@
 }
 
 :host([subtle]) #link-element:active {
+  @include mixins.no-underline;
+}
+
+:host([on-background]:not([href])) #link-element {
+  @include mixins.underline($text-decoration-color: var(--pharos-color-interactive-tertiary));
+
+  color: var(--pharos-color-interactive-tertiary);
+}
+
+:host([subtle]:not([href])) #link-element {
   @include mixins.no-underline;
 }
 
@@ -98,10 +98,6 @@
 :host([indicate-visited]) #link-element:visited {
   color: var(--pharos-color-night-blue-base);
   text-decoration-color: var(--pharos-color-night-blue-base);
-
-  &:hover {
-    color: var(--pharos-color-hover-primary);
-  }
 }
 
 :host([no-hover][subtle]) #link-element:hover {
@@ -114,4 +110,8 @@
 
 :host([on-background][subtle]) #link-element:active {
   @include mixins.no-underline;
+}
+
+:host([indicate-visited]) #link-element:visited:hover {
+  color: var(--pharos-color-hover-primary);
 }

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -95,7 +95,7 @@
   color: var(--pharos-color-interactive-secondary);
 }
 
-:host([visitable]) #link-element:visited {
+:host([indicate-visited]) #link-element:visited {
   color: var(--pharos-color-night-blue-base);
   text-decoration-color: var(--pharos-color-night-blue-base);
 }

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -98,6 +98,10 @@
 :host([indicate-visited]) #link-element:visited {
   color: var(--pharos-color-night-blue-base);
   text-decoration-color: var(--pharos-color-night-blue-base);
+
+  &:hover {
+    color: var(--pharos-color-hover-primary);
+  }
 }
 
 :host([no-hover][subtle]) #link-element:hover {

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -77,6 +77,13 @@ export class PharosLink extends FocusMixin(AnchorElement) {
   @property({ type: Boolean, reflect: true, attribute: 'no-hover' })
   public noHover = false;
 
+  /**
+   * Indicates if the link should render the visited link styling.
+   * @attr bold
+   */
+  @property({ type: Boolean, reflect: true })
+  public visitable = false;
+
   @state()
   private _alert = false;
 

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -79,10 +79,10 @@ export class PharosLink extends FocusMixin(AnchorElement) {
 
   /**
    * Indicates if the link should render the visited link styling.
-   * @attr bold
+   * @attr indicate-visited
    */
   @property({ type: Boolean, reflect: true })
-  public visitable = false;
+  public indicateVisited = false;
 
   @state()
   private _alert = false;

--- a/packages/pharos/src/components/link/pharos-link.wc.stories.mdx
+++ b/packages/pharos/src/components/link/pharos-link.wc.stories.mdx
@@ -61,21 +61,10 @@ export const Template = (args) =>
   <Story name="Button">
     {html`
       <div style="margin-bottom: 1rem">
-        <pharos-link name="primary">Primary link</pharos-link>
-      </div>
-      <div style="margin-bottom: 1rem">
-        <pharos-link name="subtle" subtle>Subtle link</pharos-link>
-      </div>
-      <div style="width:100px; margin-bottom: 1rem">
-        <pharos-link name="multi">I have text that spans multiple lines</pharos-link>
+        <pharos-link name="primary">I am a button</pharos-link>
       </div>
       <div style="background-color: #000000; padding: 1rem; margin-bottom: 1rem">
         <pharos-link name="on-background" on-background>On compliant background</pharos-link>
-      </div>
-      <div style="background-color: #000000; padding: 1rem; margin-bottom: 1rem">
-        <pharos-link name="on-background-subtle" on-background subtle
-          >On compliant background with subtle</pharos-link
-        >
       </div>
     `}
   </Story>

--- a/packages/pharos/src/components/link/pharos-link.wc.stories.mdx
+++ b/packages/pharos/src/components/link/pharos-link.wc.stories.mdx
@@ -41,6 +41,20 @@ export const Template = (args) =>
   </Story>
 </Canvas>
 
+# Visited Link
+
+<Canvas withToolbar>
+  <Story name="Visited Link">
+    {html`
+      <div style="margin-bottom: 1rem">
+        <pharos-link href="https://www.google.com" target="_blank" indicate-visited
+          >Visited link</pharos-link
+        >
+      </div>
+    `}
+  </Story>
+</Canvas>
+
 # Button
 
 <Canvas withToolbar>

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -385,9 +385,11 @@
 /// Removes underlines.
 /// @access public
 /// @group links
+/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 @mixin no-underline {
-  text-decoration: solid underline transparent;
-  -webkit-text-decoration: solid underline transparent;
+  text-decoration-style: solid;
+  text-decoration-line: underline;
+  text-decoration-color: transparent;
 }
 
 /// Removes bullets from lists.

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -387,6 +387,7 @@
 /// @group links
 @mixin no-underline {
   text-decoration: solid underline transparent;
+  -webkit-text-decoration: solid underline transparent;
 }
 
 /// Removes bullets from lists.

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -382,10 +382,10 @@
   text-decoration-color: $text-decoration-color;
 }
 
+/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 /// Removes underlines.
 /// @access public
 /// @group links
-/* stylelint-disable declaration-block-no-redundant-longhand-properties */
 @mixin no-underline {
   text-decoration-style: solid;
   text-decoration-line: underline;


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

We want the visited links styling to show up for Pharos links, when the user has visited the link. The consumer of the component should be able to either apply the visited links styling or not apply by specifying the `visitable` property on the Pharos Link component, which is defaulted to `false`

**How does this change work?**

 We add css rule to apply the required styling for the pharos link instance that has `visitable` property specified as `true`,

