### PR TITLE
Link: display blue outline on focus

### DIFF
--- a/.changeset/plenty-bobcats-know.md
+++ b/.changeset/plenty-bobcats-know.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Fix link not displaying blue outline on focus in Chrome/Safari

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -21,7 +21,7 @@
     @include mixins.underline;
   }
 
-  display: inline-block;
+  display: block;
 }
 
 :host(:not([href])) #link-element {

--- a/packages/pharos/src/components/link/pharos-link.scss
+++ b/packages/pharos/src/components/link/pharos-link.scss
@@ -20,6 +20,8 @@
   @at-root &.link--alert:active {
     @include mixins.underline;
   }
+
+  display: inline-block;
 }
 
 :host(:not([href])) #link-element {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Resolves accessibility/display issue https://github.com/ithaka/pharos/issues/485

Blue outline not rendered in Chrome when focusing on a link with a nested heading.

**How does this change work?**
Sets the `display` value to `inline-block` so that it renders the layout and elements dimensions (margin/padding) are applied properly.
