### PR TITLE
Footer: update DOM selectors for Google Translate widget

### DIFF
--- a/.changeset/metal-tomatoes-heal.md
+++ b/.changeset/metal-tomatoes-heal.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix styling of Google Translate widget

--- a/packages/pharos/src/components/footer/pharos-footer.styles.scss
+++ b/packages/pharos/src/components/footer/pharos-footer.styles.scss
@@ -39,7 +39,7 @@ div#google_translate_element div.goog-te-gadget-simple {
   }
 }
 
-div#google_translate_element div.goog-te-gadget-simple a.goog-te-menu-value {
+div#google_translate_element div.goog-te-gadget-simple a {
   @include mixins.interactive-focus;
 
   span[style],
@@ -61,7 +61,7 @@ div#google_translate_element div.goog-te-gadget-simple:hover {
   background-color: var(--pharos-color-interactive-tertiary);
   border-color: var(--pharos-color-interactive-tertiary);
 
-  a.goog-te-menu-value span {
+  a span {
     color: var(--pharos-color-interactive-secondary);
   }
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Google Translate seems to have changed their DOM recently and removed a class we use for styling purposes.

**How does this change work?**

Remove the now-missing class from the selector.

**Additional context**

This could theoretically open up our styles to other links that are present, but because the widget isn't complex and the only other precision we could give is DOM ordering which feels more fragile, it feels best to go this route for now.
