### PR TITLE
Storybook: use Pharos standard colors for background options

### DIFF
--- a/.storybook/main/preview.js
+++ b/.storybook/main/preview.js
@@ -29,6 +29,18 @@ export const parameters = {
       ...MINIMAL_VIEWPORTS,
       ...INITIAL_VIEWPORTS,
     },
-    defaultViewport: 'responsive',
+  },
+  backgrounds: {
+    default: 'White',
+    values: [
+      {
+        name: 'White',
+        value: '#FFFFFF',
+      },
+      {
+        name: 'Black',
+        value: '#000000',
+      },
+    ],
   },
 };

--- a/.storybook/react/preview.js
+++ b/.storybook/react/preview.js
@@ -1,27 +1,4 @@
-import { Canvas } from '@storybook/addon-docs';
-import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
-
-import a11yConfig from '../a11yConfig';
 import '../styleConfig';
-import theme from '../theme';
 import '../../packages/pharos/src/test/initComponents';
 
-export const parameters = {
-  a11y: a11yConfig,
-  controls: { expanded: true },
-  docs: {
-    source: { type: 'dynamic' },
-    inlineStories: true,
-    theme: theme,
-    components: {
-      Canvas: Canvas,
-    },
-  },
-  viewport: {
-    viewports: {
-      ...MINIMAL_VIEWPORTS,
-      ...INITIAL_VIEWPORTS,
-    },
-    defaultViewport: 'responsive',
-  },
-};
+export { parameters } from '../main/preview';

--- a/.storybook/wc/preview.js
+++ b/.storybook/wc/preview.js
@@ -1,11 +1,7 @@
 import { setCustomElementsManifest } from '@storybook/web-components';
-import { Canvas } from '@storybook/addon-docs';
-import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 import customElementsManifest from '../../packages/pharos/custom-elements.json';
-import a11yConfig from '../a11yConfig';
 import '../styleConfig';
-import theme from '../theme';
 import '../../packages/pharos/src/test/initComponents';
 
 window.process = window.process || {};
@@ -14,21 +10,4 @@ window.process.env.NODE_ENV = window.process.env.NODE_ENV || 'production';
 
 setCustomElementsManifest(customElementsManifest);
 
-export const parameters = {
-  a11y: a11yConfig,
-  controls: { expanded: true },
-  docs: {
-    inlineStories: true,
-    theme: theme,
-    components: {
-      Canvas: Canvas,
-    },
-  },
-  viewport: {
-    viewports: {
-      ...MINIMAL_VIEWPORTS,
-      ...INITIAL_VIEWPORTS,
-    },
-    defaultViewport: 'responsive',
-  },
-};
+export { parameters } from '../main/preview';


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

The default "dark" background in `@storybook/addon-backgrounds` is a dark grey, and is almost identical in color to some of our components' background colors because they're meant to display on a black background.

**How does this change work?**

- Add a `backgrounds` section to the `parameters` to set a hard white and black.
- Reduce code duplication and let both the web component and React Storybooks use the same `main` config.

**Additional context**

- I tried using the `--pharos-color-white` and `--pharos-color-black` tokens in the config, and that mostly worked, but didn't properly show the color swatch next to the color option in the backgrounds dropdown.

<img width="218" alt="Screen Shot 2022-12-09 at 19 37 32" src="https://user-images.githubusercontent.com/1808306/206819194-372edb5d-0c55-4e76-ae52-9666de665177.png">

<img width="215" alt="Screen Shot 2022-12-09 at 19 37 58" src="https://user-images.githubusercontent.com/1808306/206819221-f9561043-c6f8-47e8-9a7a-e5f5228246a3.png">
