### PR TITLE
Backfill architecture decision records

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/architecture/decisions

--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2023-02-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/architecture/decisions/0002-capture-design-decisions-in-a-token-hierarchy.md
+++ b/docs/architecture/decisions/0002-capture-design-decisions-in-a-token-hierarchy.md
@@ -1,0 +1,29 @@
+# 2. Capture design decisions in a token hierarchy
+
+Date: 2019-11
+
+## Status
+
+Accepted
+
+## Context
+
+Design decisions around aspects like color, font, spacing, animation, and so on are intentional and specific.
+These decisions must make their way into the concrete implementation of components.
+Hard-coding values can lead to divergence and makes updating values across the system a tedious task.
+Hard-coding also makes it difficult to see at a glance what values we use at any given time.
+
+Design decisions have layers of abstraction based on the context of the decision.
+We can choose a specific color to exist in our palette, but that doesn't provide meaning.
+We can then choose that color as the primary color for interactive elements, which adds significant context.
+We can then assign that interactive color for variants of components like primary buttons, links, and so on.
+If this hierarchy of context is built using the raw color value at each level, consistency becomes difficult.
+
+## Decision
+
+Use a hierarchical design token model that supports referential values to provide design decisions to components.
+
+## Consequences
+
+- We will experience increased complexity of the system due to abstraction of the design decision concept into tokens.
+- We need to store tokens in a format components can use directly, or that can be transformed into such a format.

--- a/docs/architecture/decisions/0003-build-components-using-web-component-technology.md
+++ b/docs/architecture/decisions/0003-build-components-using-web-component-technology.md
@@ -1,0 +1,28 @@
+# 3. Build components using web component technology
+
+Date: 2020-03
+
+## Status
+
+Accepted
+
+Enhanced by [4. Provide a React wrapper for web components](0004-provide-a-react-wrapper-for-web-components.md)
+
+## Context
+
+Web technologies change rapidly, and they change fastest at the layers that exist above web standards.
+Frameworks such as React and Vue face a growing list of competitors, and teams may use multiple frameworks.
+A design system needs to support these scenarios with longevity.
+
+A system that provides components specific to a framework(s) will need to adapt and shift as teams use new frameworks.
+This creates complexity and maintenance burden with a chance for divergence and human error.
+
+## Decision
+
+Use web component technology to remain framework agnostic and stabilize development even as frameworks come and go.
+
+## Consequences
+
+- There will be a learning curve to understand web component standards and life cycles.
+- Because web components are more isolated by way of the shadow DOM, the need for careful customizability and governance will arise.
+- The current state of browser support for the shadow DOM and of our support for browsers will require polyfilling.

--- a/docs/architecture/decisions/0004-provide-a-react-wrapper-for-web-components.md
+++ b/docs/architecture/decisions/0004-provide-a-react-wrapper-for-web-components.md
@@ -1,0 +1,26 @@
+# 4. Provide a React wrapper for web components
+
+Date: 2020-03
+
+## Status
+
+Accepted
+
+Enhances [3. Build components using web component technology](0003-build-components-using-web-component-technology.md)
+
+## Context
+
+React [does not integrate tightly with web components](https://reactjs.org/docs/web-components.html).
+A React component that wishes to use a web component's imperative API must create a ref to do so.
+A React component that wishes to listen for a web component's events must explicitly listen for those as well.
+
+A team using React will experience the same basic needs for every component they use.
+Because each component in the system is a web component, if they're using the raw components, this will be a burden.
+
+## Decision
+
+Provide a React wrapper for every component.
+
+## Consequences
+
+- This will create duplicative code or the need for an automated method of React wrapper creation at build time.

--- a/docs/architecture/decisions/0005-use-visual-testing-in-addition-to-functional-testing.md
+++ b/docs/architecture/decisions/0005-use-visual-testing-in-addition-to-functional-testing.md
@@ -1,0 +1,22 @@
+# 5. Use visual testing in addition to functional testing
+
+Date: 2020-04
+
+## Status
+
+Accepted
+
+## Context
+
+In addition to functional behavior, a large part of what it means for a component to "work" is its visual presentation.
+We may make changes that continue to pass the scrutiny of our functional tests, but that break a component visually.
+These may be changes in CSS or the DOM or the interaction between the two.
+
+## Decision
+
+Test the visual difference between each new change and the previous baseline, and make this a barrier to release.
+
+## Consequences
+
+- We will need a system that can create, store, and compare screenshots of rendered components.
+- As with snapshot testing, there may be added noise at moments where we intentionally change something.

--- a/docs/architecture/decisions/0006-use-css-custom-properties-for-component-styles.md
+++ b/docs/architecture/decisions/0006-use-css-custom-properties-for-component-styles.md
@@ -8,10 +8,6 @@ Accepted
 
 Enhanced by [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
 
-Enhanced by [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
-
-Enhanced by [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
-
 ## Context
 
 Web components tend toward full isolation from the host for a variety of good reasons.

--- a/docs/architecture/decisions/0006-use-css-custom-properties-for-component-styles.md
+++ b/docs/architecture/decisions/0006-use-css-custom-properties-for-component-styles.md
@@ -1,0 +1,32 @@
+# 6. Use CSS custom properties for component styles
+
+Date: 2020-04
+
+## Status
+
+Accepted
+
+Enhanced by [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
+
+Enhanced by [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
+
+Enhanced by [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
+
+## Context
+
+Web components tend toward full isolation from the host for a variety of good reasons.
+There are also good reasons components should be affected by the host application.
+User-indicated theming such as light and dark mode or accessible color schemes for visual impairments are examples.
+
+Because environmental dynamics should be able to impact a component's visual display, we can't bake everything in.
+SCSS variables allow for referential abstraction during development, but are dereferenced at build time.
+
+## Decision
+
+Use CSS custom properties, also known as CSS variables, to reference design tokens in component CSS.
+
+## Consequences
+
+- A component's visual design can be impacted from outside the component's scope.
+- This allows for theming and other dynamics we can't yet predict.
+- This opens up the possibility of accidental impact by consumers, but design token names are namespaced clearly.

--- a/docs/architecture/decisions/0007-use-scoped-elements-for-decoupled-teams.md
+++ b/docs/architecture/decisions/0007-use-scoped-elements-for-decoupled-teams.md
@@ -1,0 +1,27 @@
+# 7. Use scoped elements for decoupled teams
+
+Date: 2021-09
+
+## Status
+
+Accepted
+
+Enhanced by [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
+
+## Context
+
+In the context of distributed teams, each team may consume components independently but arrive on a single page.
+Imposing a single unified component version across the whole page creates maintenance burden and cross-team coupling.
+Allowing differing versions without care could result in a version (and API) mismatch.
+
+## Decision
+
+Use scoped custom element registries to ensure each consumer is isolated from others.
+
+## Consequences
+
+- Scoped custom elements are still a proposal, so a polyfill is required and the proposal may never be accepted.
+  - We are comfortable with this trade-off given the support in the ecosystem, but may need to react later on.
+- Teams adopting Pharos will have increased complexity up front to register the components they use.
+- Teams adopting Pharos will have increased complexity ongoing to use the scoped component names in their DOM.
+- Internal complexity increases when components are nested due to scoping; those must remain "invisible" to consumers.

--- a/docs/architecture/decisions/0008-evolve-tokens-in-backward-compatible-manner.md
+++ b/docs/architecture/decisions/0008-evolve-tokens-in-backward-compatible-manner.md
@@ -1,0 +1,32 @@
+# 8. Evolve tokens in backward compatible manner
+
+Date: 2023-02-15
+
+## Status
+
+Proposed
+
+Enhances [6. Use CSS custom properties for component styles](0006-use-css-custom-properties-for-component-styles.md)
+
+Enhances [7. Use scoped elements for decoupled teams](0007-use-scoped-elements-for-decoupled-teams.md)
+
+## Context
+
+When teams are using micro frontends with module sharing, the precise version of a component is not guaranteed.
+This means removing a token that seems unused by the current component code base is still a breaking change.
+
+Distribute teams experience this when trying to use a component that expects newly-available tokens
+without having updated the version of tokens available on the host application first.
+
+An improved protocol would ensure that using new tokens and removing old tokens has failsafes in place.
+
+## Decision
+
+Use an "add-only" approach for design tokens with a fallback mechanism for backward compatibility.
+
+## Consequences
+
+- Removing tokens must be treated as a breaking change.
+- Usage of newly-added tokens must provide fallbacks. As an example, `var(--new-token, var(--old-token))`.
+- Removing fallbacks must be treated as a breaking change.
+- Tokens we want to remove should be marked as deprecated so consumers can audit their usage footprint.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,10 @@
+# Architecture Decision Records
+
+- [1. Record architecture decisions](0001-record-architecture-decisions.md)
+- [2. Capture design decisions in a token hierarchy](0002-capture-design-decisions-in-a-token-hierarchy.md)
+- [3. Build components using web component technology](0003-build-components-using-web-component-technology.md)
+- [4. Provide a React wrapper for web components](0004-provide-a-react-wrapper-for-web-components.md)
+- [5. Use visual testing in addition to functional testing](0005-use-visual-testing-in-addition-to-functional-testing.md)
+- [6. Use CSS custom properties for component styles](0006-use-css-custom-properties-for-component-styles.md)
+- [7. Use scoped elements for decoupled teams](0007-use-scoped-elements-for-decoupled-teams.md)
+- [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,10 +1,42 @@
-# Architecture Decision Records
+# Pharos architecture decision records
 
-- [1. Record architecture decisions](0001-record-architecture-decisions.md)
-- [2. Capture design decisions in a token hierarchy](0002-capture-design-decisions-in-a-token-hierarchy.md)
-- [3. Build components using web component technology](0003-build-components-using-web-component-technology.md)
-- [4. Provide a React wrapper for web components](0004-provide-a-react-wrapper-for-web-components.md)
-- [5. Use visual testing in addition to functional testing](0005-use-visual-testing-in-addition-to-functional-testing.md)
-- [6. Use CSS custom properties for component styles](0006-use-css-custom-properties-for-component-styles.md)
-- [7. Use scoped elements for decoupled teams](0007-use-scoped-elements-for-decoupled-teams.md)
-- [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)
+These are high-level structural and process decisions that guide the evolution of this project over long timeframes.
+You can see the table of contents in [the index](./index.md).
+
+## Managing records
+
+These records are managed using the [adr-tools](https://github.com/npryce/adr-tools) project.
+
+### Creating a new record
+
+You can create a new record with the `new` subcommand along with a useful title:
+
+```shell
+$ adr new An important decision
+```
+
+### Generating the table of contents
+
+When adding new records, ensure the table of contents is also up to date using the `generate` subcommand:
+
+```shell
+$ adr generate toc > docs/architecture/decisions/index.md
+```
+
+If you'd like to see the records in visual form,
+you can use the `generate` subcommand
+along with [dot](https://graphviz.org/docs/layouts/dot/) and [imgcat](https://github.com/trashhalo/imgcat)
+to generate a graph of records and their relationships:
+
+```shell
+$ adr generate graph | dot -Tpng | imgcat
+```
+
+### Linking records
+
+The relationship of new decisions to old is important.
+You can link two records and the nature of their relationship using the `link` subcommand:
+
+```shell
+$ adr link <ADR A> Amends <ADR B> "Amended by"
+```

--- a/docs/architecture/decisions/index.md
+++ b/docs/architecture/decisions/index.md
@@ -1,0 +1,10 @@
+# Architecture Decision Records
+
+- [1. Record architecture decisions](0001-record-architecture-decisions.md)
+- [2. Capture design decisions in a token hierarchy](0002-capture-design-decisions-in-a-token-hierarchy.md)
+- [3. Build components using web component technology](0003-build-components-using-web-component-technology.md)
+- [4. Provide a React wrapper for web components](0004-provide-a-react-wrapper-for-web-components.md)
+- [5. Use visual testing in addition to functional testing](0005-use-visual-testing-in-addition-to-functional-testing.md)
+- [6. Use CSS custom properties for component styles](0006-use-css-custom-properties-for-component-styles.md)
+- [7. Use scoped elements for decoupled teams](0007-use-scoped-elements-for-decoupled-teams.md)
+- [8. Evolve tokens in backward compatible manner](0008-evolve-tokens-in-backward-compatible-manner.md)


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

I had wanted to capture a new architectural/process decision we were discussing today, and then found myself also wanting to capture some past pivotal decisions as well. I've been using architectural decision records (ADRs) in other contexts for a bit now and have been seeing returns on that, so thought we might give that a go here.

The important new decision revolves around managing token changes in a distributed team setting and how to avoid issues such as broken styling due to unexpectedly missing tokens. 

- [ ] This proposal is currently in "Proposed" status, so will need to update it to "Accepted" before merging.

**How does this change work?**

This change uses [adr-tools](https://github.com/npryce/adr-tools) to create several ADRs and link them appropriately. It also adds a table of contents and a README cheatseet for using adr-tools.

**Additional context**

![image](https://user-images.githubusercontent.com/1808306/219259270-1379b171-9bd6-472d-8652-3669e09fae9e.png)

