### PR TITLE
Refactor: use queryAssignedElements and simplify focus loops

### DIFF
--- a/.changeset/stupid-crabs-remember.md
+++ b/.changeset/stupid-crabs-remember.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+use queryAssignedElements and simplify focus loops

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -1,6 +1,6 @@
 import { PharosElement } from '../base/pharos-element';
 import { html, nothing } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 import type { PropertyValues, TemplateResult, CSSResultArray } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { alertStyles } from './pharos-alert.css';
@@ -66,6 +66,7 @@ export class PharosAlert extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
   @property({ type: Boolean, reflect: true })
   public closable = false;
 
+  @queryAssignedElements({ selector: '[data-pharos-component="PharosLink"]' })
   private _allLinks!: NodeListOf<PharosLink>;
 
   public static override get styles(): CSSResultArray {
@@ -92,8 +93,6 @@ export class PharosAlert extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
   }
 
   private _handleSlotChange(): void {
-    this._allLinks = this.querySelectorAll('[data-pharos-component="PharosLink"]');
-
     this._allLinks.forEach((link) => {
       link['_alert'] = true;
     });

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.ts
@@ -1,5 +1,6 @@
 import { PharosElement } from '../base/pharos-element';
 import { html } from 'lit';
+import { queryAssignedElements } from 'lit/decorators.js';
 import type { TemplateResult, CSSResultArray } from 'lit';
 import { breadcrumbStyles } from './pharos-breadcrumb.css';
 import type { PharosBreadcrumbItem } from './pharos-breadcrumb-item';
@@ -20,20 +21,16 @@ import FocusMixin from '../../utils/mixins/focus';
  *
  */
 export class PharosBreadcrumb extends FocusMixin(PharosElement) {
+  @queryAssignedElements({ selector: '[data-pharos-component="PharosBreadcrumbItem"]' })
+  private _allBreadcrumbItems!: NodeListOf<PharosBreadcrumbItem>;
+
   public static override get styles(): CSSResultArray {
     return [breadcrumbStyles];
   }
 
   private _handleSlotchange(): void {
-    const items: NodeListOf<PharosBreadcrumbItem> = this.querySelectorAll(
-      '[data-pharos-component="PharosBreadcrumbItem"]'
-    );
-    items.forEach((item, index) => {
-      item['_last'] = false;
-
-      if (index === items.length - 1) {
-        item['_last'] = true;
-      }
+    this._allBreadcrumbItems.forEach((item, index) => {
+      item['_last'] = index === this._allBreadcrumbItems.length - 1;
     });
   }
 

--- a/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.ts
+++ b/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 import type { PropertyValues, TemplateResult, CSSResultArray } from 'lit';
 import { checkboxGroupStyles } from './pharos-checkbox-group.css';
 import type { PharosCheckbox } from '../checkbox/pharos-checkbox';
@@ -35,17 +35,16 @@ export class PharosCheckboxGroup extends FormElement {
       .map((box) => (box as PharosCheckbox).value);
   }
 
+  @queryAssignedElements({ selector: '[data-pharos-component="PharosCheckbox"]' })
+  private _checkboxes!: NodeListOf<PharosCheckbox>;
+
   public static override get styles(): CSSResultArray {
     return [super.styles, checkboxGroupStyles];
   }
 
   protected override firstUpdated(): void {
     this._setBoxes();
-
-    const boxes: NodeListOf<PharosCheckbox> = this.querySelectorAll(
-      '[data-pharos-component="PharosCheckbox"]'
-    );
-    boxes.forEach((box) => {
+    this._checkboxes.forEach((box) => {
       box.addEventListener('change', (event: Event) => {
         event.stopPropagation();
 
@@ -73,10 +72,7 @@ export class PharosCheckboxGroup extends FormElement {
   }
 
   private _setBoxes(): void {
-    const boxes: NodeListOf<PharosCheckbox> = this.querySelectorAll(
-      '[data-pharos-component="PharosCheckbox"]'
-    );
-    boxes.forEach((box) => {
+    this._checkboxes.forEach((box) => {
       box.name = this.name;
       box.disabled = this.disabled;
       box.validated = this.validated;

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -372,7 +372,8 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
       '.combobox__option[highlighted]'
     ) as HTMLLIElement;
 
-    const index = values.findIndex((v) => v === highlightedOption?.innerText.trim());
+    let index = values.findIndex((v) => v === highlightedOption?.innerText.trim());
+    index = moveForward ? index : Math.max(index, 0);
     const nextOptionIndex = modulo(index + (moveForward ? 1 : -1), values.length);
 
     highlightedOption?.removeAttribute('highlighted');

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -13,7 +13,7 @@ import ScopedRegistryMixin from '../../utils/mixins/scoped-registry';
 import { PharosIcon } from '../icon/pharos-icon';
 import { PharosTooltip } from '../tooltip/pharos-tooltip';
 import { PharosButton } from '../button/pharos-button';
-import { modulo } from '../../utils/math';
+import { loopWrapIndex } from '../../utils/math';
 
 /**
  * Pharos combobox component.
@@ -372,10 +372,11 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
       '.combobox__option[highlighted]'
     ) as HTMLLIElement;
 
-    let index = values.findIndex((v) => v === highlightedOption?.innerText.trim());
-    index = moveForward ? index : Math.max(index, 0);
-    const nextOptionIndex = modulo(index + (moveForward ? 1 : -1), values.length);
-
+    const nextOptionIndex = loopWrapIndex(
+      values,
+      (v) => v === highlightedOption?.innerText.trim(),
+      moveForward
+    );
     highlightedOption?.removeAttribute('highlighted');
     highlightedOption?.setAttribute('aria-selected', 'false');
 

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -13,6 +13,7 @@ import ScopedRegistryMixin from '../../utils/mixins/scoped-registry';
 import { PharosIcon } from '../icon/pharos-icon';
 import { PharosTooltip } from '../tooltip/pharos-tooltip';
 import { PharosButton } from '../button/pharos-button';
+import { modulo } from '../../utils/math';
 
 /**
  * Pharos combobox component.
@@ -371,18 +372,13 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
       '.combobox__option[highlighted]'
     ) as HTMLLIElement;
 
-    let index = values.findIndex((v) => v === highlightedOption?.innerText.trim());
-
-    if (moveForward) {
-      index = index === values.length - 1 ? 0 : index + 1;
-    } else {
-      index = index === 0 || index === -1 ? values.length - 1 : index - 1;
-    }
+    const index = values.findIndex((v) => v === highlightedOption?.innerText.trim());
+    const nextOptionIndex = modulo(index + (moveForward ? 1 : -1), values.length);
 
     highlightedOption?.removeAttribute('highlighted');
     highlightedOption?.setAttribute('aria-selected', 'false');
 
-    const nextOption = options[index];
+    const nextOption = options[nextOptionIndex];
 
     nextOption.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     nextOption.setAttribute('highlighted', '');

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.ts
@@ -1,6 +1,6 @@
 import { PharosElement } from '../base/pharos-element';
 import { html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 import type { TemplateResult, CSSResultArray } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { dropdownMenuNavStyles } from './pharos-dropdown-menu-nav.css';
@@ -25,7 +25,10 @@ export class PharosDropdownMenuNav extends FocusMixin(PharosElement) {
   @property({ type: String, reflect: true })
   public label?: string;
 
+  @queryAssignedElements({ selector: '[data-pharos-component="PharosDropdownMenuNavLink"]' })
   private _allLinks!: NodeListOf<PharosDropdownMenuNavLink>;
+
+  @queryAssignedElements({ selector: '[data-pharos-component="PharosDropdownMenu"]' })
   private _allMenus!: NodeListOf<PharosDropdownMenu>;
 
   public static override get styles(): CSSResultArray {
@@ -46,9 +49,6 @@ export class PharosDropdownMenuNav extends FocusMixin(PharosElement) {
   }
 
   private _handleSlotChange(): void {
-    this._allLinks = this.querySelectorAll('[data-pharos-component="PharosDropdownMenuNavLink"]');
-    this._allMenus = this.querySelectorAll('[data-pharos-component="PharosDropdownMenu"]');
-
     this._allLinks.forEach((link) => {
       link.addEventListener('focusin', () => this._closeAllMenus());
       link.addEventListener('mouseenter', () => this._closeAllMenus(link));

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -15,7 +15,7 @@ import { FocusTrap } from '@ithaka/focus-trap';
 
 import type { Placement, PositioningStrategy } from '../base/overlay-element';
 import { autoUpdate, computePosition, flip, offset } from '../base/overlay-element';
-import { modulo } from '../../utils/math';
+import { loopWrapIndex } from '../../utils/math';
 export type { Placement, PositioningStrategy };
 
 const _allMenuItemsSelector = '[data-pharos-component="PharosDropdownMenuItem"]';
@@ -458,10 +458,7 @@ export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayEl
 
     const items: PharosDropdownMenuItem[] = Array.prototype.slice.call(this._activeMenuItems);
 
-    let index = items.findIndex((item) => item === current);
-    index = moveForward ? index : Math.max(index, 0);
-    const nextItemIndex = modulo(index + (moveForward ? 1 : -1), items.length);
-
+    const nextItemIndex = loopWrapIndex(items, (item) => item === current, moveForward);
     items[nextItemIndex]?.focus();
   }
 

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -458,7 +458,8 @@ export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayEl
 
     const items: PharosDropdownMenuItem[] = Array.prototype.slice.call(this._activeMenuItems);
 
-    const index = items.findIndex((item) => item === current);
+    let index = items.findIndex((item) => item === current);
+    index = moveForward ? index : Math.max(index, 0);
     const nextItemIndex = modulo(index + (moveForward ? 1 : -1), items.length);
 
     items[nextItemIndex]?.focus();

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -15,6 +15,7 @@ import { FocusTrap } from '@ithaka/focus-trap';
 
 import type { Placement, PositioningStrategy } from '../base/overlay-element';
 import { autoUpdate, computePosition, flip, offset } from '../base/overlay-element';
+import { modulo } from '../../utils/math';
 export type { Placement, PositioningStrategy };
 
 const _allMenuItemsSelector = '[data-pharos-component="PharosDropdownMenuItem"]';
@@ -457,15 +458,10 @@ export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayEl
 
     const items: PharosDropdownMenuItem[] = Array.prototype.slice.call(this._activeMenuItems);
 
-    let index = items.findIndex((item) => item === current);
+    const index = items.findIndex((item) => item === current);
+    const nextItemIndex = modulo(index + (moveForward ? 1 : -1), items.length);
 
-    if (moveForward) {
-      index = index === items.length - 1 ? 0 : index + 1;
-    } else {
-      index = index === 0 || index === -1 ? items.length - 1 : index - 1;
-    }
-
-    items[index]?.focus();
+    items[nextItemIndex]?.focus();
   }
 
   private _setupResizeObserver(): void {

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.ts
@@ -5,7 +5,7 @@ import { radioGroupStyles } from './pharos-radio-group.css';
 import type { PharosRadioButton } from '../radio-button/pharos-radio-button';
 
 import { FormElement } from '../base/form-element';
-import { modulo } from '../../utils/math';
+import { loopWrapIndex } from '../../utils/math';
 
 const _allRadioButtonsSelector = '[data-pharos-component="PharosRadioButton"]';
 
@@ -113,13 +113,10 @@ export class PharosRadioGroup extends FormElement {
       this.querySelectorAll(`${_allRadioButtonsSelector}:not([disabled])`)
     );
     const values = radios.map((radio) => radio.value);
-
     const focusedRadio = document.activeElement as PharosRadioButton;
-    let index = values.findIndex((v) => v === focusedRadio.value);
-    index = moveForward ? index : Math.max(index, 0);
-    const nextRadioIndex = modulo(index + (moveForward ? 1 : -1), values.length);
-
+    const nextRadioIndex = loopWrapIndex(values, (v) => v === focusedRadio.value, moveForward);
     const checkedRadio = radios[nextRadioIndex];
+
     checkedRadio['_radio'].click();
     checkedRadio['_radio'].focus();
   }

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.ts
@@ -5,6 +5,7 @@ import { radioGroupStyles } from './pharos-radio-group.css';
 import type { PharosRadioButton } from '../radio-button/pharos-radio-button';
 
 import { FormElement } from '../base/form-element';
+import { modulo } from '../../utils/math';
 
 const _allRadioButtonsSelector = '[data-pharos-component="PharosRadioButton"]';
 
@@ -114,17 +115,10 @@ export class PharosRadioGroup extends FormElement {
     const values = radios.map((radio) => radio.value);
 
     const focusedRadio = document.activeElement as PharosRadioButton;
-    let index = values.findIndex((v) => v === focusedRadio.value);
+    const index = values.findIndex((v) => v === focusedRadio.value);
+    const nextRadioIndex = modulo(index + (moveForward ? 1 : -1), values.length);
 
-    if (moveForward) {
-      // move forward/loop
-      index = index === values.length - 1 ? 0 : index + 1;
-    } else {
-      // move backwards/loop
-      index = index === 0 ? values.length - 1 : index - 1;
-    }
-
-    const checkedRadio = radios[index];
+    const checkedRadio = radios[nextRadioIndex];
     checkedRadio['_radio'].click();
     checkedRadio['_radio'].focus();
   }

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.ts
@@ -1,10 +1,12 @@
 import { html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 import type { PropertyValues, TemplateResult, CSSResultArray } from 'lit';
 import { radioGroupStyles } from './pharos-radio-group.css';
 import type { PharosRadioButton } from '../radio-button/pharos-radio-button';
 
 import { FormElement } from '../base/form-element';
+
+const _allRadioButtonsSelector = '[data-pharos-component="PharosRadioButton"]';
 
 /**
  * Pharos radio group component.
@@ -38,6 +40,9 @@ export class PharosRadioGroup extends FormElement {
     )?.value;
   }
 
+  @queryAssignedElements({ selector: _allRadioButtonsSelector })
+  private _radioButtons!: NodeListOf<PharosRadioButton>;
+
   private _clicked = false;
 
   public static override get styles(): CSSResultArray {
@@ -48,10 +53,7 @@ export class PharosRadioGroup extends FormElement {
     this._setRadios();
     this._addFocusListeners();
 
-    const radios: NodeListOf<PharosRadioButton> = this.querySelectorAll(
-      '[data-pharos-component="PharosRadioButton"]'
-    );
-    radios.forEach((radio) => {
+    this._radioButtons.forEach((radio) => {
       radio.addEventListener('change', (event: Event) => {
         event.stopPropagation();
 
@@ -107,7 +109,7 @@ export class PharosRadioGroup extends FormElement {
 
   private _handleArrowKeys(moveForward: boolean): void {
     const radios: PharosRadioButton[] = Array.prototype.slice.call(
-      this.querySelectorAll('[data-pharos-component="PharosRadioButton"]:not([disabled])')
+      this.querySelectorAll(`${_allRadioButtonsSelector}:not([disabled])`)
     );
     const values = radios.map((radio) => radio.value);
 
@@ -129,7 +131,7 @@ export class PharosRadioGroup extends FormElement {
 
   private _updateSelection(value: string): void {
     const previouslyChecked: PharosRadioButton | null = this.querySelector(
-      `[data-pharos-component="PharosRadioButton"][checked]:not([value="${value}"])`
+      `${_allRadioButtonsSelector}[checked]:not([value="${value}"])`
     );
 
     if (previouslyChecked) {
@@ -138,10 +140,7 @@ export class PharosRadioGroup extends FormElement {
   }
 
   private _setRadios(): void {
-    const radios: NodeListOf<PharosRadioButton> = this.querySelectorAll(
-      '[data-pharos-component="PharosRadioButton"]'
-    );
-    radios.forEach((radio) => {
+    this._radioButtons.forEach((radio) => {
       radio.name = this.name;
       radio.disabled = this.disabled;
       radio.validated = this.validated;
@@ -150,10 +149,7 @@ export class PharosRadioGroup extends FormElement {
   }
 
   private _addFocusListeners(): void {
-    const radios: NodeListOf<PharosRadioButton> = this.querySelectorAll(
-      '[data-pharos-component="PharosRadioButton"]'
-    );
-    radios.forEach((radio) => {
+    this._radioButtons.forEach((radio) => {
       // Disregard focus from clicks
       radio.addEventListener('mousedown', () => {
         this._clicked = true;
@@ -162,7 +158,7 @@ export class PharosRadioGroup extends FormElement {
       // Ensure focus is delegated to the selected radio when focus enters the group
       radio.addEventListener('focusin', (event: FocusEvent) => {
         const checkedRadio: PharosRadioButton | null = this.querySelector(
-          `[data-pharos-component="PharosRadioButton"][checked]`
+          `${_allRadioButtonsSelector}[checked]`
         );
 
         const withinGroup =

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.ts
@@ -115,7 +115,8 @@ export class PharosRadioGroup extends FormElement {
     const values = radios.map((radio) => radio.value);
 
     const focusedRadio = document.activeElement as PharosRadioButton;
-    const index = values.findIndex((v) => v === focusedRadio.value);
+    let index = values.findIndex((v) => v === focusedRadio.value);
+    index = moveForward ? index : Math.max(index, 0);
     const nextRadioIndex = modulo(index + (moveForward ? 1 : -1), values.length);
 
     const checkedRadio = radios[nextRadioIndex];

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
@@ -1,6 +1,6 @@
 import { PharosElement } from '../base/pharos-element';
 import { html } from 'lit';
-import { property } from 'lit/decorators.js';
+import { property, queryAssignedElements } from 'lit/decorators.js';
 import type { TemplateResult, CSSResultArray } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { sidenavMenuStyles } from './pharos-sidenav-menu.css';
@@ -37,6 +37,7 @@ export class PharosSidenavMenu extends ScopedRegistryMixin(FocusMixin(PharosElem
   @property({ type: Boolean, reflect: true })
   public expanded = false;
 
+  @queryAssignedElements({ selector: '[data-pharos-component="PharosSidenavLink"]' })
   private _allLinks!: NodeListOf<PharosSidenavLink>;
 
   public static override get styles(): CSSResultArray {
@@ -44,7 +45,6 @@ export class PharosSidenavMenu extends ScopedRegistryMixin(FocusMixin(PharosElem
   }
 
   protected override firstUpdated(): void {
-    this._allLinks = this.querySelectorAll('[data-pharos-component="PharosSidenavLink"]');
     this._allLinks.forEach((link) => {
       link.menuItem = true;
       link.setAttribute('role', 'menuitem');

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -121,7 +121,8 @@ export class PharosTabs extends PharosElement {
       return;
     }
 
-    const index = ids.findIndex((v) => v === focused.id);
+    let index = ids.findIndex((v) => v === focused.id);
+    index = moveForward ? index : Math.max(index, 0);
     const nextTabIndex = modulo(index + (moveForward ? 1 : -1), ids.length);
 
     focused['_focused'] = false;

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -6,6 +6,7 @@ import { tabsStyles } from './pharos-tabs.css';
 
 import type { PharosTab } from './pharos-tab';
 import type { PharosTabPanel } from './pharos-tab-panel';
+import { modulo } from '../../utils/math';
 
 const _allTabsSelector = '[data-pharos-component="PharosTab"]';
 const _allTabPanelsSelector = '[data-pharos-component="PharosTabPanel"]';
@@ -120,16 +121,11 @@ export class PharosTabs extends PharosElement {
       return;
     }
 
-    let index = ids.findIndex((v) => v === focused.id);
-
-    if (moveForward) {
-      index = index === ids.length - 1 ? 0 : index + 1;
-    } else {
-      index = index === 0 ? ids.length - 1 : index - 1;
-    }
+    const index = ids.findIndex((v) => v === focused.id);
+    const nextTabIndex = modulo(index + (moveForward ? 1 : -1), ids.length);
 
     focused['_focused'] = false;
-    const moveFocusTo = tabs[index];
+    const moveFocusTo = tabs[nextTabIndex];
     moveFocusTo['_focused'] = true;
 
     await moveFocusTo.updateComplete;

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -6,7 +6,7 @@ import { tabsStyles } from './pharos-tabs.css';
 
 import type { PharosTab } from './pharos-tab';
 import type { PharosTabPanel } from './pharos-tab-panel';
-import { modulo } from '../../utils/math';
+import { loopWrapIndex } from '../../utils/math';
 
 const _allTabsSelector = '[data-pharos-component="PharosTab"]';
 const _allTabPanelsSelector = '[data-pharos-component="PharosTabPanel"]';
@@ -121,9 +121,7 @@ export class PharosTabs extends PharosElement {
       return;
     }
 
-    let index = ids.findIndex((v) => v === focused.id);
-    index = moveForward ? index : Math.max(index, 0);
-    const nextTabIndex = modulo(index + (moveForward ? 1 : -1), ids.length);
+    const nextTabIndex = loopWrapIndex(ids, (v) => v === focused.id, moveForward);
 
     focused['_focused'] = false;
     const moveFocusTo = tabs[nextTabIndex];

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -4,6 +4,7 @@ import type { TemplateResult, CSSResultArray } from 'lit';
 import { toggleButtonGroupStyles } from './pharos-toggle-button-group.css';
 import type { PharosToggleButton } from './pharos-toggle-button';
 import { property, queryAssignedElements } from 'lit/decorators.js';
+import { modulo } from '../../utils/math';
 
 const _allToggleButtonsSelector = '[data-pharos-component="PharosToggleButton"]';
 
@@ -51,7 +52,7 @@ export class PharosToggleButtonGroup extends PharosElement {
 
   private _selectInitialToggleButton(toggleButtons: PharosToggleButton[]): void {
     const selected: PharosToggleButton | null = this._selectedToggleButtons[0];
-    const selectedButton: PharosToggleButton = selected ? selected : toggleButtons[0];
+    const selectedButton: PharosToggleButton = selected || toggleButtons[0];
 
     selectedButton.selected = true;
     selectedButton.pressed = 'true';
@@ -106,18 +107,11 @@ export class PharosToggleButtonGroup extends PharosElement {
       return;
     }
 
-    const focusedButtonIndex = toggleButtons.findIndex((button) => button.id === focused.id);
-    const lastButton = toggleButtons.length - 1;
-    const firstButton = 0;
-    let moveToIndex;
-    if (moveForward) {
-      moveToIndex = focusedButtonIndex === lastButton ? firstButton : focusedButtonIndex + 1;
-    } else {
-      moveToIndex = focusedButtonIndex === firstButton ? lastButton : focusedButtonIndex - 1;
-    }
+    const index = toggleButtons.findIndex((button) => button.id === focused.id);
+    const nextButtonIndex = modulo(index + (moveForward ? 1 : -1), toggleButtons.length);
 
     focused['_focused'] = false;
-    const moveFocusTo = toggleButtons[moveToIndex];
+    const moveFocusTo = toggleButtons[nextButtonIndex];
     moveFocusTo['_focused'] = true;
 
     await moveFocusTo.updateComplete;

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.ts
@@ -107,7 +107,8 @@ export class PharosToggleButtonGroup extends PharosElement {
       return;
     }
 
-    const index = toggleButtons.findIndex((button) => button.id === focused.id);
+    let index = toggleButtons.findIndex((button) => button.id === focused.id);
+    index = moveForward ? index : Math.max(index, 0);
     const nextButtonIndex = modulo(index + (moveForward ? 1 : -1), toggleButtons.length);
 
     focused['_focused'] = false;

--- a/packages/pharos/src/utils/math.test.ts
+++ b/packages/pharos/src/utils/math.test.ts
@@ -1,0 +1,24 @@
+import { expect } from '@open-wc/testing';
+import { modulo } from './math';
+
+describe('modulo', () => {
+  it('rolls over to zero at the modulus', () => {
+    expect(modulo(13, 13)).to.equal(0);
+  });
+
+  it('maintains its value when less than the modulus', () => {
+    expect(modulo(5, 13)).to.equal(5);
+  });
+
+  it('maintains its value when zero', () => {
+    expect(modulo(0, 13)).to.equal(0);
+  });
+
+  it('removes multiples of the modulus when more than the modulus', () => {
+    expect(modulo(13, 5)).to.equal(3);
+  });
+
+  it('works for negative numbers', () => {
+    expect(modulo(-3, 17)).to.equal(14);
+  });
+});

--- a/packages/pharos/src/utils/math.test.ts
+++ b/packages/pharos/src/utils/math.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { modulo } from './math';
+import { loopWrapIndex, modulo } from './math';
 
 describe('modulo', () => {
   it('rolls over to zero at the modulus', () => {
@@ -20,5 +20,23 @@ describe('modulo', () => {
 
   it('works for negative numbers', () => {
     expect(modulo(-3, 17)).to.equal(14);
+  });
+});
+
+describe('loopWrapIndex', () => {
+  it('returns the last item if moving backward from first item', () => {
+    expect(loopWrapIndex([0, 1, 2], (i) => i === 0, false)).to.equal(2);
+  });
+
+  it('returns the last item if moving backward and no current index', () => {
+    expect(loopWrapIndex([0, 1, 2], (i) => i === 42, false)).to.equal(2);
+  });
+
+  it('returns the first item if moving forward from last item', () => {
+    expect(loopWrapIndex([0, 1, 2], (i) => i === 2, true)).to.equal(0);
+  });
+
+  it('returns the first item if moving forward and no current index', () => {
+    expect(loopWrapIndex([0, 1, 2], (i) => i === 42, true)).to.equal(0);
   });
 });

--- a/packages/pharos/src/utils/math.ts
+++ b/packages/pharos/src/utils/math.ts
@@ -1,0 +1,8 @@
+/**
+ * Like the modulo operator (%), but works as expected for negative numbers.
+ * @param num
+ * @param modulus
+ */
+export const modulo = (num: number, modulus: number): number => {
+  return ((num % modulus) + modulus) % modulus;
+};

--- a/packages/pharos/src/utils/math.ts
+++ b/packages/pharos/src/utils/math.ts
@@ -6,3 +6,23 @@
 export const modulo = (num: number, modulus: number): number => {
   return ((num % modulus) + modulus) % modulus;
 };
+
+interface FilterFunction {
+  (item: any): boolean;
+}
+
+/**
+ * Given an array of items and an iteration direction, return the next index in that direction when looping is allowed.
+ * @param items
+ * @param currentItemFilterFunction
+ * @param moveForward
+ */
+export const loopWrapIndex = (
+  items: Array<any>,
+  currentItemFilterFunction: FilterFunction,
+  moveForward: boolean
+): number => {
+  let index = items.findIndex(currentItemFilterFunction);
+  index = moveForward ? index : Math.max(index, 0);
+  return modulo(index + (moveForward ? 1 : -1), items.length);
+};


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Resolves #294 

**How does this change work?**

- Replace imperative `querySelectorAll` (and some `querySelector`) with declarative `@queryAssignedElements` to move it out of the main component logic flow
- Replace forward/backward focus looping logic with a (custom) modulus calculation

**Additional context**

I tried finding opportunities to use some of the other directives mentioned, but after trying a few it felt like the new code wasn't any clearer. We're mostly using ternaries rather than if/else in our rendering, so the `when`/`choose` resulted in longer code that was more cluttered.