### PR TITLE
Link & Image Card: Fix visited link hover state underline color for link + adding visited link support for title link in image card

### DIFF
--- a/.changeset/blue-toys-relate.md
+++ b/.changeset/blue-toys-relate.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Link & Image Card: Fix visited link hover state underline color for link + adding visited link support for title link in image card

--- a/.changeset/blue-toys-relate.md
+++ b/.changeset/blue-toys-relate.md
@@ -2,4 +2,5 @@
 '@ithaka/pharos': minor
 ---
 
-Link & Image Card: Fix visited link hover state underline color for link + adding visited link support for title link in image card
+Link: Fix visited link hover state underline color
+Image card: Add visited link support for title link

--- a/.changeset/bright-clouds-bake.md
+++ b/.changeset/bright-clouds-bake.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Link: Fixes visited link hover state underline color

--- a/.changeset/bright-clouds-bake.md
+++ b/.changeset/bright-clouds-bake.md
@@ -1,5 +1,0 @@
----
-'@ithaka/pharos': patch
----
-
-Link: Fixes visited link hover state underline color

--- a/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
+++ b/packages/pharos/src/components/image-card/PharosImageCard.react.stories.mdx
@@ -191,6 +191,14 @@ export const PromotionalTemplate = () => (
   </Story>
 </Canvas>
 
+# Visited Title Link
+
+<Canvas>
+  <Story name="Visited Title Link" args={{ indicateLinkVisited: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
 # With Action Menu
 
 <Canvas>

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -196,6 +196,13 @@ describe('pharos-image-card', () => {
     expect(heading?.getAttribute('level')).to.equal('2');
   });
 
+  it('uses the supplied indicate link visited', async () => {
+    component.indicateLinkVisited = true;
+    await component.updateComplete;
+    const link = component.renderRoot.querySelector('pharos-link.card__link--title');
+    expect(link?.getAttribute('indicate-visited')).to.equal('true');
+  });
+
   it('sets title link hover state when the card image link is hovered', async () => {
     const imageLink = component.renderRoot.querySelector('.card__link--image');
     imageLink?.parentElement?.dispatchEvent(new Event('mouseenter'));

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -135,6 +135,13 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   @property({ type: Boolean, reflect: true, attribute: 'disabled' })
   public disabled = false;
 
+  /**
+   * Indicates if the image card title link should render the visited link styling.
+   * @attr indicate-link-visited
+   */
+  @property({ type: Boolean, reflect: true, attribute: 'indicate-link-visited' })
+  public indicateLinkVisited = false;
+
   @state()
   private _isSelectableHovered = false;
 
@@ -315,7 +322,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       href="${this.link}"
       subtle
       flex
-      indicate-visited
+      indicate-visited="${this.indicateLinkVisited}"
       @click=${this._cardToggleSelect}
       >${this.title
         ? html`<pharos-heading

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -315,6 +315,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       href="${this.link}"
       subtle
       flex
+      indicate-visited
       @click=${this._cardToggleSelect}
       >${this.title
         ? html`<pharos-heading

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.mdx
@@ -207,6 +207,14 @@ export const Selectable = () => html`<pharos-layout tag="ol" style="margin: 1rem
   </Story>
 </Canvas>
 
+# Visited Title Link
+
+<Canvas>
+  <Story name="Visited Title Link" args={{ indicateLinkVisited: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
 # With Action Menu
 
 <Canvas>

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -86,6 +86,7 @@
       @include mixins.no-underline;
 
       color: var(--pharos-color-hover-primary);
+      text-decoration-color: var(--pharos-color-hover-primary);
     }
   }
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
For a link with `indicate-visited` set to `true`, when being visited, if the link contains underline on hover, then the underline color should be consistent with text color i.e `--pharos-color-hover-primary`.

**How does this change work?**
We add the `text-decoration-color` for the hover state for a visited link.
