### PR TITLE
ImageCard: allow tab into subtle image card checkbox

### DIFF
--- a/.changeset/silent-candles-smash.md
+++ b/.changeset/silent-candles-smash.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix subtle select image card accessibility

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -228,7 +228,8 @@ slot[name='image']::slotted(img) {
 }
 
 :host([subtle]) .card__link--image {
-  &:hover {
+  &:hover,
+  &:focus-within {
     .card__metadata--hover {
       background-color: rgb(0 0 0 / 0.75);
       visibility: visible;

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -435,10 +435,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
     );
   }
 
-  private _isSubtleAndSelectable(): boolean {
-    return Boolean(this._isSelectable() && this.subtle && !this.disabled);
-  }
-
   private _showSubtleOverlay(): boolean {
     return Boolean(
       this.subtle && ((this.subtleSelect && !this._isSelected) || !this._isSelectable())
@@ -463,7 +459,6 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
   private _isCheckboxDisplayed() {
     return (
       this._isSubtleSelectHover() ||
-      this._isSubtleAndSelectable() ||
       this._isSelectableViaCard() ||
       this._isSelected ||
       (this.disabled && this._isSelectable())


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Fix the issue of no way to select checkbox in subtle selectable image card. We want to make the subtle select image card selectable through tabbing.

before: 

https://user-images.githubusercontent.com/38861633/215830430-df08f4cd-68d7-4a00-a889-880d58775e3d.mp4

after:

https://user-images.githubusercontent.com/38861633/215830721-bc55c9f8-2355-4d40-880c-d6319f3db203.mp4

**How does this change work?**
Allow metadata layout show up via tab. Previously the metadata layout only shows up when you hover on it. Add "focus-within" to allow the layout show up when user tabs into the image card. So that the checkbox can also appear to be selected.
Focus on checkbox inside subtle metadata layout after user tab into it.

