### PR TITLE
Tabs: fire event when tab selected programmatically

### DIFF
--- a/.changeset/six-days-ring.md
+++ b/.changeset/six-days-ring.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Fire pharos-tab-selected in response to tab being selected programmatically in addition to user clicks

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -1,7 +1,8 @@
-import { PharosElement } from '../base/pharos-element';
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit';
+
+import { PharosElement } from '../base/pharos-element';
 import { tabStyles } from './pharos-tab.css';
 
 /**
@@ -43,6 +44,13 @@ export class PharosTab extends PharosElement {
     if (changedProperties.has('selected')) {
       this._focused = this.selected;
       this.setAttribute('aria-selected', this.selected ? 'true' : 'false');
+      if (this.selected) {
+        const details = {
+          bubbles: true,
+          composed: true,
+        };
+        this.dispatchEvent(new CustomEvent('pharos-tab-selected', details));
+      }
     }
     if (changedProperties.has('_focused')) {
       this.setAttribute('tabindex', this._focused ? '0' : '-1');
@@ -50,12 +58,7 @@ export class PharosTab extends PharosElement {
   }
 
   private _handleClick(): void {
-    const details = {
-      bubbles: true,
-      composed: true,
-    };
     this.selected = true;
-    this.dispatchEvent(new CustomEvent('pharos-tab-selected', details));
   }
 
   protected override render(): TemplateResult {


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Resolves #220 

**How does this change work?**

Move firing of event from click handler to `updated` handler
