### PR TITLE
Tabs: move selected state management to pharos-tabs

### DIFF
--- a/.changeset/perfect-cycles-drum.md
+++ b/.changeset/perfect-cycles-drum.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': major
+---
+
+pharos-tab `selected` has been deprecated, see new property for pharos-tabs `selected-tab`

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -60,7 +60,9 @@ export class PharosTab extends PharosElement {
   }
 
   private _handleClick(): void {
-    this._triggerSelectedEvent();
+    if (!this.selected) {
+      this._triggerSelectedEvent();
+    }
   }
 
   protected override render(): TemplateResult {

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -44,9 +44,6 @@ export class PharosTab extends PharosElement {
     if (changedProperties.has('selected')) {
       this._focused = this.selected;
       this.setAttribute('aria-selected', this.selected ? 'true' : 'false');
-      if (this.selected) {
-        this._triggerSelectedEvent();
-      }
     }
 
     if (changedProperties.has('_focused')) {
@@ -63,7 +60,7 @@ export class PharosTab extends PharosElement {
   }
 
   private _handleClick(): void {
-    this.selected = true;
+    this._triggerSelectedEvent();
   }
 
   protected override render(): TemplateResult {

--- a/packages/pharos/src/components/tabs/pharos-tab.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.ts
@@ -63,7 +63,7 @@ export class PharosTab extends PharosElement {
   }
 
   private _handleClick(): void {
-    this._triggerSelectedEvent();
+    this.selected = true;
   }
 
   protected override render(): TemplateResult {

--- a/packages/pharos/src/components/tabs/pharos-tabs.test.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.test.ts
@@ -21,10 +21,10 @@ describe('pharos-tabs', () => {
     `);
 
     componentLastTabSelected = await fixture(html`
-      <pharos-tabs>
+      <pharos-tabs selected-tab="2">
         <pharos-tab id="tab-4" data-panel-id="panel-4">Tab 1</pharos-tab>
         <pharos-tab id="tab-5" data-panel-id="panel-5">Tab 2</pharos-tab>
-        <pharos-tab id="tab-6" data-panel-id="panel-6" selected>Tab 3</pharos-tab>
+        <pharos-tab id="tab-6" data-panel-id="panel-6">Tab 3</pharos-tab>
         <pharos-tab-panel id="panel-4" slot="panel">Panel 1</pharos-tab-panel>
         <pharos-tab-panel id="panel-5" slot="panel">Panel 2</pharos-tab-panel>
         <pharos-tab-panel id="panel-6" slot="panel">Panel 3</pharos-tab-panel>

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -32,7 +32,7 @@ export class PharosTabs extends PharosElement {
   public panelSeparator = false;
 
   /**
-   * Indicates if the tab is selected-tab.
+   * The 0-based index of the tab that is initially selected.
    * @attr selected-tab
    */
   @property({ type: Number, reflect: true, attribute: 'selected-tab' })

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -48,9 +48,6 @@ export class PharosTabs extends PharosElement {
   @queryAssignedElements({ selector: _allTabsSelector })
   private _tabs!: NodeListOf<PharosTab>;
 
-  @queryAssignedElements({ selector: `${_allTabsSelector}[selected]` })
-  private _selectedTabs!: NodeListOf<PharosTab>;
-
   public static override get styles(): CSSResultArray {
     return [tabsStyles];
   }
@@ -129,9 +126,6 @@ export class PharosTabs extends PharosElement {
   }
 
   private _selectInitialTab(): void {
-    if (this._selectedTabs?.[0]) {
-      this.selectedTab = this._findTabIndex(this._selectedTabs[0]);
-    }
     const selectedTab: PharosTab = this._tabs[this.selectedTab];
     selectedTab.selected = true;
     this._makeTabVisible(selectedTab);

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -1,6 +1,6 @@
 import { PharosElement } from '../base/pharos-element';
 import { html } from 'lit';
-import type { TemplateResult, CSSResultArray } from 'lit';
+import type { TemplateResult, CSSResultArray, PropertyValues } from 'lit';
 import { property, query, queryAssignedElements, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { tabsStyles } from './pharos-tabs.css';
@@ -28,6 +28,13 @@ export class PharosTabs extends PharosElement {
    */
   @property({ type: Boolean, reflect: true, attribute: 'panel-separator' })
   public panelSeparator = false;
+
+  /**
+   * Indicates if the tab is selected-tab.
+   * @attr selected-tab
+   */
+  @property({ type: Number, reflect: true })
+  public selectedTab = 0;
 
   @query('.tab__list')
   private _tabList!: HTMLElement;
@@ -66,6 +73,12 @@ export class PharosTabs extends PharosElement {
     this._selectInitialTab();
     this._watchTablistScrolling();
     this._watchResize();
+  }
+
+  protected override async updated(changedProperties: PropertyValues): Promise<void> {
+    if (changedProperties.has('selected-tab')) {
+      this._handleTabSelected(this._tabs[this.selectedTab]);
+    }
   }
 
   private _tabOverflowObserver!: IntersectionObserver;
@@ -128,6 +141,9 @@ export class PharosTabs extends PharosElement {
   }
 
   private _handleTabSelected(selectedTab: PharosTab): void {
+    this.selectedTab = Array.from(this._tabs).findIndex(
+      (tab: PharosTab) => tab.id === selectedTab.id
+    );
     selectedTab.selected = true;
     this._makeTabVisible(selectedTab);
 

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -76,6 +76,13 @@ export class PharosTabs extends PharosElement {
 
   protected override async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('selectedTab') && this._tabs[this.selectedTab]) {
+      const details = {
+        bubbles: true,
+        composed: true,
+        detail: this._tabs[this.selectedTab],
+      };
+      this.dispatchEvent(new CustomEvent('pharos-tabs-tab-selected', details));
+
       this._handleTabSelected(this._tabs[this.selectedTab]);
     }
   }
@@ -151,13 +158,6 @@ export class PharosTabs extends PharosElement {
   }
 
   private _handleTabSelected(selectedTab: PharosTab): void {
-    const details = {
-      bubbles: true,
-      composed: true,
-      detail: selectedTab,
-    };
-    this.dispatchEvent(new CustomEvent('pharos-tabs-tab-selected', details));
-
     this.selectedTab = this._findTabIndex(selectedTab);
     selectedTab.selected = true;
     this._makeTabVisible(selectedTab);

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -20,6 +20,8 @@ const _allTabPanelsSelector = '[data-pharos-component="PharosTabPanel"]';
  * @slot - Contains the tabs.
  * @slot panel - Contains the panel to be shown for a tab.
  *
+ * @fires pharos-tabs-tab-selected - Fires when the tab is selected.
+ *
  */
 export class PharosTabs extends PharosElement {
   /**
@@ -149,6 +151,13 @@ export class PharosTabs extends PharosElement {
   }
 
   private _handleTabSelected(selectedTab: PharosTab): void {
+    const details = {
+      bubbles: true,
+      composed: true,
+      detail: selectedTab,
+    };
+    this.dispatchEvent(new CustomEvent('pharos-tabs-tab-selected', details));
+
     this.selectedTab = this._findTabIndex(selectedTab);
     selectedTab.selected = true;
     this._makeTabVisible(selectedTab);

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -135,6 +135,13 @@ export class PharosTabs extends PharosElement {
     const selectedTab: PharosTab = this._tabs[this.selectedTab];
     selectedTab.selected = true;
     this._makeTabVisible(selectedTab);
+
+    const selectedPanel: PharosTabPanel | null = this.querySelector(
+      `${_allTabPanelsSelector}[id="${selectedTab.getAttribute('aria-controls')}"]`
+    );
+    if (selectedPanel) {
+      selectedPanel.selected = true;
+    }
   }
 
   private _queryPanelByTab(tab: PharosTab): PharosTabPanel | null {

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -76,9 +76,7 @@ export class PharosTabs extends PharosElement {
   }
 
   protected override async updated(changedProperties: PropertyValues): Promise<void> {
-    console.log('Changed');
-    console.log(changedProperties);
-    if (changedProperties.has('selectedTab')) {
+    if (changedProperties.has('selectedTab') && this._tabs[this.selectedTab]) {
       this._handleTabSelected(this._tabs[this.selectedTab]);
     }
   }
@@ -117,7 +115,7 @@ export class PharosTabs extends PharosElement {
     this._tabListResizeObserver = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.target === this._tabList) {
-          this._makeTabVisible(this._selectedTabs[0]);
+          this._makeTabVisible(this._tabs[this.selectedTab]);
         }
       });
     });
@@ -131,9 +129,12 @@ export class PharosTabs extends PharosElement {
   }
 
   private _selectInitialTab(): void {
-    const selected: PharosTab | null = this.querySelector(`${_allTabsSelector}[selected]`);
-    const selectedTab: PharosTab = selected || this._tabs[0];
-    this._handleTabSelected(selectedTab);
+    if (this._selectedTabs?.[0]) {
+      this.selectedTab = this._findTabIndex(this._selectedTabs[0]);
+    }
+    const selectedTab: PharosTab = this._tabs[this.selectedTab || 0];
+    selectedTab.selected = true;
+    this._makeTabVisible(selectedTab);
   }
 
   private _queryPanelByTab(tab: PharosTab): PharosTabPanel | null {
@@ -142,10 +143,12 @@ export class PharosTabs extends PharosElement {
     return this.querySelector(`#${panelId}`);
   }
 
+  private _findTabIndex(tabToFind: PharosTab): number {
+    return Array.from(this._tabs).findIndex((tab: PharosTab) => tab.id === tabToFind.id);
+  }
+
   private _handleTabSelected(selectedTab: PharosTab): void {
-    this.selectedTab = Array.from(this._tabs).findIndex(
-      (tab: PharosTab) => tab.id === selectedTab.id
-    );
+    this.selectedTab = this._findTabIndex(selectedTab);
     selectedTab.selected = true;
     this._makeTabVisible(selectedTab);
 

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -132,7 +132,7 @@ export class PharosTabs extends PharosElement {
     if (this._selectedTabs?.[0]) {
       this.selectedTab = this._findTabIndex(this._selectedTabs[0]);
     }
-    const selectedTab: PharosTab = this._tabs[this.selectedTab || 0];
+    const selectedTab: PharosTab = this._tabs[this.selectedTab];
     selectedTab.selected = true;
     this._makeTabVisible(selectedTab);
   }

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -33,7 +33,7 @@ export class PharosTabs extends PharosElement {
    * Indicates if the tab is selected-tab.
    * @attr selected-tab
    */
-  @property({ type: Number, reflect: true })
+  @property({ type: Number, reflect: true, attribute: 'selected-tab' })
   public selectedTab = 0;
 
   @query('.tab__list')
@@ -76,7 +76,9 @@ export class PharosTabs extends PharosElement {
   }
 
   protected override async updated(changedProperties: PropertyValues): Promise<void> {
-    if (changedProperties.has('selected-tab')) {
+    console.log('Changed');
+    console.log(changedProperties);
+    if (changedProperties.has('selectedTab')) {
       this._handleTabSelected(this._tabs[this.selectedTab]);
     }
   }

--- a/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
+++ b/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
@@ -35,7 +35,7 @@ export const Events = {
         @pharos-tab-selected="${(e) => action('Selected')(e.target.id)}"
       >
         <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" selected data-panel-id="panel-2">Tab 2</pharos-tab>
+        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
         <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
         <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
         <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
@@ -88,14 +88,14 @@ export const PanelSeparator = {
 export const HorizontalScrolling = {
   render: () =>
     html`
-      <pharos-tabs panel-separator style="width: 100%">
+      <pharos-tabs selected-tab="6" panel-separator style="width: 100%">
         <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
         <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
         <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
         <pharos-tab id="tab-4" data-panel-id="panel-4">Tab 4</pharos-tab>
         <pharos-tab id="tab-5" data-panel-id="panel-5">Tab 5</pharos-tab>
         <pharos-tab id="tab-6" data-panel-id="panel-6">Tab 6</pharos-tab>
-        <pharos-tab id="tab-7" data-panel-id="panel-7" selected>Tab 7</pharos-tab>
+        <pharos-tab id="tab-7" data-panel-id="panel-7">Tab 7</pharos-tab>
         <pharos-tab id="tab-8" data-panel-id="panel-8">Tab 8</pharos-tab>
         <pharos-tab id="tab-9" data-panel-id="panel-9">Tab 9</pharos-tab>
         <pharos-tab-panel id="panel-1" slot="panel"

--- a/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
+++ b/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
@@ -30,10 +30,13 @@ export const Base = {
 export const Events = {
   render: () =>
     html`
-      <pharos-tabs @pharos-tab-selected="${(e) => action('Selected')(e.target.id)}">
+      <pharos-tabs
+        selected-tab="2"
+        @pharos-tab-selected="${(e) => action('Selected')(e.target.id)}"
+      >
         <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3" selected>Tab 3</pharos-tab>
+        <pharos-tab id="tab-2" selected data-panel-id="panel-2">Tab 2</pharos-tab>
+        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
         <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
         <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
         <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>

--- a/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
+++ b/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
@@ -30,17 +30,16 @@ export const Base = {
 export const Events = {
   render: () =>
     html`
-      <pharos-tabs
-        selected-tab="2"
-        @pharos-tab-selected="${(e) => action('Selected')(e.target.id)}"
-      >
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
-        <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
-        <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>
-      </pharos-tabs>
+      <div @pharos-tabs-tab-selected="${(e) => action('Selected')(e.detail.id)}">
+        <pharos-tabs selected-tab="2">
+          <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
+          <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
+          <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
+          <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
+          <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
+          <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>
+        </pharos-tabs>
+      </div>
     `,
   parameters: { options: { selectedPanel: 'addon-controls' } },
 };


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [x] Yes
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Fixes #462

**How does this change work?**

A new attribute of pharos-tabs will manage the `selected-tab`, which refers to the index of the selected tab in the tablist.

On initial render, the `selected-tab` attribute of `pharos-tabs` will be used (which defaults to 0) to set the correct `pharos-tab` as `selected`

After updates, `selected-tab` prop on `pharos-tabs` should be used to programmatically update the selected tab. When a `pharos-tab` is clicked it dispatches an event and lets the parent manage its state. When a `pharos-tab` is clicked and it is already `selected` it does not dispatch an event to the parent.