### PR TITLE
Dropdown: apply position computation and styles to proper element

### DIFF
--- a/.changeset/olive-days-melt.md
+++ b/.changeset/olive-days-melt.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Apply position computation and resulting styles to the proper menu element instead of the host container

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -237,7 +237,7 @@ export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayEl
     if (this._currentTrigger) {
       this._cleanup = autoUpdate(this._currentTrigger, this, () => {
         if (this._currentTrigger && this._menu) {
-          computePosition(this._currentTrigger, this, {
+          computePosition(this._currentTrigger, this._menu, {
             placement: this._navMenu ? 'bottom-start' : placement,
             strategy: this.strategy,
             middleware: [
@@ -247,7 +247,7 @@ export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayEl
               }),
             ],
           }).then(({ x, y }) => {
-            Object.assign(this.style, {
+            Object.assign(this._menu.style, {
               left: `${x}px`,
               top: `${y}px`,
             });


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

In #434 I used the DropdownMenu host container to compute and apply position styles, rather than the visible `_menu` element.

**How does this change work?**

Use `this._menu` for computing and applying styles, similar to how it's done in Tooltip.
