### PR TITLE
Toast: make toast IDs unique

### DIFF
--- a/.changeset/itchy-actors-worry.md
+++ b/.changeset/itchy-actors-worry.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix duplicate id in toast

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@storybook/source-loader": "^6.5.13",
     "@storybook/theming": "^6.5.13",
     "@storybook/web-components": "^6.5.13",
+    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
     "all-contributors-cli": "^6.20.0",

--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -58,7 +58,8 @@
     "@ithaka/focus-trap": "2.0.1",
     "@lit-labs/scoped-registry-mixin": "^1.0.0",
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "lit": "^2.0.0"
+    "lit": "^2.0.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.5.6",

--- a/packages/pharos/src/components/toast/pharos-toast.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.test.ts
@@ -31,7 +31,7 @@ describe('pharos-toast', () => {
     await component.updateComplete;
 
     component.dispatchEvent(new FocusEvent('focusout'));
-    await aTimeout(6000);
+    await aTimeout(7000);
     await component.updateComplete;
 
     expect(component.open).to.be.false;

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -26,8 +26,6 @@ const TOAST_LIFE = 6000;
 
 export const DEFAULT_STATUS = 'success';
 
-export const DEFAULT_ID = 'toast';
-
 export const DEFAULT_INDEFINITE = false;
 
 /**
@@ -65,7 +63,7 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
    * @attr id
    */
   @property({ type: String, reflect: true })
-  public override id = DEFAULT_ID;
+  public override id = 'toast';
 
   /**
    * Indicates if the toast should persist indefinitely

--- a/packages/pharos/src/components/toast/pharos-toaster.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.test.ts
@@ -78,12 +78,8 @@ describe('pharos-toaster', () => {
     await component.updateComplete;
     await nextFrame();
 
-    expect(component).dom.to.equal(`
-      <pharos-toaster data-pharos-component="PharosToaster">
-        <pharos-toast data-pharos-component="PharosToast" id="toast" open="" status="success">I am a toast</pharos-toast>
-        <pharos-toast data-pharos-component="PharosToast" id="toast" open="" status="success">I am a toast</pharos-toast>
-      </pharos-toaster>
-    `);
+    const toast = component.querySelectorAll('pharos-toast');
+    expect(toast.length).to.equal(2);
   });
 
   it('delegates focus to a newly opened toast', async () => {

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -53,7 +53,7 @@ export class PharosToaster extends PharosElement {
   }
 
   private _getToastID(id: string | null) {
-    return id || DEFAULT_ID + uuidv4();
+    return id || DEFAULT_ID + '_' + uuidv4();
   }
 
   private async _openToast(event: Event): Promise<void> {

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -4,7 +4,7 @@ import type { TemplateResult, CSSResultArray } from 'lit';
 import { toasterStyles } from './pharos-toaster.css';
 
 import type { PharosToast } from './pharos-toast';
-import { DEFAULT_STATUS, DEFAULT_ID, DEFAULT_INDEFINITE } from './pharos-toast';
+import { DEFAULT_STATUS, DEFAULT_INDEFINITE } from './pharos-toast';
 
 import { v4 as uuidv4 } from 'uuid';
 
@@ -53,7 +53,7 @@ export class PharosToaster extends PharosElement {
   }
 
   private _getToastID(id: string | null) {
-    return id || DEFAULT_ID + '_' + uuidv4();
+    return id || `toast_${uuidv4()}`;
   }
 
   private async _openToast(event: Event): Promise<void> {

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -6,6 +6,8 @@ import { toasterStyles } from './pharos-toaster.css';
 import type { PharosToast } from './pharos-toast';
 import { DEFAULT_STATUS, DEFAULT_ID, DEFAULT_INDEFINITE } from './pharos-toast';
 
+import { v4 as uuidv4 } from 'uuid';
+
 /**
  * pharos-toast-open event.
  *
@@ -51,7 +53,7 @@ export class PharosToaster extends PharosElement {
   }
 
   private _getToastID(id: string | null) {
-    return id || DEFAULT_ID;
+    return id || DEFAULT_ID + uuidv4();
   }
 
   private async _openToast(event: Event): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20683,6 +20683,11 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://artifactory.acorn.cirrostratus.org/artifactory/api/npm/npms/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20685,7 +20685,7 @@ uuid@^8.3.2:
 
 uuid@^9.0.0:
   version "9.0.0"
-  resolved "https://artifactory.acorn.cirrostratus.org/artifactory/api/npm/npms/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  resolved "https://registry.yarnpkg.com/artifactory/api/npm/npms/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4837,6 +4837,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/uuid@^9.0.0":
+  version "9.0.0"
+  resolved "https://artifactory.acorn.cirrostratus.org/artifactory/api/npm/npms/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
+  integrity sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==
+
 "@types/vfile-message@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20685,7 +20685,7 @@ uuid@^8.3.2:
 
 uuid@^9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/artifactory/api/npm/npms/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4839,7 +4839,7 @@
 
 "@types/uuid@^9.0.0":
   version "9.0.0"
-  resolved "https://artifactory.acorn.cirrostratus.org/artifactory/api/npm/npms/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.0.tgz#53ef263e5239728b56096b0a869595135b7952d2"
   integrity sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==
 
 "@types/vfile-message@*":


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [x] Component status page up to date?

**What does this change address?**
When consumer doesn't provide an id to the toast, we used to set default toast id to be "toast", which cause duplicate id if same toast is emitted more than once. And because of the duplicated id, some toasts are not actually destroyed after they self-closed. Resulting in "ghost toasts" on the page. 

<img width="734" alt="image" src="https://user-images.githubusercontent.com/38861633/208513944-f8d0aa02-3d79-4145-980f-a05931a52143.png">


**How does this change work?**
Make the id unique, no more ghost toasts.

