### PR TITLE
Tabs: make tabs scroll horizontally when cramped

### DIFF
--- a/.changeset/blue-adults-attend.md
+++ b/.changeset/blue-adults-attend.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Allow tabs to scroll horizontally when cramped

--- a/.storybook/main/preview.js
+++ b/.storybook/main/preview.js
@@ -1,5 +1,6 @@
 import { setCustomElements } from '@storybook/web-components';
 import { Canvas } from '@storybook/addon-docs';
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import customElements from '../../packages/pharos/custom-elements.json';
 import a11yConfig from '../a11yConfig';
@@ -22,5 +23,12 @@ export const parameters = {
     components: {
       Canvas: Canvas,
     },
+  },
+  viewport: {
+    viewports: {
+      ...MINIMAL_VIEWPORTS,
+      ...INITIAL_VIEWPORTS,
+    },
+    defaultViewport: 'responsive',
   },
 };

--- a/.storybook/react/preview.js
+++ b/.storybook/react/preview.js
@@ -4,6 +4,7 @@ import a11yConfig from '../a11yConfig';
 import '../styleConfig';
 import theme from '../theme';
 import '../../packages/pharos/src/test/initComponents';
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 export const parameters = {
   a11y: a11yConfig,
@@ -15,5 +16,12 @@ export const parameters = {
     components: {
       Canvas: Canvas,
     },
+  },
+  viewport: {
+    viewports: {
+      ...MINIMAL_VIEWPORTS,
+      ...INITIAL_VIEWPORTS,
+    },
+    defaultViewport: 'responsive',
   },
 };

--- a/.storybook/react/preview.js
+++ b/.storybook/react/preview.js
@@ -1,10 +1,10 @@
 import { Canvas } from '@storybook/addon-docs';
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import a11yConfig from '../a11yConfig';
 import '../styleConfig';
 import theme from '../theme';
 import '../../packages/pharos/src/test/initComponents';
-import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 export const parameters = {
   a11y: a11yConfig,

--- a/.storybook/wc/preview.js
+++ b/.storybook/wc/preview.js
@@ -1,12 +1,12 @@
 import { setCustomElementsManifest } from '@storybook/web-components';
 import { Canvas } from '@storybook/addon-docs';
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import customElementsManifest from '../../packages/pharos/custom-elements.json';
 import a11yConfig from '../a11yConfig';
 import '../styleConfig';
 import theme from '../theme';
 import '../../packages/pharos/src/test/initComponents';
-import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 window.process = window.process || {};
 window.process.env = window.process.env || {};

--- a/.storybook/wc/preview.js
+++ b/.storybook/wc/preview.js
@@ -6,6 +6,7 @@ import a11yConfig from '../a11yConfig';
 import '../styleConfig';
 import theme from '../theme';
 import '../../packages/pharos/src/test/initComponents';
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 window.process = window.process || {};
 window.process.env = window.process.env || {};
@@ -22,5 +23,12 @@ export const parameters = {
     components: {
       Canvas: Canvas,
     },
+  },
+  viewport: {
+    viewports: {
+      ...MINIMAL_VIEWPORTS,
+      ...INITIAL_VIEWPORTS,
+    },
+    defaultViewport: 'responsive',
   },
 };

--- a/packages/pharos-site/static/guidelines/tabs.docs.mdx
+++ b/packages/pharos-site/static/guidelines/tabs.docs.mdx
@@ -36,7 +36,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
 <PageSection topMargin title="Usage">
   <p>
     Use tabs to provide a way to switch between various related content that are grouped by logical
-    connection in a single space.
+    connection in a single space. Tabs on narrow screens become a horizontally-scrollable area.
   </p>
 </PageSection>
 

--- a/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
+++ b/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
@@ -113,3 +113,69 @@ export const PanelSeparator = {
     </PharosTabs>
   ),
 };
+
+export const HorizontalScrolling = {
+  render: () => (
+    <PharosTabs panelSeparator style={{ width: '100%' }}>
+      <PharosTab id="tab-1" data-panel-id="panel-1">
+        Tab 1
+      </PharosTab>
+      <PharosTab id="tab-2" data-panel-id="panel-2">
+        Tab 2
+      </PharosTab>
+      <PharosTab id="tab-3" data-panel-id="panel-3">
+        Tab 3
+      </PharosTab>
+      <PharosTab id="tab-4" data-panel-id="panel-4">
+        Tab 4
+      </PharosTab>
+      <PharosTab id="tab-5" data-panel-id="panel-5">
+        Tab 5
+      </PharosTab>
+      <PharosTab id="tab-6" data-panel-id="panel-6">
+        Tab 6
+      </PharosTab>
+      <PharosTab id="tab-7" data-panel-id="panel-7" selected>
+        Tab 7
+      </PharosTab>
+      <PharosTab id="tab-8" data-panel-id="panel-8">
+        Tab 8
+      </PharosTab>
+      <PharosTab id="tab-9" data-panel-id="panel-9">
+        Tab 9
+      </PharosTab>
+      <PharosTabPanel id="panel-1" slot="panel">
+        Panel 1 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-2" slot="panel">
+        Panel 2 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-3" slot="panel">
+        Panel 3 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-4" slot="panel">
+        Panel 4 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-5" slot="panel">
+        Panel 5 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-6" slot="panel">
+        Panel 6 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-7" slot="panel">
+        Panel 7 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-8" slot="panel">
+        Panel 8 with a panel separator
+      </PharosTabPanel>
+      <PharosTabPanel id="panel-9" slot="panel">
+        Panel 9 with a panel separator
+      </PharosTabPanel>
+    </PharosTabs>
+  ),
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};

--- a/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
+++ b/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
@@ -174,8 +174,7 @@ export const HorizontalScrolling = {
     </PharosTabs>
   ),
   parameters: {
-    viewport: {
-      defaultViewport: 'mobile1',
-    },
+    viewport: { defaultViewport: 'mobile1' },
+    chromatic: { viewports: [320, 1200] },
   },
 };

--- a/packages/pharos/src/components/tabs/pharos-tab.scss
+++ b/packages/pharos/src/components/tabs/pharos-tab.scss
@@ -12,7 +12,6 @@
   contain: content;
   display: grid;
   grid-template-columns: max-content;
-  scroll-margin-inline: var(--pharos-spacing-3-x);
 
   &::after {
     content: attr(data-text);

--- a/packages/pharos/src/components/tabs/pharos-tab.scss
+++ b/packages/pharos/src/components/tabs/pharos-tab.scss
@@ -4,14 +4,15 @@
   @include mixins.font-base;
   @include mixins.transition-base(color, border-bottom-color);
 
-  display: inline-block;
-  align-self: flex-start;
   color: var(--pharos-color-text-20);
   padding: var(--pharos-spacing-one-half-x) var(--pharos-spacing-1-x);
   border: none;
   background: none;
   border-bottom: 1px solid var(--pharos-color-ui-40);
   contain: content;
+  display: grid;
+  grid-template-columns: max-content;
+  scroll-margin-inline: var(--pharos-spacing-3-x);
 
   &::after {
     content: attr(data-text);

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -40,24 +40,16 @@ export class PharosTab extends PharosElement {
     this.dataset.text = this.textContent || '';
   }
 
-  private async _ensureVisible(): Promise<void> {
-    setTimeout(() => this.scrollIntoView(), 1);
-  }
-
   protected override async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('selected')) {
       this._focused = this.selected;
       this.setAttribute('aria-selected', this.selected ? 'true' : 'false');
       if (this.selected) {
         this._triggerSelectedEvent();
-        await this._ensureVisible();
       }
     }
 
     if (changedProperties.has('_focused')) {
-      if (this._focused) {
-        await this._ensureVisible();
-      }
       this.setAttribute('tabindex', this._focused ? '0' : '-1');
     }
   }

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -40,16 +40,24 @@ export class PharosTab extends PharosElement {
     this.dataset.text = this.textContent || '';
   }
 
-  protected override updated(changedProperties: PropertyValues): void {
+  private async _ensureVisible(): Promise<void> {
+    setTimeout(() => this.scrollIntoView(), 1);
+  }
+
+  protected override async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('selected')) {
       this._focused = this.selected;
       this.setAttribute('aria-selected', this.selected ? 'true' : 'false');
       if (this.selected) {
         this._triggerSelectedEvent();
+        await this._ensureVisible();
       }
     }
 
     if (changedProperties.has('_focused')) {
+      if (this._focused) {
+        await this._ensureVisible();
+      }
       this.setAttribute('tabindex', this._focused ? '0' : '-1');
     }
   }

--- a/packages/pharos/src/components/tabs/pharos-tabs.scss
+++ b/packages/pharos/src/components/tabs/pharos-tabs.scss
@@ -4,10 +4,35 @@
   contain: layout;
 }
 
+.cloak {
+  --cloak-distance: 20%;
+  --cloak-antidistance: calc(100% - var(--cloak-distance));
+
+  @at-root #{&}--cloak-left {
+    mask-image: linear-gradient(to right, transparent, gray var(--cloak-distance));
+  }
+
+  @at-root #{&}--cloak-right {
+    mask-image: linear-gradient(to left, transparent, gray var(--cloak-distance));
+  }
+
+  @at-root #{&}--cloak-left#{&}--cloak-right {
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      gray var(--cloak-distance),
+      gray var(--cloak-antidistance),
+      transparent
+    );
+  }
+}
+
 .tab__list {
   display: flex;
-  flex-direction: row;
-  margin-bottom: var(--pharos-spacing-one-and-a-half-x);
+  overflow-x: scroll;
+  scroll-behavior: smooth;
+  margin-bottom: var(--pharos-spacing-one-half-x);
+  padding-bottom: var(--pharos-spacing-1-x);
 }
 
 .tab__panels {

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -94,11 +94,15 @@ export class PharosTabs extends PharosElement {
     this._tabOverflowObserver.observe(this._tabs[this._tabs.length - 1]);
   }
 
+  private _makeTabVisible(tab: PharosTab) {
+    this._tabList.scroll({ left: tab.offsetLeft - 3 * 16, behavior: 'smooth' });
+  }
+
   private _watchResize(): void {
     this._tabListResizeObserver = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.target === this._tabList) {
-          this._selectedTabs[0].scrollIntoView();
+          this._makeTabVisible(this._selectedTabs[0]);
         }
       });
     });
@@ -125,6 +129,7 @@ export class PharosTabs extends PharosElement {
 
   private _handleTabSelected(selectedTab: PharosTab): void {
     selectedTab.selected = true;
+    this._makeTabVisible(selectedTab);
 
     const previousTab: PharosTab | null = this.querySelector(
       `${_allTabsSelector}[selected]:not([id="${selectedTab.id}"])`
@@ -187,6 +192,7 @@ export class PharosTabs extends PharosElement {
 
     await moveFocusTo.updateComplete;
     moveFocusTo.focus();
+    this._makeTabVisible(moveFocusTo);
   }
 
   private _handleEnterKey(): void {

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -68,39 +68,40 @@ export class PharosTabs extends PharosElement {
     this._watchResize();
   }
 
-  private _tabOverflowObserver = new IntersectionObserver(
-    (entries) => {
-      entries.forEach((entry) => {
-        if (entry.target === this._tabs[0]) {
-          this._overflowingLeft = entry.intersectionRatio < 1;
-        }
-
-        if (entry.target === this._tabs[this._tabs.length - 1]) {
-          this._overflowingRight = entry.intersectionRatio < 1;
-        }
-      });
-    },
-    {
-      root: this._tabList,
-      rootMargin: '1px',
-      threshold: 1,
-    }
-  );
+  private _tabOverflowObserver!: IntersectionObserver;
+  private _tabListResizeObserver!: ResizeObserver;
 
   private _watchTablistScrolling(): void {
+    this._tabOverflowObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.target === this._tabs[0]) {
+            this._overflowingLeft = entry.intersectionRatio < 1;
+          }
+
+          if (entry.target === this._tabs[this._tabs.length - 1]) {
+            this._overflowingRight = entry.intersectionRatio < 1;
+          }
+        });
+      },
+      {
+        root: this._tabList,
+        rootMargin: '1px',
+        threshold: 1,
+      }
+    );
     this._tabOverflowObserver.observe(this._tabs[0]);
     this._tabOverflowObserver.observe(this._tabs[this._tabs.length - 1]);
   }
 
-  private _tabListResizeObserver = new ResizeObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.target === this._tabList) {
-        this._selectedTabs[0].scrollIntoView();
-      }
-    });
-  });
-
   private _watchResize(): void {
+    this._tabListResizeObserver = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.target === this._tabList) {
+          this._selectedTabs[0].scrollIntoView();
+        }
+      });
+    });
     this._tabListResizeObserver.observe(this._tabList);
   }
 

--- a/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
+++ b/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
@@ -125,8 +125,7 @@ export const HorizontalScrolling = {
       </pharos-tabs>
     `,
   parameters: {
-    viewport: {
-      defaultViewport: 'mobile1',
-    },
+    viewport: { defaultViewport: 'mobile1' },
+    chromatic: { viewports: [320, 1200] },
   },
 };

--- a/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
+++ b/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
@@ -81,3 +81,52 @@ export const PanelSeparator = {
       </pharos-tabs>
     `,
 };
+
+export const HorizontalScrolling = {
+  render: () =>
+    html`
+      <pharos-tabs panel-separator style="width: 100%">
+        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
+        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
+        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
+        <pharos-tab id="tab-4" data-panel-id="panel-4">Tab 4</pharos-tab>
+        <pharos-tab id="tab-5" data-panel-id="panel-5">Tab 5</pharos-tab>
+        <pharos-tab id="tab-6" data-panel-id="panel-6">Tab 6</pharos-tab>
+        <pharos-tab id="tab-7" data-panel-id="panel-7" selected>Tab 7</pharos-tab>
+        <pharos-tab id="tab-8" data-panel-id="panel-8">Tab 8</pharos-tab>
+        <pharos-tab id="tab-9" data-panel-id="panel-9">Tab 9</pharos-tab>
+        <pharos-tab-panel id="panel-1" slot="panel"
+          >Panel 1 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-2" slot="panel"
+          >Panel 2 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-3" slot="panel"
+          >Panel 3 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-4" slot="panel"
+          >Panel 4 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-5" slot="panel"
+          >Panel 5 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-6" slot="panel"
+          >Panel 6 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-7" slot="panel"
+          >Panel 7 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-8" slot="panel"
+          >Panel 8 with a panel separator</pharos-tab-panel
+        >
+        <pharos-tab-panel id="panel-9" slot="panel"
+          >Panel 9 with a panel separator</pharos-tab-panel
+        >
+      </pharos-tabs>
+    `,
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};

--- a/packages/pharos/src/utils/math.ts
+++ b/packages/pharos/src/utils/math.ts
@@ -8,7 +8,7 @@ export const modulo = (num: number, modulus: number): number => {
 };
 
 interface FilterFunction {
-  (item: any): boolean;
+  <Type>(item: Type): boolean;
 }
 
 /**
@@ -17,8 +17,8 @@ interface FilterFunction {
  * @param currentItemFilterFunction
  * @param moveForward
  */
-export const loopWrapIndex = (
-  items: Array<any>,
+export const loopWrapIndex = <Type>(
+  items: Array<Type>,
   currentItemFilterFunction: FilterFunction,
   moveForward: boolean
 ): number => {


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Resolves #292 

**How does this change work?**

When a list of tabs is cramped horizontally, make them scrollable with indicators of scrollability.
