### PR TITLE
Toast: Update Toaster to use internally consistent scoping

### DIFF
--- a/.changeset/cold-jeans-fail.md
+++ b/.changeset/cold-jeans-fail.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': major
+---
+
+Update Toaster to use internally consistent component scoping

--- a/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
+++ b/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
@@ -135,6 +135,7 @@ export const UpdateableToast = {
           onClick={() => {
             const event = new CustomEvent('pharos-toast-open', {
               detail: {
+                id: 'the-toast',
                 status: 'info',
                 content: 'Saving 15 items to your Workspace',
                 indefinite: true,
@@ -144,14 +145,19 @@ export const UpdateableToast = {
             setTimeout(() => {
               const updateEvent = new CustomEvent('pharos-toast-update', {
                 detail: {
+                  id: 'the-toast',
                   status: 'success',
-                  content: '15 items succsessfully saved',
+                  content: '15 items successfully saved',
                 },
               });
               document.dispatchEvent(updateEvent);
             }, '3000');
             setTimeout(() => {
-              const updateEvent = new CustomEvent('pharos-toast-close', {});
+              const updateEvent = new CustomEvent('pharos-toast-close', {
+                detail: {
+                  id: 'the-toast',
+                },
+              });
               document.dispatchEvent(updateEvent);
             }, '6000');
           }}

--- a/packages/pharos/src/components/toast/pharos-toast.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.test.ts
@@ -77,6 +77,6 @@ describe('pharos-toast', () => {
     await component.updateComplete;
     await aTimeout(500);
 
-    expect(detail === component).to.be.true;
+    expect((detail as any).id === component.id).to.be.true;
   });
 });

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -73,6 +73,7 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
   public indefinite = false;
 
   private _timer: number | void = 0;
+
   private _debouncer: Procedure = debounce(() => {
     this.close();
   }, TOAST_LIFE);
@@ -116,7 +117,9 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
     const details = {
       bubbles: true,
       composed: true,
-      detail: this,
+      detail: {
+        id: this.id,
+      },
     };
 
     this.open = false;

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.jsx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.jsx
@@ -145,6 +145,7 @@ export const UpdateableToast = {
         @click="${() => {
           const event = new CustomEvent('pharos-toast-open', {
             detail: {
+              id: 'the-toast',
               status: 'info',
               content: 'Saving 15 items to your Workspace',
               indefinite: true,
@@ -154,14 +155,19 @@ export const UpdateableToast = {
           setTimeout(() => {
             const updateEvent = new CustomEvent('pharos-toast-update', {
               detail: {
+                id: 'the-toast',
                 status: 'success',
-                content: '15 items succsessfully saved',
+                content: '15 items successfully saved',
               },
             });
             document.dispatchEvent(updateEvent);
           }, '3000');
           setTimeout(() => {
-            const updateEvent = new CustomEvent('pharos-toast-close', {});
+            const updateEvent = new CustomEvent('pharos-toast-close', {
+              detail: {
+                id: 'the-toast',
+              },
+            });
             document.dispatchEvent(updateEvent);
           }, '6000');
         }}"

--- a/packages/pharos/src/components/toast/pharos-toaster.scss
+++ b/packages/pharos/src/components/toast/pharos-toaster.scss
@@ -13,6 +13,6 @@
   align-items: flex-end;
 }
 
-::slotted([data-pharos-component='PharosToast']:not(:last-child)) {
+[data-pharos-component='PharosToast']:not(:last-child) {
   margin-bottom: var(--pharos-spacing-1-x);
 }

--- a/packages/pharos/src/components/toast/pharos-toaster.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.test.ts
@@ -63,7 +63,7 @@ describe('pharos-toaster', () => {
     trigger.click();
     await component.updateComplete;
 
-    const toast = component.querySelector('pharos-toast');
+    const toast = component.renderRoot.querySelector('pharos-toast');
     expect(toast).to.not.be.null;
   });
 
@@ -78,7 +78,7 @@ describe('pharos-toaster', () => {
     await component.updateComplete;
     await nextFrame();
 
-    const toast = component.querySelectorAll('pharos-toast');
+    const toast = component.renderRoot.querySelectorAll('pharos-toast');
     expect(toast.length).to.equal(2);
   });
 
@@ -97,7 +97,7 @@ describe('pharos-toaster', () => {
     await component.updateComplete;
 
     const toast = (
-      component.querySelector('pharos-toast') as PharosToast
+      component.renderRoot.querySelector('pharos-toast') as PharosToast
     )?.renderRoot.querySelector('.toast');
     expect(activeElement === toast).to.be.true;
     document.removeEventListener('focusin', onFocusIn);
@@ -111,7 +111,7 @@ describe('pharos-toaster', () => {
     trigger.click();
     await component.updateComplete;
 
-    const toast = component.querySelector('pharos-toast');
+    const toast = component.renderRoot.querySelector('pharos-toast');
     expect(toast).to.not.be.null;
   });
 
@@ -123,7 +123,7 @@ describe('pharos-toaster', () => {
     trigger.click();
     await component.updateComplete;
 
-    const openToast = component.querySelector('pharos-toast');
+    const openToast = component.renderRoot.querySelector('pharos-toast');
     const details = {
       bubbles: true,
       composed: true,
@@ -149,10 +149,14 @@ describe('pharos-toaster', () => {
     triggerUpdate.click();
     await component.updateComplete;
 
-    expect(component).dom.to.equal(`
-      <pharos-toaster data-pharos-component="PharosToaster">
-        <pharos-toast data-pharos-component="PharosToast" id="my-updateable-toast" indefinite="" open="" status="success">Toast has been updated</pharos-toast>
-      </pharos-toaster>
+    expect(component).shadowDom.to.equal(`
+      <div class="toaster__container">
+        <pharos-toast data-pharos-component="PharosToast" id="my-updateable-toast" indefinite="" open="" status="success">
+          <div>
+            Toast has been updated
+          </div>
+        </pharos-toast>
+      </div>
     `);
   });
 });

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -148,7 +148,7 @@ export class PharosToaster extends ScopedRegistryMixin(PharosElement) {
 
   private _renderToast(toast: ToastDetail): TemplateResult {
     // This is used to properly render any Pharos components present in the supplied content.
-    // unsafeHtml will render content in general, but does not appear to render components.
+    // unsafeHTML will render content in general, but does not appear to render components.
     const toastContentElement = document.createElement('div');
     toastContentElement.innerHTML = toast.content;
 

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -1,32 +1,83 @@
 import { PharosElement } from '../base/pharos-element';
 import { html } from 'lit';
 import type { TemplateResult, CSSResultArray } from 'lit';
+import { state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { toasterStyles } from './pharos-toaster.css';
 
-import type { PharosToast } from './pharos-toast';
+import type { ToastStatus } from './pharos-toast';
+import { PharosToast } from './pharos-toast';
 import { DEFAULT_STATUS, DEFAULT_INDEFINITE } from './pharos-toast';
 
 import { v4 as uuidv4 } from 'uuid';
+import ScopedRegistryMixin from '../../utils/mixins/scoped-registry';
 
 /**
  * pharos-toast-open event.
  *
- * @tag pharos-toaster
- *
  * @event pharos-toast-open
- * @type {object}
- * @property {ToastStatus} status - The status for the toast.
- * @property {string} content - The content to slot into the toast.
+ * @type {ToastCreateDetail}
  */
+
+/**
+ * pharos-toast-update event.
+ *
+ * @event pharos-toast-update
+ * @type {ToastUpdateDetail}
+ */
+
+/**
+ * pharos-toast-close event.
+ *
+ * @event pharos-toast-close
+ * @type {ToastCloseDetail}
+ */
+
+type ToastID = string;
+type ToastContent = string;
+type ToastIndefinite = boolean;
+
+interface ToastDetail {
+  id: ToastID;
+  content: ToastContent;
+  status: ToastStatus;
+  indefinite: ToastIndefinite;
+}
+
+interface ToastCreateDetail {
+  id?: ToastID;
+  content: ToastContent;
+  status?: ToastStatus;
+  indefinite?: ToastIndefinite;
+}
+
+interface ToastUpdateDetail {
+  id: ToastID;
+  content?: ToastContent;
+  status?: ToastStatus;
+}
+
+interface ToastCloseDetail {
+  id: ToastID;
+}
 
 /**
  * Pharos toaster component.
  *
- * @slot - Contains the toasts (the default slot).
+ * @tag pharos-toaster
  *
- * @listens pharos-toast-open
+ * @listens pharos-toast-open - Use this to create new toasts
+ * @listens pharos-toast-update - Use this to update an existing toast
+ * @listens pharos-toast-close - Use this to close an existing toast
  */
-export class PharosToaster extends PharosElement {
+export class PharosToaster extends ScopedRegistryMixin(PharosElement) {
+  static elementDefinitions = {
+    'pharos-toast': PharosToast,
+  };
+
+  @state()
+  private _toasts: ToastDetail[] = [];
+
   constructor() {
     super();
     this._openToast = this._openToast.bind(this);
@@ -52,45 +103,72 @@ export class PharosToaster extends PharosElement {
     super.disconnectedCallback && super.disconnectedCallback();
   }
 
-  private _getToastID(id: string | null) {
+  private _getToastID(id: ToastID | null | undefined) {
     return id || `toast_${uuidv4()}`;
   }
 
   private async _openToast(event: Event): Promise<void> {
-    const toastTag = this.localName.split('pharos-toaster')[0] + 'pharos-toast';
-    const toast = document.createElement(toastTag) as PharosToast;
-    const { content, status, id, indefinite } = (<CustomEvent>event).detail;
+    const { content, status, id, indefinite } = <ToastCreateDetail>(<CustomEvent>event).detail;
+    const toastId = this._getToastID(id);
 
-    toast.innerHTML = content;
-    toast.status = status || DEFAULT_STATUS;
-    toast.id = this._getToastID(id);
-    toast.indefinite = indefinite || DEFAULT_INDEFINITE;
-    this.insertBefore(toast, this.childNodes[0] || null);
+    this._toasts = [
+      {
+        content,
+        status: status || DEFAULT_STATUS,
+        id: toastId,
+        indefinite: indefinite || DEFAULT_INDEFINITE,
+      },
+      ...this._toasts,
+    ];
+
     await this.updateComplete;
-    toast.focus();
+    (this.renderRoot.querySelector(`#${toastId}`) as HTMLElement)?.focus();
   }
 
   private _updateToast(event: CustomEvent): void {
-    const { content, status, id } = (<CustomEvent>event).detail;
-    const toast = document.getElementById(this._getToastID(id));
-    if (toast) {
-      toast.innerHTML = content;
-      toast.status = status;
-    }
+    const { content, status, id } = <ToastUpdateDetail>(<CustomEvent>event).detail;
+
+    this._toasts = this._toasts.map((toast: ToastDetail): ToastDetail => {
+      if (toast.id === id) {
+        return {
+          ...toast,
+          content: content || toast.content,
+          status: status || toast.status,
+        };
+      } else {
+        return toast;
+      }
+    });
   }
 
   private _closeToast(event: CustomEvent): void {
-    const { id } = (<CustomEvent>event).detail || {};
-    const toast = document.getElementById(this._getToastID(id));
-    if (toast) {
-      this.removeChild(toast);
-    }
+    const { id } = <ToastCloseDetail>(<CustomEvent>event).detail || {};
+    this._toasts = this._toasts.filter((toast) => toast.id !== id);
+  }
+
+  private _renderToast(toast: ToastDetail): TemplateResult {
+    // This is used to properly render any Pharos components present in the supplied content.
+    // unsafeHtml will render content in general, but does not appear to render components.
+    const toastContentElement = document.createElement('div');
+    toastContentElement.innerHTML = toast.content;
+
+    return html`<pharos-toast
+      id="${toast.id}"
+      status="${toast.status}"
+      ?indefinite="${toast.indefinite}"
+    >
+      ${toastContentElement}
+    </pharos-toast>`;
   }
 
   protected override render(): TemplateResult {
     return html`
       <div class="toaster__container">
-        <slot></slot>
+        ${repeat(
+          this._toasts,
+          (toast) => toast.id,
+          (toast) => this._renderToast(toast)
+        )}
       </div>
     `;
   }

--- a/packages/pharos/src/components/toast/pharos-toaster.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.ts
@@ -147,8 +147,9 @@ export class PharosToaster extends ScopedRegistryMixin(PharosElement) {
   }
 
   private _renderToast(toast: ToastDetail): TemplateResult {
-    // This is used to properly render any Pharos components present in the supplied content.
-    // unsafeHTML will render content in general, but does not appear to render components.
+    // This is used to properly render any scoped Pharos components present in the supplied content.
+    // unsafeHTML will render content in the scope of the current component,
+    // so any components not explicitly registered in elementDefinitions above will not render.
     const toastContentElement = document.createElement('div');
     toastContentElement.innerHTML = toast.content;
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [x] Yes
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Fixes #474 

**How does this change work?**

Updates `PharosToaster` to use `ScopedRegistryMixin` and replace (most of) the DOM manipulation it was doing with declarative HTML rendering.

**Additional context**

This is a breaking change because it changes the `detail` value for the `pharos-toast-close` event. Because this event was externally visible, this is technically an API change. I don't, however, believe any internal consumers were listening for this event. Because we're gearing up for v13 and this isn't otherwise too pressing, let's just wait and include it there.