### PR TITLE
ToggleButton: indicate toggle button state on underlying button elements

### DIFF
--- a/.changeset/long-seahorses-obey.md
+++ b/.changeset/long-seahorses-obey.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Improve accessibility for toggle button groups

--- a/packages/pharos/src/components/button/pharos-button.test.ts
+++ b/packages/pharos/src/components/button/pharos-button.test.ts
@@ -103,6 +103,13 @@ describe('pharos-button', () => {
       );
       await expect(component).to.be.accessible();
     });
+
+    it('is accessible when pressed', async () => {
+      component = await fixture(
+        html`<pharos-button pressed="true">I am a pressed button</pharos-button>`
+      );
+      await expect(component).to.be.accessible();
+    });
   });
 
   describe('API', () => {

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -17,6 +17,8 @@ export type ButtonType = 'button' | 'submit' | 'reset';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'overlay';
 
+type PressedState = 'false' | 'true' | 'mixed' | 'undefined';
+
 const TYPES = ['button', 'submit', 'reset'];
 
 const VARIANTS = ['primary', 'secondary', 'subtle', 'overlay'];
@@ -136,6 +138,13 @@ export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement))
   @property({ type: String, reflect: true })
   public value?: string;
 
+  /**
+   * Indicates this button is a toggle button and whether it is pressed or not.
+   * @attr value
+   */
+  @property({ type: String, reflect: true })
+  public pressed: PressedState = 'undefined';
+
   @query('#button-element')
   private _button!: HTMLButtonElement | HTMLAnchorElement;
 
@@ -245,6 +254,7 @@ export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement))
             rel=${ifDefined(this.rel)}
             target=${ifDefined(this.target)}
             aria-label=${ifDefined(this.label)}
+            aria-pressed=${ifDefined(this.pressed)}
             @keyup=${this._handleKeyup}
           >
             ${this.buttonContent}
@@ -259,6 +269,7 @@ export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement))
             ?disabled=${this.disabled}
             type="${ifDefined(this.type)}"
             aria-label=${ifDefined(this.label)}
+            aria-pressed=${ifDefined(this.pressed)}
           >
             ${this.buttonContent}
           </button>

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -17,7 +17,7 @@ export type ButtonType = 'button' | 'submit' | 'reset';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'overlay';
 
-type PressedState = 'false' | 'true' | 'mixed' | 'undefined';
+export type PressedState = 'false' | 'true' | 'mixed' | 'undefined';
 
 const TYPES = ['button', 'submit', 'reset'];
 

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-button.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-button.ts
@@ -4,8 +4,8 @@ import { PharosButton } from '../button/pharos-button';
 import type { PharosSidenav } from './pharos-sidenav';
 
 import type { LinkTarget } from '../base/anchor-element';
-import type { ButtonType, IconName, ButtonVariant } from '../button/pharos-button';
-export type { LinkTarget, ButtonType, IconName, ButtonVariant };
+import type { ButtonType, IconName, ButtonVariant, PressedState } from '../button/pharos-button';
+export type { LinkTarget, ButtonType, IconName, ButtonVariant, PressedState };
 
 /**
  * Pharos sidenav button component.

--- a/packages/pharos/src/components/toast/pharos-toast-button.ts
+++ b/packages/pharos/src/components/toast/pharos-toast-button.ts
@@ -3,9 +3,9 @@ import { toastButtonStyles } from './pharos-toast-button.css';
 import { PharosButton } from '../button/pharos-button';
 
 import type { LinkTarget } from '../base/anchor-element';
-import type { ButtonType, IconName, ButtonVariant } from '../button/pharos-button';
+import type { ButtonType, IconName, ButtonVariant, PressedState } from '../button/pharos-button';
 
-export type { LinkTarget, ButtonType, IconName, ButtonVariant };
+export type { LinkTarget, ButtonType, IconName, ButtonVariant, PressedState };
 
 /**
  * Pharos toast button component.

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.test.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.test.ts
@@ -5,7 +5,9 @@ import type { PharosToggleButtonGroup } from './pharos-toggle-button-group';
 import type { PharosToggleButton } from './pharos-toggle-button';
 
 describe('pharos-toggle-button-group', () => {
-  let component: PharosToggleButtonGroup, componentLastButtonSelected: PharosToggleButton;
+  let component: PharosToggleButtonGroup;
+  let componentLastButtonSelected: PharosToggleButton;
+  let componentWithLabel: PharosToggleButton;
 
   beforeEach(async () => {
     component = await fixture(html`
@@ -23,6 +25,14 @@ describe('pharos-toggle-button-group', () => {
         <pharos-toggle-button id="button-6" selected>Button 6</pharos-toggle-button>
       </pharos-toggle-button-group>
     `);
+
+    componentWithLabel = await fixture(html`
+      <pharos-toggle-button-group group-label="New options">
+        <pharos-toggle-button id="button-7">Button 7</pharos-toggle-button>
+        <pharos-toggle-button id="button-8">Button 8</pharos-toggle-button>
+        <pharos-toggle-button id="button-9" selected>Button 9</pharos-toggle-button>
+      </pharos-toggle-button-group>
+    `);
   });
 
   it('is accessible', async () => {
@@ -34,6 +44,20 @@ describe('pharos-toggle-button-group', () => {
       '[role="group"]'
     ) as HTMLDivElement;
     expect(toggleButtonGroup).not.to.be.null;
+  });
+
+  it('renders a default aria-label', async () => {
+    const toggleButtonGroup = component.renderRoot.querySelector(
+      '[role="group"]'
+    ) as HTMLDivElement;
+    expect(toggleButtonGroup.getAttribute('aria-label')).to.equal('Options');
+  });
+
+  it('renders the provided aria-label', async () => {
+    const toggleButtonGroup = componentWithLabel.renderRoot.querySelector(
+      '[role="group"]'
+    ) as HTMLDivElement;
+    expect(toggleButtonGroup.getAttribute('aria-label')).to.equal('New options');
   });
 
   it('has a slot to contain the toggle button elements', async () => {
@@ -57,8 +81,11 @@ describe('pharos-toggle-button-group', () => {
     ) as PharosToggleButton[];
 
     expect(toggleButtons[0].selected).to.be.true;
+    expect(toggleButtons[0].pressed).to.equal('true');
     expect(toggleButtons[1].selected).to.be.false;
+    expect(toggleButtons[1].pressed).to.equal('false');
     expect(toggleButtons[2].selected).to.be.false;
+    expect(toggleButtons[2].pressed).to.equal('false');
   });
 
   it('selects the defined toggle button', async () => {
@@ -67,8 +94,11 @@ describe('pharos-toggle-button-group', () => {
     ) as PharosToggleButton[];
 
     expect(toggleButtons[0].selected).to.be.false;
+    expect(toggleButtons[0].pressed).to.equal('false');
     expect(toggleButtons[1].selected).to.be.false;
+    expect(toggleButtons[1].pressed).to.equal('false');
     expect(toggleButtons[2].selected).to.be.true;
+    expect(toggleButtons[2].pressed).to.equal('true');
   });
 
   it('changes the focus right with the right arrow key', async () => {
@@ -111,8 +141,11 @@ describe('pharos-toggle-button-group', () => {
     await aTimeout(1);
 
     expect(toggleButtons[0].selected).to.be.false;
+    expect(toggleButtons[0].pressed).to.equal('false');
     expect(toggleButtons[1].selected).to.be.false;
+    expect(toggleButtons[1].pressed).to.equal('false');
     expect(toggleButtons[2].selected).to.be.true;
+    expect(toggleButtons[2].pressed).to.equal('true');
   });
 
   it('wraps focus to the last toggle button when left arrow is hit on the first button', async () => {
@@ -159,7 +192,10 @@ describe('pharos-toggle-button-group', () => {
     await aTimeout(1);
 
     expect(toggleButtons[0].selected).to.be.false;
+    expect(toggleButtons[0].pressed).to.equal('false');
     expect(toggleButtons[1].selected).to.be.true;
+    expect(toggleButtons[1].pressed).to.equal('true');
     expect(toggleButtons[2].selected).to.be.false;
+    expect(toggleButtons[2].pressed).to.equal('false');
   });
 });

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -3,6 +3,7 @@ import { html } from 'lit';
 import type { TemplateResult, CSSResultArray } from 'lit';
 import { toggleButtonGroupStyles } from './pharos-toggle-button-group.css';
 import type { PharosToggleButton } from './pharos-toggle-button';
+import { property } from 'lit/decorators.js';
 
 /**
  * Pharos toggle button group component.
@@ -13,6 +14,13 @@ import type { PharosToggleButton } from './pharos-toggle-button';
  *
  */
 export class PharosToggleButtonGroup extends PharosElement {
+  /**
+   * The label used to announce this group to assistive technologies.
+   * @attr group-label
+   */
+  @property({ type: String, reflect: true, attribute: 'group-label' })
+  public groupLabel = 'Options';
+
   public static override get styles(): CSSResultArray {
     return [toggleButtonGroupStyles];
   }
@@ -42,6 +50,7 @@ export class PharosToggleButtonGroup extends PharosElement {
     const selectedButton: PharosToggleButton = selected ? selected : toggleButtons[0];
 
     selectedButton.selected = true;
+    selectedButton.pressed = 'true';
   }
 
   private _handleButtonSelected(event: Event): void {
@@ -53,6 +62,7 @@ export class PharosToggleButtonGroup extends PharosElement {
 
     if (previous) {
       previous.selected = false;
+      previous.pressed = 'false';
     }
 
     const toggleButtons: PharosToggleButton[] = Array.prototype.slice.call(
@@ -136,7 +146,7 @@ export class PharosToggleButtonGroup extends PharosElement {
 
   protected override render(): TemplateResult {
     return html`
-      <div class="toggle-button__list" role="group">
+      <div class="toggle-button__list" role="group" aria-label="${this.groupLabel}">
         <slot></slot>
       </div>
     `;

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
@@ -36,6 +36,7 @@ export class PharosToggleButton extends PharosButton {
 
   constructor() {
     super();
+    this.pressed = 'false';
     this.variant = 'secondary';
     this.type = 'button';
   }

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.ts
@@ -3,8 +3,14 @@ import type { CSSResultArray, PropertyValues } from 'lit';
 import { toggleButtonStyles } from './pharos-toggle-button.css';
 import { PharosButton } from '../button/pharos-button';
 
-import type { ButtonType, LinkTarget, IconName, ButtonVariant } from '../button/pharos-button';
-export type { ButtonType, LinkTarget, IconName, ButtonVariant };
+import type {
+  ButtonType,
+  LinkTarget,
+  IconName,
+  ButtonVariant,
+  PressedState,
+} from '../button/pharos-button';
+export type { ButtonType, LinkTarget, IconName, ButtonVariant, PressedState };
 
 /**
  * Pharos toggle button component.
@@ -87,6 +93,7 @@ export class PharosToggleButton extends PharosButton {
       composed: true,
     };
     this.selected = true;
+    this.pressed = 'true';
     this.dispatchEvent(new CustomEvent('pharos-toggle-button-selected', details));
   }
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Resolves #430 

Because the accessibility object model (AOM) is still in active development and doesn't enjoy wide browser vendor adoption at present, we need to maintain the accessibility for assistive technologies in the underlying native elements rather than the custom element host containers.

**How does this change work?**

For things like buttons, this often means adding a property that gets rendered onto the underlying native element as an `aria-` attribute. Here, I add a `pressed` property to Button so that the ToggleButton can set it appropriately, which gets rendered as `aria-pressed` on the underlying `<button>` element. I also add a `group-label` prop to ToggleButton that renders the `aria-label` for the full button group, useful for consumers to add the most contextualized description they can for each usage.

**Additional context**

The approach here is a generally desired one for optimal accessibility, and not unique to this particular component. Some of these may prove more difficult to manage, such as getting the right `aria-describedby` value down into the native element for any and every component that might need a tooltip. One approach could be for the tooltip to attach itself to the outermost shadow DOM element, but we'll need to take stock to see how future-proof that'd be.
