### PR TITLE
Combobox: add loose-match option for matching query

### DIFF
--- a/.changeset/empty-queens-listen.md
+++ b/.changeset/empty-queens-listen.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add loose-match option to the combobox for query matching

--- a/packages/pharos/src/components/combobox/pharos-combobox.test.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.test.ts
@@ -165,6 +165,30 @@ describe('pharos-combobox', () => {
     expect(component['_input'].value).to.equal('Gobbledegook');
   });
 
+  it('query matches text when loose-match is enabled and query contains accent', async () => {
+    component = await fixture(html`
+      <pharos-combobox loose-match>
+        <span slot="label">I am a label</span>
+        <option value="1">Option 1</option>
+        <option value="2">Oṕtion 2</option>
+        <option value="3">Option 3</option>
+      </pharos-combobox>
+    `);
+    component['_input'].value = 'Oṕtion';
+    component['_input'].dispatchEvent(new Event('input'));
+    await component.updateComplete;
+
+    const options = component.renderRoot.querySelectorAll(
+      '.combobox__option'
+    ) as NodeListOf<HTMLLIElement>;
+    const firstOption = options[0];
+    const expectedHTML = '<mark class="combobox__mark">Option</mark> 1';
+    const optionHTML = firstOption.innerHTML.replace(/<!--.*?-->/g, '').trim();
+
+    expect(optionHTML).to.equal(expectedHTML);
+    expect(options.length).to.equal(3);
+  });
+
   it('highlights text in the option that match the query', async () => {
     component['_input'].value = 'o';
     component['_input'].dispatchEvent(new Event('input'));

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -448,6 +448,15 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
     this.open = !this.open;
   }
 
+  /**
+   * Normalizes a string in the following order:
+   *
+   * 1 - Applies https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+   *     with the 'NFKD' parameters for compatibility
+   * 2 - Removes all diacritic characters using a global regex
+   * 3 - Lower case all characters
+   *
+   */
   private _normalizeString(textString: string) {
     return textString
       .normalize('NFKD')

--- a/packages/pharos/src/components/combobox/pharos-combobox.wc.stories.jsx
+++ b/packages/pharos/src/components/combobox/pharos-combobox.wc.stories.jsx
@@ -25,6 +25,7 @@ export const Base = {
         .value=${ifDefined(args.value)}
         .name=${ifDefined(args.name)}
         ?open=${args.open}
+        ?loose-match=${args.looseMatch}
         ?disabled=${args.disabled}
         ?hide-label=${args.hideLabel}
         ?invalidated=${args.invalidated}

--- a/packages/pharos/src/components/combobox/storyArgs.ts
+++ b/packages/pharos/src/components/combobox/storyArgs.ts
@@ -3,6 +3,7 @@ export const defaultArgs = {
   hideLabel: false,
   invalidated: false,
   label: 'Combobox Label',
+  looseMatch: false,
   message: '',
   name: '',
   open: false,


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [x] Component status page up to date?

**What does this change address?**
Provides the option to loosely match user input values to the text options. By default there's an exact match and this excludes cases when a query or text has accents or different casing.

**How does this change work?**
Added method to normalize strings using https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#parameters

**Additional context**
Users couldn't find their institutions when searching on https://www.jstor.org/site/collection-list/ because the official spelling contains an accent.
