### PR TITLE
fix(checkbox): update ARIA attribute on decorative SVG

### DIFF
--- a/.changeset/light-ravens-sip.md
+++ b/.changeset/light-ravens-sip.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Update ARIA attribute to improve screen reading experience for checkboxes

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.ts
@@ -134,7 +134,7 @@ export class PharosCheckbox extends FormMixin(FormElement) {
           height="24"
           class="input__icon"
           role="img"
-          aria-label="checkbox"
+          aria-hidden="true"
           focusable="false"
           @click="${this._handleClick}"
           @mousedown=${this._handleMousedown}


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Closes #424 

**How does this change work?**

Update the `aria-label` attribute on the decorative SVG element to `aria-hidden` so that it is explicitly hidden from assistive technologies rather than explicitly highlighted for them.
