### PR TITLE
Docs: Update flex attribute docs for links 

### DIFF
--- a/.changeset/plenty-dots-remember.md
+++ b/.changeset/plenty-dots-remember.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Update link docs

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -57,7 +57,8 @@ export class PharosLink extends FocusMixin(AnchorElement) {
   public bold = false;
 
   /**
-   * Indicates if the link should display as a flex container.
+   * Indicates if the link should display as a flex container. Enable this with a link heading so that
+   * the blue outline is rendered on focus.
    * @attr flex
    */
   @property({ type: Boolean, reflect: true })

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -57,8 +57,13 @@ export class PharosLink extends FocusMixin(AnchorElement) {
   public bold = false;
 
   /**
-   * Indicates if the link should display as a flex container. Enable this for a link heading so that
-   * the blue outline is rendered on focus for Chrome and Safari (works as expected on Firefox).
+   * Indicates if the link should display as a flex container.
+   *
+   * Known bug if using link with a nested header: while in a focus state, a blue outline is not rendered on Chrome and Safari,
+   * but it works as expected on Firefox. See here for more details https://github.com/ithaka/pharos/issues/485
+   *
+   * Temporary workaround: Enable `flex` so that the element layout is rendered and displays the outline.
+   *
    * @attr flex
    */
   @property({ type: Boolean, reflect: true })

--- a/packages/pharos/src/components/link/pharos-link.ts
+++ b/packages/pharos/src/components/link/pharos-link.ts
@@ -57,8 +57,8 @@ export class PharosLink extends FocusMixin(AnchorElement) {
   public bold = false;
 
   /**
-   * Indicates if the link should display as a flex container. Enable this with a link heading so that
-   * the blue outline is rendered on focus.
+   * Indicates if the link should display as a flex container. Enable this for a link heading so that
+   * the blue outline is rendered on focus for Chrome and Safari (works as expected on Firefox).
    * @attr flex
    */
   @property({ type: Boolean, reflect: true })


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [ ] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Adds extra information for users to use the `flex` attribute when using a nested heading so that it's visually accessible in all browsers.
