### PR TITLE
Heading: Fix text color inheritance for linked headings

### DIFF
--- a/.changeset/angry-guests-occur.md
+++ b/.changeset/angry-guests-occur.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+removes color inherit from pharos-heading

--- a/package.json
+++ b/package.json
@@ -149,6 +149,5 @@
     {
       "path": "packages/pharos/lib/index.js"
     }
-  ],
-  "packageManager": "yarn@1.22.19"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -149,5 +149,6 @@
     {
       "path": "packages/pharos/lib/index.js"
     }
-  ]
+  ],
+  "packageManager": "yarn@1.22.19"
 }

--- a/packages/pharos/src/components/heading/pharos-heading.scss
+++ b/packages/pharos/src/components/heading/pharos-heading.scss
@@ -8,7 +8,6 @@
 .heading {
   font-family: var(--pharos-font-family-serif);
   font-weight: var(--pharos-font-weight-regular);
-  color: inherit;
   margin-top: 0;
   margin-bottom: 0.5em;
 }

--- a/packages/pharos/src/components/link/PharosLink.react.stories.mdx
+++ b/packages/pharos/src/components/link/PharosLink.react.stories.mdx
@@ -36,6 +36,18 @@ import { PharosLink } from '../../react-components/link/pharos-link';
   </Story>
 </Canvas>
 
+# Visited Link Heading
+
+<Canvas withToolbar>
+  <Story name="Visited Link Heading">
+    <div style={{ marginBottom: '1rem' }}>
+      <PharosLink href="https://www.google.com" target="_blank" indicateVisited>
+        <PharosHeading level="1"> Visited link heading </PharosHeading>
+      </PharosLink>
+    </div>
+  </Story>
+</Canvas>
+
 # Button
 
 <Canvas withToolbar>

--- a/packages/pharos/src/components/link/pharos-link.wc.stories.mdx
+++ b/packages/pharos/src/components/link/pharos-link.wc.stories.mdx
@@ -55,6 +55,20 @@ export const Template = (args) =>
   </Story>
 </Canvas>
 
+# Visited Link Heading
+
+<Canvas withToolbar>
+  <Story name="Visited Link Heading">
+    {html`
+      <div style="margin-bottom: 1rem">
+        <pharos-link href="https://www.google.com" target="_blank" indicate-visited>
+          <pharos-heading level="1"> Visited link heading </pharos-heading>
+        </pharos-link>
+      </div>
+    `}
+  </Story>
+</Canvas>
+
 # Button
 
 <Canvas withToolbar>


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Headings were not properly reflecting color when linked inside a visited link, added in #409.

**How does this change work?**

Remove `color: inherit` which was added when headings were first introduced. We may have removed `inherit` from other properties along the way for similar reasons.
