### PR TITLE
ImageCard: stopPropagation when toggling select

### DIFF
--- a/.changeset/selfish-actors-exist.md
+++ b/.changeset/selfish-actors-exist.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+pharos-image card will only emit selected event or click instead of both

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -407,6 +407,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     if (!this.disabled && (cardClicked || checkboxClicked)) {
       // this is required to prevent navigation on the link click
       event.preventDefault();
+      event.stopPropagation();
       this._isSelected = !this._isSelected;
 
       this.dispatchEvent(


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [ ] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Currently, when the image card is in select mode, on a user click the card dispatches both a `click` and `pharos-image-card-selected`

**How does this change work?**

Only emit the `pharos-image-card-selected` event such that we can have greater fidelity for the consumer.