### PR TITLE
Storybook, tests: use scoped components

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,20 +26,6 @@ jobs:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "YARN_CACHE_DIR=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.YARN_CACHE_DIR }}
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,7 @@ on:
       - '.storybook/**'
       - 'yarn.lock'
       - 'package.json'
+      - '.github/workflows/chromatic.yml'
     branches-ignore:
       - main
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -50,9 +50,6 @@ jobs:
       - name: Build Storybook
         run: yarn build-storybook:wc
 
-      - name: Check build
-        run: grep -i 'could not get icon' .storybook-static/wc/main*.js
-
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build Storybook
         run: yarn build-storybook:wc
 
+      - name: Check build
+        run: grep -i 'could not get icon' .storybook-static/wc/main*.js
+
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,6 +27,20 @@ jobs:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "YARN_CACHE_DIR=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.YARN_CACHE_DIR }}
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install Dependencies
         run: yarn --prefer-offline --frozen-lockfile
 

--- a/.storybook/initComponents.js
+++ b/.storybook/initComponents.js
@@ -42,10 +42,10 @@ import {
   PharosToggleButton,
   PharosToggleButtonGroup,
   PharosTooltip,
-} from '../index';
-import registerComponents from '../utils/registerComponents';
+} from '../packages/pharos/lib/index';
+import registerComponents from '../packages/pharos/lib/utils/registerComponents';
 
-registerComponents('test', [
+registerComponents('storybook', [
   PharosAlert,
   PharosBreadcrumb,
   PharosBreadcrumbItem,

--- a/.storybook/main/preview.js
+++ b/.storybook/main/preview.js
@@ -2,7 +2,7 @@ import { setCustomElements } from '@storybook/web-components';
 
 import customElements from '../../packages/pharos/custom-elements.json';
 import '../styleConfig';
-import '../../packages/pharos/src/test/initComponents';
+import '../initComponents';
 
 window.process = window.process || {};
 window.process.env = window.process.env || {};

--- a/.storybook/react/preview.js
+++ b/.storybook/react/preview.js
@@ -1,4 +1,4 @@
 import '../styleConfig';
-import '../../packages/pharos/src/test/initComponents';
+import '../initComponents';
 
 export { parameters } from '../parameters';

--- a/.storybook/wc/preview.js
+++ b/.storybook/wc/preview.js
@@ -2,7 +2,7 @@ import { setCustomElementsManifest } from '@storybook/web-components';
 
 import customElementsManifest from '../../packages/pharos/custom-elements.json';
 import '../styleConfig';
-import '../../packages/pharos/src/test/initComponents';
+import '../initComponents';
 
 window.process = window.process || {};
 window.process.env = window.process.env || {};

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -95,6 +95,10 @@ module.exports = async ({ config, mode }) => {
     })
   );
 
+  config.experiments = {
+    outputModule: true,
+  };
+
   // Return the altered config
   return config;
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -95,10 +95,6 @@ module.exports = async ({ config, mode }) => {
     })
   );
 
-  config.experiments = {
-    outputModule: true,
-  };
-
   // Return the altered config
   return config;
 };

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -45,8 +45,7 @@ module.exports = async ({ config, mode }) => {
 
   config.module.rules[1].exclude = /node_modules/;
 
-  // TODO: Refactor when Chromatic updates Firefox
-  const TARGET_ENV = process.env.GITHUB_WORKFLOW === 'Chromatic' ? 'firefox65' : 'esnext';
+  const TARGET_ENV = 'esnext';
 
   // https://github.com/evanw/esbuild/issues/1354#issuecomment-855452057
   // https://www.typescriptlang.org/tsconfig#useDefineForClassFields

--- a/packages/pharos-site/static/styles/global.scss
+++ b/packages/pharos-site/static/styles/global.scss
@@ -71,7 +71,7 @@ p.alert-example__content + p.alert-example__content {
     white-space: nowrap;
   }
 
-  pharos-icon {
+  [data-pharos-component='PharosIcon'] {
     fill: var(--pharos-color-black);
     stroke: var(--pharos-color-black);
   }

--- a/packages/pharos/src/components/alert/PharosAlert.react.stories.jsx
+++ b/packages/pharos/src/components/alert/PharosAlert.react.stories.jsx
@@ -1,10 +1,18 @@
 import { PharosAlert, PharosLink } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Alert',
   component: PharosAlert,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: {
       page: configureDocsPage('alert'),

--- a/packages/pharos/src/components/alert/pharos-alert.test.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.test.ts
@@ -9,7 +9,9 @@ describe('pharos-alert', () => {
   let component: PharosAlert;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-alert status="success"> It worked! </pharos-alert> `);
+    component = await fixture(
+      html` <test-pharos-alert status="success"> It worked! </test-pharos-alert> `
+    );
   });
 
   it('is accessible', async () => {
@@ -17,12 +19,16 @@ describe('pharos-alert', () => {
   });
 
   it('throws an error for missing status attribute', async () => {
-    component = await fixture(html` <pharos-alert> It worked! </pharos-alert> `).catch((e) => e);
+    component = await fixture(html` <test-pharos-alert> It worked! </test-pharos-alert> `).catch(
+      (e) => e
+    );
     expect('status is a required attribute.').to.be.thrown;
   });
 
   it('renders the alert when a status is provided', async () => {
-    component = await fixture(html` <pharos-alert status="info"> It worked! </pharos-alert> `);
+    component = await fixture(
+      html` <test-pharos-alert status="info"> It worked! </test-pharos-alert> `
+    );
     expect(component).shadowDom.to.equal(`
       <div
         class="alert alert--info"
@@ -46,7 +52,7 @@ describe('pharos-alert', () => {
 
   it('throws an error for an invalid status value', async () => {
     component = await fixture(html`
-      <pharos-alert status="fake"> It worked! </pharos-alert>
+      <test-pharos-alert status="fake"> It worked! </test-pharos-alert>
     `).catch((e) => e);
     expect('fake is not a valid status. Valid statuses are: info, success, warning, error').to.be
       .thrown;
@@ -67,7 +73,7 @@ describe('pharos-alert', () => {
   });
 
   it('adds a class to slotted links', async () => {
-    const link = document.createElement('pharos-link') as PharosLink;
+    const link = document.createElement('test-pharos-link') as PharosLink;
 
     component.appendChild(link);
     await component.updateComplete;
@@ -79,7 +85,9 @@ describe('pharos-alert', () => {
   it('is closable', async () => {
     component = await fixture(
       html`
-        <pharos-alert status="success" closable id="closable-alert"> It worked! </pharos-alert>
+        <test-pharos-alert status="success" closable id="closable-alert">
+          It worked!
+        </test-pharos-alert>
       `
     );
 
@@ -94,7 +102,9 @@ describe('pharos-alert', () => {
   it('fires a custom event pharos-alert-closed when closed by user interaction', async () => {
     component = await fixture(
       html`
-        <pharos-alert status="success" closable id="closable-alert"> It worked! </pharos-alert>
+        <test-pharos-alert status="success" closable id="closable-alert">
+          It worked!
+        </test-pharos-alert>
       `
     );
     let wasFired = false;

--- a/packages/pharos/src/components/alert/pharos-alert.wc.stories.jsx
+++ b/packages/pharos/src/components/alert/pharos-alert.wc.stories.jsx
@@ -4,7 +4,7 @@ import { defaultArgs, argTypes } from './storyArgs';
 
 export default {
   title: 'Components/Alert',
-  component: 'pharos-alert',
+  component: 'storybook-pharos-alert',
   parameters: {
     docs: {
       page: configureDocsPage('alert'),
@@ -15,7 +15,9 @@ export default {
 
 const Base = {
   render: ({ status, text, closable }) =>
-    html`<pharos-alert status=${status} ?closable=${closable}>${text}</pharos-alert>`,
+    html`<storybook-pharos-alert status=${status} ?closable=${closable}
+      >${text}</storybook-pharos-alert
+    >`,
   args: defaultArgs,
 };
 
@@ -37,10 +39,12 @@ export const Success = {
 
 export const Warning = {
   render: ({ status, text, closable }) =>
-    html` <pharos-alert status=${status} ?closable=${closable}>
+    html` <storybook-pharos-alert status=${status} ?closable=${closable}>
       <p class="alert-example__content">${text}</p>
-      <p class="alert-example__content">See <pharos-link href="#">how to fix this</pharos-link>.</p>
-    </pharos-alert>`,
+      <p class="alert-example__content">
+        See <storybook-pharos-link href="#">how to fix this</storybook-pharos-link>.
+      </p>
+    </storybook-pharos-alert>`,
   args: {
     status: 'warning',
     text: 'Your profile is incomplete.',
@@ -49,13 +53,13 @@ export const Warning = {
 
 export const Error = {
   render: ({ status, text, closable }) =>
-    html` <pharos-alert status=${status} ?closable=${closable}>
+    html` <storybook-pharos-alert status=${status} ?closable=${closable}>
       <p class="alert-example__content">${text}</p>
       <p class="alert-example__content">
         For more information,
-        <pharos-link href="#">read the documentation</pharos-link>.
+        <storybook-pharos-link href="#">read the documentation</storybook-pharos-link>.
       </p>
-    </pharos-alert>`,
+    </storybook-pharos-alert>`,
   args: {
     status: 'error',
     text: "Your password didn't meet the minimum requirements.",

--- a/packages/pharos/src/components/breadcrumb/PharosBreadcrumb.react.stories.jsx
+++ b/packages/pharos/src/components/breadcrumb/PharosBreadcrumb.react.stories.jsx
@@ -1,9 +1,17 @@
 import { PharosBreadcrumb, PharosBreadcrumbItem } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Breadcrumb',
   component: PharosBreadcrumb,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: {
       page: configureDocsPage('breadcrumb'),

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.test.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb-item.test.ts
@@ -11,15 +11,15 @@ describe('pharos-breadcrumb-item', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html`<pharos-breadcrumb-item href="#first">${longText}</pharos-breadcrumb-item>`
+      html`<test-pharos-breadcrumb-item href="#first">${longText}</test-pharos-breadcrumb-item>`
     );
   });
 
   it('is accessible', async () => {
-    const parentNode = document.createElement('pharos-breadcrumb');
+    const parentNode = document.createElement('test-pharos-breadcrumb');
 
     component = await fixture(
-      html`<pharos-breadcrumb-item href="#first">${longText}</pharos-breadcrumb-item>`,
+      html`<test-pharos-breadcrumb-item href="#first">${longText}</test-pharos-breadcrumb-item>`,
       {
         parentNode,
       }
@@ -28,24 +28,28 @@ describe('pharos-breadcrumb-item', () => {
   });
 
   it('truncates long text', async () => {
-    const anchor = component.renderRoot.querySelector('pharos-link') as PharosLink;
+    const anchor = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"]'
+    ) as PharosLink;
     await expect(anchor?.innerText).to.equal(`${longText.substr(0, 40)}...`);
   });
 
   it('contains tooltip with truncated text', async () => {
-    const tooltip = component.renderRoot.querySelector('pharos-tooltip');
+    const tooltip = component.renderRoot.querySelector('[data-pharos-component="PharosTooltip"]');
     await expect(tooltip).to.exist;
   });
 
   it('is a link if "href" attribute is passed', async () => {
-    const anchor = component.renderRoot.querySelector('pharos-link');
+    const anchor = component.renderRoot.querySelector('[data-pharos-component="PharosLink"]');
     await expect(anchor).to.exist;
   });
 
   it('is a plan text span if no "href" attribute is passed', async () => {
-    component = await fixture(html`<pharos-breadcrumb-item>${longText}</pharos-breadcrumb-item>`);
+    component = await fixture(
+      html`<test-pharos-breadcrumb-item>${longText}</test-pharos-breadcrumb-item>`
+    );
 
-    const anchor = component.renderRoot.querySelector('pharos-link');
+    const anchor = component.renderRoot.querySelector('[data-pharos-component="PharosLink"]');
     await expect(anchor).to.not.exist;
     const span = component.renderRoot.querySelector('span');
     await expect(span).to.exist;
@@ -53,9 +57,11 @@ describe('pharos-breadcrumb-item', () => {
 
   it('does not truncate short text', async () => {
     const component: PharosBreadcrumbItem = await fixture(
-      html`<pharos-breadcrumb-item href="#first">${shortText}</pharos-breadcrumb-item>`
+      html`<test-pharos-breadcrumb-item href="#first">${shortText}</test-pharos-breadcrumb-item>`
     );
-    const anchor = component.renderRoot.querySelector('pharos-link') as PharosLink;
+    const anchor = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"]'
+    ) as PharosLink;
     await expect(anchor?.innerText).to.equal(shortText);
   });
 });

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.test.ts
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.test.ts
@@ -8,18 +8,20 @@ describe('pharos-breadcrumb', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-breadcrumb>
-        <pharos-breadcrumb-item href="#first">
+      <test-pharos-breadcrumb>
+        <test-pharos-breadcrumb-item href="#first">
           The First Link That is Too Long of Text to Fit inside any reasonable amount of space
-        </pharos-breadcrumb-item>
-        <pharos-breadcrumb-item href="#second"> A link that's better </pharos-breadcrumb-item>
-        <pharos-breadcrumb-item href="#third">
+        </test-pharos-breadcrumb-item>
+        <test-pharos-breadcrumb-item href="#second">
+          A link that's better
+        </test-pharos-breadcrumb-item>
+        <test-pharos-breadcrumb-item href="#third">
           The Second Link That is Too Long of Text to Fit inside any reasonable amount of space
-        </pharos-breadcrumb-item>
-        <pharos-breadcrumb-item>
+        </test-pharos-breadcrumb-item>
+        <test-pharos-breadcrumb-item>
           Where we are right now is a long way from where we used to be
-        </pharos-breadcrumb-item>
-      </pharos-breadcrumb>
+        </test-pharos-breadcrumb-item>
+      </test-pharos-breadcrumb>
     `);
   });
 

--- a/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.wc.stories.jsx
+++ b/packages/pharos/src/components/breadcrumb/pharos-breadcrumb.wc.stories.jsx
@@ -13,11 +13,17 @@ export default {
 
 export const Base = {
   render: ({ firstCrumb, secondCrumb, thirdCrumb }) =>
-    html` <pharos-breadcrumb>
-      <pharos-breadcrumb-item href="#" id="firstBreadcrumb">${firstCrumb}</pharos-breadcrumb-item>
-      <pharos-breadcrumb-item href="#" id="secondBreadcrumb">${secondCrumb}</pharos-breadcrumb-item>
-      <pharos-breadcrumb-item id="thirdBreadcrumb">${thirdCrumb}</pharos-breadcrumb-item>
-    </pharos-breadcrumb>`,
+    html` <storybook-pharos-breadcrumb>
+      <storybook-pharos-breadcrumb-item href="#" id="firstBreadcrumb"
+        >${firstCrumb}</storybook-pharos-breadcrumb-item
+      >
+      <storybook-pharos-breadcrumb-item href="#" id="secondBreadcrumb"
+        >${secondCrumb}</storybook-pharos-breadcrumb-item
+      >
+      <storybook-pharos-breadcrumb-item id="thirdBreadcrumb"
+        >${thirdCrumb}</storybook-pharos-breadcrumb-item
+      >
+    </storybook-pharos-breadcrumb>`,
   args: {
     firstCrumb: 'Hover to see the full text of long content, which are truncated',
     secondCrumb: 'Short texts will not',

--- a/packages/pharos/src/components/button/PharosButton.react.stories.jsx
+++ b/packages/pharos/src/components/button/PharosButton.react.stories.jsx
@@ -12,10 +12,18 @@ import {
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
 import { action } from '@storybook/addon-actions';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Button',
   component: PharosButton,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: {
       page: configureDocsPage('button'),

--- a/packages/pharos/src/components/button/pharos-button.test.ts
+++ b/packages/pharos/src/components/button/pharos-button.test.ts
@@ -10,7 +10,7 @@ describe('pharos-button', () => {
   let component: PharosButton;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-button>I am a button</pharos-button> `);
+    component = await fixture(html` <test-pharos-button>I am a button</test-pharos-button> `);
   });
 
   describe('Accessibility', () => {
@@ -59,9 +59,12 @@ describe('pharos-button', () => {
       const parentNode = document.createElement('div');
       parentNode.style.backgroundColor = PharosColorBlack;
 
-      component = await fixture(html`<pharos-button on-background>I am a button</pharos-button>`, {
-        parentNode,
-      });
+      component = await fixture(
+        html`<test-pharos-button on-background>I am a button</test-pharos-button>`,
+        {
+          parentNode,
+        }
+      );
       await expect(component).to.be.accessible();
     });
 
@@ -70,7 +73,9 @@ describe('pharos-button', () => {
       parentNode.style.backgroundColor = PharosColorBlack;
 
       component = await fixture(
-        html`<pharos-button variant="secondary" on-background>I am a button</pharos-button>`,
+        html`<test-pharos-button variant="secondary" on-background
+          >I am a button</test-pharos-button
+        >`,
         {
           parentNode,
         }
@@ -83,7 +88,7 @@ describe('pharos-button', () => {
       parentNode.style.backgroundColor = PharosColorBlack;
 
       component = await fixture(
-        html`<pharos-button variant="subtle" on-background>I am a button</pharos-button>`,
+        html`<test-pharos-button variant="subtle" on-background>I am a button</test-pharos-button>`,
         {
           parentNode,
         }
@@ -96,7 +101,9 @@ describe('pharos-button', () => {
       parentNode.style.backgroundColor = PharosColorBlack;
 
       component = await fixture(
-        html`<pharos-button variant="overlay" on-background>I am a button</pharos-button>`,
+        html`<test-pharos-button variant="overlay" on-background
+          >I am a button</test-pharos-button
+        >`,
         {
           parentNode,
         }
@@ -106,7 +113,7 @@ describe('pharos-button', () => {
 
     it('is accessible when pressed', async () => {
       component = await fixture(
-        html`<pharos-button pressed="true">I am a pressed button</pharos-button>`
+        html`<test-pharos-button pressed="true">I am a pressed button</test-pharos-button>`
       );
       await expect(component).to.be.accessible();
     });
@@ -129,14 +136,14 @@ describe('pharos-button', () => {
 
     it('throws an error for an invalid type value', async () => {
       component = await fixture(html`
-        <pharos-button type="fake">I am a button</pharos-button>
+        <test-pharos-button type="fake">I am a button</test-pharos-button>
       `).catch((e) => e);
       expect('fake is not a valid type. Valid types are: button, submit, reset').to.be.thrown;
     });
 
     it('throws an error for an invalid variant value', async () => {
       component = await fixture(html`
-        <pharos-button variant="fake">I am a button</pharos-button>
+        <test-pharos-button variant="fake">I am a button</test-pharos-button>
       `).catch((e) => e);
       expect('fake is not a valid variant. Valid variants are: primary, secondary, subtle').to.be
         .thrown;
@@ -146,7 +153,9 @@ describe('pharos-button', () => {
       component.icon = 'download';
       await component.updateComplete;
 
-      const icon = component.renderRoot.querySelector(`pharos-icon[name='download']`);
+      const icon = component.renderRoot.querySelector(
+        `[data-pharos-component="PharosIcon"][name='download']`
+      );
       expect(icon).not.to.be.null;
     });
 
@@ -154,7 +163,9 @@ describe('pharos-button', () => {
       component.iconLeft = 'view-gallery';
       await component.updateComplete;
 
-      const icon = component.renderRoot.querySelector(`pharos-icon[name='view-gallery']`);
+      const icon = component.renderRoot.querySelector(
+        `[data-pharos-component="PharosIcon"][name='view-gallery']`
+      );
       expect(icon).not.to.be.null;
     });
 
@@ -162,7 +173,9 @@ describe('pharos-button', () => {
       component.iconRight = 'chevron-down';
       await component.updateComplete;
 
-      const icon = component.renderRoot.querySelector(`pharos-icon[name='chevron-down']`);
+      const icon = component.renderRoot.querySelector(
+        `[data-pharos-component="PharosIcon"][name='chevron-down']`
+      );
       expect(icon).not.to.be.null;
     });
 
@@ -171,8 +184,12 @@ describe('pharos-button', () => {
       component.iconRight = 'chevron-down';
       await component.updateComplete;
 
-      const leftIcon = component.renderRoot.querySelector(`pharos-icon[name='view-gallery']`);
-      const rightIcon = component.renderRoot.querySelector(`pharos-icon[name='chevron-down']`);
+      const leftIcon = component.renderRoot.querySelector(
+        `[data-pharos-component="PharosIcon"][name='view-gallery']`
+      );
+      const rightIcon = component.renderRoot.querySelector(
+        `[data-pharos-component="PharosIcon"][name='chevron-down']`
+      );
       expect(leftIcon).not.to.be.null;
       expect(rightIcon).not.to.be.null;
     });
@@ -185,7 +202,7 @@ describe('pharos-button', () => {
         count++;
       };
       component = await fixture(html`
-        <pharos-button href="#" @click=${onClick}>I am a button link</pharos-button>
+        <test-pharos-button href="#" @click=${onClick}>I am a button link</test-pharos-button>
       `);
 
       component['_button'].dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
@@ -199,16 +216,16 @@ describe('pharos-button', () => {
       let formdata = new FormData();
       parentNode.setAttribute('name', 'my-form');
 
-      const submitButton = document.createElement('pharos-button') as PharosButton;
+      const submitButton = document.createElement('test-pharos-button') as PharosButton;
       submitButton.type = 'submit';
       submitButton.appendChild(document.createTextNode('I am a button'));
       parentNode.appendChild(submitButton);
 
       component = await fixture(
         html`
-          <pharos-text-input name="my-input" value="test">
+          <test-pharos-text-input name="my-input" value="test">
             <span slot="label">I am a label</span>
-          </pharos-text-input>
+          </test-pharos-text-input>
         `,
         { parentNode }
       );
@@ -230,21 +247,21 @@ describe('pharos-button', () => {
       let formdata = new FormData();
       parentNode.setAttribute('name', 'my-form');
 
-      const resetButton = document.createElement('pharos-button') as PharosButton;
+      const resetButton = document.createElement('test-pharos-button') as PharosButton;
       resetButton.type = 'reset';
       resetButton.appendChild(document.createTextNode('I am a button'));
       parentNode.appendChild(resetButton);
 
       component = await fixture(
         html`
-          <pharos-text-input name="my-input" value="test">
+          <test-pharos-text-input name="my-input" value="test">
             <span slot="label">I am a label</span>
-          </pharos-text-input>
+          </test-pharos-text-input>
         `,
         { parentNode }
       );
 
-      const input = document.querySelector('pharos-text-input') as PharosTextInput;
+      const input = document.querySelector('test-pharos-text-input') as PharosTextInput;
       if (input) {
         input.value = 'otherValue';
       }
@@ -267,16 +284,16 @@ describe('pharos-button', () => {
       let leak = false;
       parentNode.setAttribute('name', 'my-form');
 
-      const submitButton = document.createElement('pharos-button') as PharosButton;
+      const submitButton = document.createElement('test-pharos-button') as PharosButton;
       submitButton.type = 'submit';
       submitButton.appendChild(document.createTextNode('I am a button'));
       parentNode.appendChild(submitButton);
 
       component = await fixture(
         html`
-          <pharos-text-input name="my-input" value="test">
+          <test-pharos-text-input name="my-input" value="test">
             <span slot="label">I am a label</span>
-          </pharos-text-input>
+          </test-pharos-text-input>
         `,
         { parentNode }
       );
@@ -302,7 +319,7 @@ describe('pharos-button', () => {
       let formdata = new FormData();
       parentNode.setAttribute('name', 'my-form');
 
-      const submitButton = document.createElement('pharos-button') as PharosButton;
+      const submitButton = document.createElement('test-pharos-button') as PharosButton;
       submitButton.type = 'submit';
       submitButton.appendChild(document.createTextNode('I am a button'));
       submitButton.addEventListener('click', (event) => {
@@ -312,9 +329,9 @@ describe('pharos-button', () => {
 
       component = await fixture(
         html`
-          <pharos-text-input name="my-input" value="test">
+          <test-pharos-text-input name="my-input" value="test">
             <span slot="label">I am a label</span>
-          </pharos-text-input>
+          </test-pharos-text-input>
         `,
         { parentNode }
       );

--- a/packages/pharos/src/components/button/pharos-button.wc.stories.jsx
+++ b/packages/pharos/src/components/button/pharos-button.wc.stories.jsx
@@ -20,7 +20,7 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-button
+      <storybook-pharos-button
         ?disabled=${ifDefined(args.disabled)}
         download=${ifDefined(args.download)}
         icon=${ifDefined(args.icon)}
@@ -41,7 +41,7 @@ export const Base = {
         @click="${(e) => action('Click')(e.target)}"
       >
         ${args.text}
-      </pharos-button>
+      </storybook-pharos-button>
     `,
   args: defaultArgs,
 };
@@ -51,29 +51,41 @@ export const Variants = {
     html`
       <div style="display: grid; grid-gap: 2rem; grid-template-columns: repeat(3, 200px);">
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="primary">Primary</pharos-button>
-          <pharos-button name="secondary" variant="secondary">Secondary</pharos-button>
-          <pharos-button name="subtle" variant="subtle">Subtle</pharos-button>
-          <pharos-button name="overlay" variant="overlay">Overlay</pharos-button>
+          <storybook-pharos-button name="primary">Primary</storybook-pharos-button>
+          <storybook-pharos-button name="secondary" variant="secondary"
+            >Secondary</storybook-pharos-button
+          >
+          <storybook-pharos-button name="subtle" variant="subtle">Subtle</storybook-pharos-button>
+          <storybook-pharos-button name="overlay" variant="overlay"
+            >Overlay</storybook-pharos-button
+          >
         </div>
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="primary-disabled" disabled>Primary</pharos-button>
-          <pharos-button name="secondary-disabled" variant="secondary" disabled
-            >Secondary</pharos-button
+          <storybook-pharos-button name="primary-disabled" disabled
+            >Primary</storybook-pharos-button
           >
-          <pharos-button name="subtle-disabled" variant="subtle" disabled>Subtle</pharos-button>
-          <pharos-button name="overlay-disabled" variant="overlay" disabled>Overlay</pharos-button>
+          <storybook-pharos-button name="secondary-disabled" variant="secondary" disabled
+            >Secondary</storybook-pharos-button
+          >
+          <storybook-pharos-button name="subtle-disabled" variant="subtle" disabled
+            >Subtle</storybook-pharos-button
+          >
+          <storybook-pharos-button name="overlay-disabled" variant="overlay" disabled
+            >Overlay</storybook-pharos-button
+          >
         </div>
         <div style="background-color: #000000; padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="primary-on-background" on-background>Primary</pharos-button>
-          <pharos-button name="secondary-on-background" variant="secondary" on-background
-            >Secondary</pharos-button
+          <storybook-pharos-button name="primary-on-background" on-background
+            >Primary</storybook-pharos-button
           >
-          <pharos-button name="subtle-on-background" variant="subtle" on-background
-            >Subtle</pharos-button
+          <storybook-pharos-button name="secondary-on-background" variant="secondary" on-background
+            >Secondary</storybook-pharos-button
           >
-          <pharos-button name="overlay-on-background" variant="overlay" on-background
-            >Overlay</pharos-button
+          <storybook-pharos-button name="subtle-on-background" variant="subtle" on-background
+            >Subtle</storybook-pharos-button
+          >
+          <storybook-pharos-button name="overlay-on-background" variant="overlay" on-background
+            >Overlay</storybook-pharos-button
           >
         </div>
       </div>
@@ -85,40 +97,56 @@ export const Large = {
     html`
       <div style="display: grid; grid-gap: 2rem; grid-template-columns: repeat(3, 200px);">
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="large-primary" large>Primary</pharos-button>
-          <pharos-button name="large-secondary" variant="secondary" large>Secondary</pharos-button>
-          <pharos-button name="large-subtle" variant="subtle" large>Subtle</pharos-button>
-          <pharos-button name="large-overlay" variant="overlay" large>Overlay</pharos-button>
+          <storybook-pharos-button name="large-primary" large>Primary</storybook-pharos-button>
+          <storybook-pharos-button name="large-secondary" variant="secondary" large
+            >Secondary</storybook-pharos-button
+          >
+          <storybook-pharos-button name="large-subtle" variant="subtle" large
+            >Subtle</storybook-pharos-button
+          >
+          <storybook-pharos-button name="large-overlay" variant="overlay" large
+            >Overlay</storybook-pharos-button
+          >
         </div>
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="large-primary-disabled" large disabled>Primary</pharos-button>
-          <pharos-button name="large-secondary-disabled" variant="secondary" large disabled
+          <storybook-pharos-button name="large-primary-disabled" large disabled
+            >Primary</storybook-pharos-button
+          >
+          <storybook-pharos-button
+            name="large-secondary-disabled"
+            variant="secondary"
+            large
+            disabled
             >Secondary
-          </pharos-button>
-          <pharos-button name="large-subtle-disabled" variant="subtle" large disabled
+          </storybook-pharos-button>
+          <storybook-pharos-button name="large-subtle-disabled" variant="subtle" large disabled
             >Subtle
-          </pharos-button>
-          <pharos-button name="large-overlay" variant="overlay" large disabled
+          </storybook-pharos-button>
+          <storybook-pharos-button name="large-overlay" variant="overlay" large disabled
             >Overlay
-          </pharos-button>
+          </storybook-pharos-button>
         </div>
         <div style="background-color: #000000; padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="large-primary-on-background" large on-background
+          <storybook-pharos-button name="large-primary-on-background" large on-background
             >Primary
-          </pharos-button>
-          <pharos-button
+          </storybook-pharos-button>
+          <storybook-pharos-button
             name="large-secondary-on-background"
             variant="secondary"
             large
             on-background
             >Secondary
-          </pharos-button>
-          <pharos-button name="large-subtle-on-background" variant="subtle" large on-background
+          </storybook-pharos-button>
+          <storybook-pharos-button
+            name="large-subtle-on-background"
+            variant="subtle"
+            large
+            on-background
             >Subtle
-          </pharos-button>
-          <pharos-button name="large-overlay" variant="overlay" large on-background
+          </storybook-pharos-button>
+          <storybook-pharos-button name="large-overlay" variant="overlay" large on-background
             >Overlay
-          </pharos-button>
+          </storybook-pharos-button>
         </div>
       </div>
     `,
@@ -129,46 +157,57 @@ export const WithIcons = {
     html`
       <div style="display: grid; grid-gap: 2rem; grid-template-columns: repeat(3, 200px);">
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="primary-icon-left" icon-left="download">Icon left</pharos-button>
-          <pharos-button name="primary-icon-right" icon-right="chevron-down"
+          <storybook-pharos-button name="primary-icon-left" icon-left="download"
+            >Icon left</storybook-pharos-button
+          >
+          <storybook-pharos-button name="primary-icon-right" icon-right="chevron-down"
             >Icon right
-          </pharos-button>
-          <pharos-button name="primary-icon-both" icon-right="chevron-down" icon-left="view-gallery"
+          </storybook-pharos-button>
+          <storybook-pharos-button
+            name="primary-icon-both"
+            icon-right="chevron-down"
+            icon-left="view-gallery"
             >Icon both
-          </pharos-button>
+          </storybook-pharos-button>
         </div>
         <div style="padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="primary-icon-left-disabled" icon-left="download" disabled
+          <storybook-pharos-button name="primary-icon-left-disabled" icon-left="download" disabled
             >Icon left
-          </pharos-button>
-          <pharos-button name="primary-icon-right-disabled" icon-right="chevron-down" disabled
+          </storybook-pharos-button>
+          <storybook-pharos-button
+            name="primary-icon-right-disabled"
+            icon-right="chevron-down"
+            disabled
             >Icon right
-          </pharos-button>
-          <pharos-button
+          </storybook-pharos-button>
+          <storybook-pharos-button
             name="primary-icon-both-disabled"
             icon-right="chevron-down"
             icon-left="view-gallery"
             disabled
             >Icon both
-          </pharos-button>
+          </storybook-pharos-button>
         </div>
         <div style="background-color: #000000; padding: 1rem; display: grid; grid-gap: 1.5rem;">
-          <pharos-button name="primary-icon-left-on-background" icon-left="download" on-background
+          <storybook-pharos-button
+            name="primary-icon-left-on-background"
+            icon-left="download"
+            on-background
             >Icon left
-          </pharos-button>
-          <pharos-button
+          </storybook-pharos-button>
+          <storybook-pharos-button
             name="primary-icon-right-on-background"
             icon-right="chevron-down"
             on-background
             >Icon right
-          </pharos-button>
-          <pharos-button
+          </storybook-pharos-button>
+          <storybook-pharos-button
             name="primary-icon-both-on-background"
             icon-right="chevron-down"
             icon-left="view-gallery"
             on-background
             >Icon both
-          </pharos-button>
+          </storybook-pharos-button>
         </div>
       </div>
     `,
@@ -208,44 +247,53 @@ export const Forms = {
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 300px;">
         <form name="my-form" action="https://httpbin.org/post" method="POST">
-          <pharos-text-input name="my-text-input" required>
+          <storybook-pharos-text-input name="my-text-input" required>
             <span slot="label">Name</span>
-          </pharos-text-input>
-          <pharos-select name="my-select" required style="margin-top: 1.5rem">
+          </storybook-pharos-text-input>
+          <storybook-pharos-select name="my-select" required style="margin-top: 1.5rem">
             <span slot="label">Role</span>
             <option value="1">Student</option>
             <option value="2">Teacher</option>
             <option value="3" selected>Librarian</option>
-          </pharos-select>
-          <pharos-combobox name="my-combobox" value="2" required style="margin-top: 1.5rem">
+          </storybook-pharos-select>
+          <storybook-pharos-combobox
+            name="my-combobox"
+            value="2"
+            required
+            style="margin-top: 1.5rem"
+          >
             <span slot="label">State</span>
             <option value="1">New York</option>
             <option value="2">Michigan</option>
             <option value="3">New Jersey</option>
-          </pharos-combobox>
-          <pharos-radio-group name="my-radio-group" style="margin-top: 1.5rem">
+          </storybook-pharos-combobox>
+          <storybook-pharos-radio-group name="my-radio-group" style="margin-top: 1.5rem">
             <span slot="legend">Degree</span>
-            <pharos-radio-button value="1"
-              ><span slot="label">Undergraduate</span></pharos-radio-button
+            <storybook-pharos-radio-button value="1"
+              ><span slot="label">Undergraduate</span></storybook-pharos-radio-button
             >
-            <pharos-radio-button value="2"><span slot="label">Graduate</span></pharos-radio-button>
-          </pharos-radio-group>
-          <pharos-checkbox-group name="my-checkbox-group" style="margin-top: 1.5rem">
+            <storybook-pharos-radio-button value="2"
+              ><span slot="label">Graduate</span></storybook-pharos-radio-button
+            >
+          </storybook-pharos-radio-group>
+          <storybook-pharos-checkbox-group name="my-checkbox-group" style="margin-top: 1.5rem">
             <span slot="legend">Preferences</span>
-            <pharos-checkbox value="1"
-              ><span slot="label">Send me promotions and discounts</span></pharos-checkbox
+            <storybook-pharos-checkbox value="1"
+              ><span slot="label">Send me promotions and discounts</span></storybook-pharos-checkbox
             >
-            <pharos-checkbox value="2" checked
-              ><span slot="label">Send me weekly updates</span></pharos-checkbox
+            <storybook-pharos-checkbox value="2" checked
+              ><span slot="label">Send me weekly updates</span></storybook-pharos-checkbox
             >
-          </pharos-checkbox-group>
-          <pharos-textarea name="comments" style="margin-top: 1.5rem">
+          </storybook-pharos-checkbox-group>
+          <storybook-pharos-textarea name="comments" style="margin-top: 1.5rem">
             <span slot="label">Comments</span>
-          </pharos-textarea>
-          <pharos-button type="reset" variant="secondary" style="margin-top: 1.5rem"
+          </storybook-pharos-textarea>
+          <storybook-pharos-button type="reset" variant="secondary" style="margin-top: 1.5rem"
             >Reset
-          </pharos-button>
-          <pharos-button type="submit" style="margin-top: 1.5rem">Submit</pharos-button>
+          </storybook-pharos-button>
+          <storybook-pharos-button type="submit" style="margin-top: 1.5rem"
+            >Submit</storybook-pharos-button
+          >
         </form>
       </div>
     `,

--- a/packages/pharos/src/components/checkbox-group/PharosCheckboxGroup.react.stories.jsx
+++ b/packages/pharos/src/components/checkbox-group/PharosCheckboxGroup.react.stories.jsx
@@ -4,11 +4,19 @@ import { PharosButton, PharosCheckbox, PharosCheckboxGroup } from '../../react-c
 import createFormData from '../../utils/createFormData';
 import { defaultArgs } from './storyArgs';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Checkbox Group',
   component: PharosCheckboxGroup,
   subcomponents: { PharosCheckbox },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('checkbox') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.test.ts
+++ b/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.test.ts
@@ -11,11 +11,11 @@ describe('pharos-checkbox-group', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-checkbox-group name="checkbox-group">
+      <test-pharos-checkbox-group name="checkbox-group">
         <span slot="legend">Checkbox Group Header</span>
-        <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-      </pharos-checkbox-group>
+        <test-pharos-checkbox value="1"><span slot="label">Checkbox 1</span></test-pharos-checkbox>
+        <test-pharos-checkbox value="2"><span slot="label">Checkbox 2</span></test-pharos-checkbox>
+      </test-pharos-checkbox-group>
     `);
   });
 
@@ -31,10 +31,12 @@ describe('pharos-checkbox-group', () => {
 
   it('has an attribute to set orientation', async () => {
     component = await fixture(html`
-      <pharos-checkbox-group horizontal>
-        <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2" checked><span slot="label">Checkbox 2</span></pharos-checkbox>
-      </pharos-checkbox-group>
+      <test-pharos-checkbox-group horizontal>
+        <test-pharos-checkbox value="1"><span slot="label">Checkbox 1</span></test-pharos-checkbox>
+        <test-pharos-checkbox value="2" checked
+          ><span slot="label">Checkbox 2</span></test-pharos-checkbox
+        >
+      </test-pharos-checkbox-group>
     `);
     const fieldset = component.renderRoot.querySelector('fieldset') as HTMLElement;
     expect(fieldset.classList.contains('checkbox-group--horizontal')).to.be.true;
@@ -46,13 +48,13 @@ describe('pharos-checkbox-group', () => {
       eventSource = event.composedPath()[0] as Element;
     };
     component = await fixture(html`
-      <pharos-checkbox-group @change=${onChange}>
-        <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-      </pharos-checkbox-group>
+      <test-pharos-checkbox-group @change=${onChange}>
+        <test-pharos-checkbox value="1"><span slot="label">Checkbox 1</span></test-pharos-checkbox>
+        <test-pharos-checkbox value="2"><span slot="label">Checkbox 2</span></test-pharos-checkbox>
+      </test-pharos-checkbox-group>
     `);
 
-    const box = component.querySelector('pharos-checkbox[value="2"]') as PharosCheckbox;
+    const box = component.querySelector('test-pharos-checkbox[value="2"]') as PharosCheckbox;
     box['_checkbox'].click();
     await component.updateComplete;
 
@@ -61,12 +63,12 @@ describe('pharos-checkbox-group', () => {
 
   it('sets the name for each checkbox in the group', async () => {
     component = await fixture(html`
-      <pharos-checkbox-group name="group1">
-        <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-      </pharos-checkbox-group>
+      <test-pharos-checkbox-group name="group1">
+        <test-pharos-checkbox value="1"><span slot="label">Checkbox 1</span></test-pharos-checkbox>
+        <test-pharos-checkbox value="2"><span slot="label">Checkbox 2</span></test-pharos-checkbox>
+      </test-pharos-checkbox-group>
     `);
-    const boxes = component.querySelectorAll('pharos-checkbox') as NodeListOf<PharosCheckbox>;
+    const boxes = component.querySelectorAll('test-pharos-checkbox') as NodeListOf<PharosCheckbox>;
     boxes.forEach((box) => {
       expect(box.name).to.equal('group1');
     });
@@ -74,22 +76,28 @@ describe('pharos-checkbox-group', () => {
 
   it('sets value if a single checkbox is checked', async () => {
     component = await fixture(html`
-      <pharos-checkbox-group name="group1">
-        <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2" checked><span slot="label">Checkbox 2</span></pharos-checkbox>
-        <pharos-checkbox value="3"><span slot="label">Checkbox 3</span></pharos-checkbox>
-      </pharos-checkbox-group>
+      <test-pharos-checkbox-group name="group1">
+        <test-pharos-checkbox value="1"><span slot="label">Checkbox 1</span></test-pharos-checkbox>
+        <test-pharos-checkbox value="2" checked
+          ><span slot="label">Checkbox 2</span></test-pharos-checkbox
+        >
+        <test-pharos-checkbox value="3"><span slot="label">Checkbox 3</span></test-pharos-checkbox>
+      </test-pharos-checkbox-group>
     `);
     expect(component.value).to.eql(['2']);
   });
 
   it('sets value if multiple checkboxes are checked', async () => {
     component = await fixture(html`
-      <pharos-checkbox-group name="group1">
-        <pharos-checkbox value="1" checked><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-        <pharos-checkbox value="3" checked><span slot="label">Checkbox 3</span></pharos-checkbox>
-      </pharos-checkbox-group>
+      <test-pharos-checkbox-group name="group1">
+        <test-pharos-checkbox value="1" checked
+          ><span slot="label">Checkbox 1</span></test-pharos-checkbox
+        >
+        <test-pharos-checkbox value="2"><span slot="label">Checkbox 2</span></test-pharos-checkbox>
+        <test-pharos-checkbox value="3" checked
+          ><span slot="label">Checkbox 3</span></test-pharos-checkbox
+        >
+      </test-pharos-checkbox-group>
     `);
     expect(component.value).to.eql(['1', '3']);
   });
@@ -100,7 +108,7 @@ describe('pharos-checkbox-group', () => {
       activeElement = event.composedPath()[0];
     };
     document.addEventListener('focusin', onFocusIn);
-    const checkbox = component.querySelector('pharos-checkbox') as PharosCheckbox;
+    const checkbox = component.querySelector('test-pharos-checkbox') as PharosCheckbox;
 
     component.focus();
 
@@ -112,11 +120,15 @@ describe('pharos-checkbox-group', () => {
     const text = 'Please make a selection';
     component = await fixture(
       html`
-        <pharos-checkbox-group message="${text}">
+        <test-pharos-checkbox-group message="${text}">
           <span slot="legend">Checkbox Group Header</span>
-          <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-          <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-        </pharos-checkbox-group>
+          <test-pharos-checkbox value="1"
+            ><span slot="label">Checkbox 1</span></test-pharos-checkbox
+          >
+          <test-pharos-checkbox value="2"
+            ><span slot="label">Checkbox 2</span></test-pharos-checkbox
+          >
+        </test-pharos-checkbox-group>
       `
     );
     const message = component.renderRoot.querySelector('.input-message__text');
@@ -124,7 +136,7 @@ describe('pharos-checkbox-group', () => {
   });
 
   it('updates the state of its children', async () => {
-    const boxes = component.querySelectorAll('pharos-checkbox') as NodeListOf<PharosCheckbox>;
+    const boxes = component.querySelectorAll('test-pharos-checkbox') as NodeListOf<PharosCheckbox>;
     component.disabled = true;
     await component.updateComplete;
     boxes.forEach((box) => {
@@ -146,7 +158,7 @@ describe('pharos-checkbox-group', () => {
     const event = new Event('change');
     const changeSpy: SinonSpy = sinon.spy(event, 'stopPropagation');
 
-    const box = component.querySelector('pharos-checkbox[value="2"]') as PharosCheckbox;
+    const box = component.querySelector('test-pharos-checkbox[value="2"]') as PharosCheckbox;
     box.dispatchEvent(event);
     await component.updateComplete;
 

--- a/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.wc.stories.jsx
+++ b/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.wc.stories.jsx
@@ -19,7 +19,7 @@ export default {
 
 export const Base = {
   render: (args) =>
-    html` <pharos-checkbox-group
+    html` <storybook-pharos-checkbox-group
       ?disabled=${args.disabled}
       ?hide-label="${args.hideLabel}"
       ?horizontal=${args.horizontal}
@@ -29,23 +29,33 @@ export const Base = {
       ?validated=${args.validated}
     >
       <span slot="legend">Checkbox Group Header</span>
-      <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-      <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-    </pharos-checkbox-group>`,
+      <storybook-pharos-checkbox value="1"
+        ><span slot="label">Checkbox 1</span></storybook-pharos-checkbox
+      >
+      <storybook-pharos-checkbox value="2"
+        ><span slot="label">Checkbox 2</span></storybook-pharos-checkbox
+      >
+    </storybook-pharos-checkbox-group>`,
   args: defaultArgs,
 };
 
 export const Events = {
   render: () =>
-    html` <pharos-checkbox-group
+    html` <storybook-pharos-checkbox-group
       @change="${(e) => action('Change')(JSON.stringify(e.target.value))}"
       name="checkbox-group2"
     >
       <span slot="legend">Checkbox Group Header</span>
-      <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-      <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-      <pharos-checkbox value="3"><span slot="label">Checkbox 3</span></pharos-checkbox>
-    </pharos-checkbox-group>`,
+      <storybook-pharos-checkbox value="1"
+        ><span slot="label">Checkbox 1</span></storybook-pharos-checkbox
+      >
+      <storybook-pharos-checkbox value="2"
+        ><span slot="label">Checkbox 2</span></storybook-pharos-checkbox
+      >
+      <storybook-pharos-checkbox value="3"
+        ><span slot="label">Checkbox 3</span></storybook-pharos-checkbox
+      >
+    </storybook-pharos-checkbox-group>`,
   args: {},
   parameters: { options: { selectedPanel: 'addon-actions' } },
 };
@@ -63,18 +73,24 @@ export const Validity = {
 export const FormData = {
   render: () =>
     html` <form name="my-form" action="https://httpbin.org/post" method="POST">
-      <pharos-checkbox-group
+      <storybook-pharos-checkbox-group
         @change="${(e) => action('Change')(e.target.value)}"
         name="checkbox-group4"
         style="margin-bottom: 0.5rem;"
         required
       >
         <span slot="legend">Checkbox Group Header</span>
-        <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-        <pharos-checkbox value="3"><span slot="label">Checkbox 3</span></pharos-checkbox>
-      </pharos-checkbox-group>
-      <pharos-button
+        <storybook-pharos-checkbox value="1"
+          ><span slot="label">Checkbox 1</span></storybook-pharos-checkbox
+        >
+        <storybook-pharos-checkbox value="2"
+          ><span slot="label">Checkbox 2</span></storybook-pharos-checkbox
+        >
+        <storybook-pharos-checkbox value="3"
+          ><span slot="label">Checkbox 3</span></storybook-pharos-checkbox
+        >
+      </storybook-pharos-checkbox-group>
+      <storybook-pharos-button
         type="submit"
         value="Submit"
         @click="${(e) => {
@@ -89,7 +105,7 @@ export const FormData = {
           };
           xhr.send(formData);
         }}"
-        >Submit</pharos-button
+        >Submit</storybook-pharos-button
       >
     </form>`,
   parameters: { options: { selectedPanel: 'addon-actions' } },

--- a/packages/pharos/src/components/checkbox/PharosCheckbox.react.stories.jsx
+++ b/packages/pharos/src/components/checkbox/PharosCheckbox.react.stories.jsx
@@ -3,10 +3,18 @@ import { action } from '@storybook/addon-actions';
 import { PharosCheckbox, PharosLink } from '../../react-components';
 import { defaultArgs } from './storyArgs';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Checkbox',
   component: PharosCheckbox,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('checkbox') },
     options: {

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.test.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.test.ts
@@ -12,7 +12,7 @@ describe('pharos-checkbox', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html`<pharos-checkbox><span slot="label">test checkbox</span></pharos-checkbox>`
+      html`<test-pharos-checkbox><span slot="label">test checkbox</span></test-pharos-checkbox>`
     );
   });
 
@@ -28,14 +28,18 @@ describe('pharos-checkbox', () => {
 
   it('is accessible when disabled', async () => {
     component = await fixture(
-      html`<pharos-checkbox disabled><span slot="label">test checkbox</span></pharos-checkbox>`
+      html`<test-pharos-checkbox disabled
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >`
     );
     await expect(component).to.be.accessible();
   });
 
   it('has an attribute to set check value', async () => {
     component = await fixture(html`
-      <pharos-checkbox ?checked=${true}><span slot="label">test checkbox</span></pharos-checkbox>
+      <test-pharos-checkbox ?checked=${true}
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >
     `);
     await expect(component.checked).to.equal(true);
   });
@@ -46,7 +50,9 @@ describe('pharos-checkbox', () => {
       eventSource = event.composedPath()[0] as Element;
     };
     component = await fixture(html`
-      <pharos-checkbox @change=${onChange}><span slot="label">test checkbox</span></pharos-checkbox>
+      <test-pharos-checkbox @change=${onChange}
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >
     `);
 
     component['_checkbox'].click();
@@ -76,7 +82,9 @@ describe('pharos-checkbox', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(
-      html`<pharos-checkbox disabled><span slot="label">test checkbox</span></pharos-checkbox>`
+      html`<test-pharos-checkbox disabled
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >`
     );
 
     component['_checkbox'].focus();
@@ -91,9 +99,9 @@ describe('pharos-checkbox', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-checkbox name="my-checkbox" value="test" checked>
+        <test-pharos-checkbox name="my-checkbox" value="test" checked>
           <span slot="label">test checkbox</span>
-        </pharos-checkbox>
+        </test-pharos-checkbox>
       `,
       { parentNode }
     );
@@ -109,9 +117,9 @@ describe('pharos-checkbox', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-checkbox name="my-checkbox" checked>
+        <test-pharos-checkbox name="my-checkbox" checked>
           <span slot="label">test checkbox</span>
-        </pharos-checkbox>
+        </test-pharos-checkbox>
       `,
       { parentNode }
     );
@@ -127,9 +135,9 @@ describe('pharos-checkbox', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-checkbox name="my-checkbox" value="test" disabled>
+        <test-pharos-checkbox name="my-checkbox" value="test" disabled>
           <span slot="label">test checkbox</span>
-        </pharos-checkbox>
+        </test-pharos-checkbox>
       `,
       { parentNode }
     );
@@ -148,9 +156,9 @@ describe('pharos-checkbox', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-checkbox hide-label>
+      <test-pharos-checkbox hide-label>
         <span slot="label">test checkbox</span>
-      </pharos-checkbox>
+      </test-pharos-checkbox>
     `);
 
     const icon = component.renderRoot.querySelector('svg') as SVGElement;
@@ -169,7 +177,7 @@ describe('pharos-checkbox', () => {
     };
     document.addEventListener('focusin', onFocusIn);
 
-    component = await fixture(html` <pharos-checkbox></pharos-checkbox> `);
+    component = await fixture(html` <test-pharos-checkbox></test-pharos-checkbox> `);
 
     const icon = component.renderRoot.querySelector('svg') as SVGElement;
     icon.dispatchEvent(new Event('click'));
@@ -195,8 +203,8 @@ describe('pharos-checkbox', () => {
 
   it('allows links in the label to be clicked', async () => {
     component = await fixture(html`
-      <pharos-checkbox
-        ><span slot="label">test checkbox with <a href="#">link</a></span></pharos-checkbox
+      <test-pharos-checkbox
+        ><span slot="label">test checkbox with <a href="#">link</a></span></test-pharos-checkbox
       >
     `);
     const link = component.renderRoot.querySelector('a');
@@ -208,13 +216,13 @@ describe('pharos-checkbox', () => {
 
   it('allows Pharos links in the label to be clicked', async () => {
     component = await fixture(html`
-      <pharos-checkbox
+      <test-pharos-checkbox
         ><span slot="label"
-          >test checkbox with <pharos-link href="#">link</pharos-link></span
-        ></pharos-checkbox
+          >test checkbox with <test-pharos-link href="#">link</test-pharos-link></span
+        ></test-pharos-checkbox
       >
     `);
-    const link = component.querySelector('pharos-link') as PharosLink;
+    const link = component.querySelector('test-pharos-link') as PharosLink;
     const anchor = link?.renderRoot.querySelector('#link-element') as HTMLAnchorElement;
     anchor.click();
     await component.updateComplete;
@@ -228,7 +236,9 @@ describe('pharos-checkbox', () => {
       count++;
     };
     component = await fixture(html`
-      <pharos-checkbox @click=${onClick}><span slot="label">test checkbox</span></pharos-checkbox>
+      <test-pharos-checkbox @click=${onClick}
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >
     `);
 
     const label = component.renderRoot.querySelector('label') as HTMLLabelElement;
@@ -242,7 +252,9 @@ describe('pharos-checkbox', () => {
       event.preventDefault();
     };
     component = await fixture(html`
-      <pharos-checkbox @click=${onClick}><span slot="label">test checkbox</span></pharos-checkbox>
+      <test-pharos-checkbox @click=${onClick}
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >
     `);
 
     const label = component.renderRoot.querySelector('label') as HTMLLabelElement;
@@ -253,7 +265,9 @@ describe('pharos-checkbox', () => {
 
   it('is checked when clicked from indeterminate state', async () => {
     component = await fixture(html`
-      <pharos-checkbox indeterminate><span slot="label">test checkbox</span></pharos-checkbox>
+      <test-pharos-checkbox indeterminate
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >
     `);
 
     const label = component.renderRoot.querySelector('label') as HTMLLabelElement;
@@ -277,9 +291,9 @@ describe('pharos-checkbox', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-checkbox name="my-checkbox" value="test" checked>
+        <test-pharos-checkbox name="my-checkbox" value="test" checked>
           <span slot="label">test checkbox</span>
-        </pharos-checkbox>
+        </test-pharos-checkbox>
       `,
       { parentNode }
     );

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.wc.stories.jsx
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.wc.stories.jsx
@@ -16,7 +16,7 @@ export default {
 
 export const Base = {
   render: (args) =>
-    html`<pharos-checkbox
+    html`<storybook-pharos-checkbox
       ?checked=${args.checked}
       ?disabled=${args.disabled}
       ?hide-label=${args.hideLabel}
@@ -25,7 +25,7 @@ export const Base = {
       .message=${args.message}
     >
       <span slot="label">${args.label}</span>
-    </pharos-checkbox>`,
+    </storybook-pharos-checkbox>`,
   args: defaultArgs,
 };
 
@@ -33,44 +33,48 @@ export const States = {
   render: () =>
     html`
       <div>
-        <pharos-checkbox name="one"><span slot="label">Normal Checkbox</span></pharos-checkbox>
-      </div>
-      <div>
-        <pharos-checkbox name="two" disabled
-          ><span slot="label">Disabled Checkbox</span></pharos-checkbox
+        <storybook-pharos-checkbox name="one"
+          ><span slot="label">Normal Checkbox</span></storybook-pharos-checkbox
         >
       </div>
       <div>
-        <pharos-checkbox name="three" checked><span slot="label">Checked</span></pharos-checkbox>
-      </div>
-      <div>
-        <pharos-checkbox name="four" checked disabled
-          ><span slot="label">Checked & Disabled</span></pharos-checkbox
+        <storybook-pharos-checkbox name="two" disabled
+          ><span slot="label">Disabled Checkbox</span></storybook-pharos-checkbox
         >
       </div>
       <div>
-        <pharos-checkbox name="five" checked>
+        <storybook-pharos-checkbox name="three" checked
+          ><span slot="label">Checked</span></storybook-pharos-checkbox
+        >
+      </div>
+      <div>
+        <storybook-pharos-checkbox name="four" checked disabled
+          ><span slot="label">Checked & Disabled</span></storybook-pharos-checkbox
+        >
+      </div>
+      <div>
+        <storybook-pharos-checkbox name="five" checked>
           <div slot="label">
             <div>Multiple lined</div>
             <div>Checkbox</div>
           </div>
-        </pharos-checkbox>
+        </storybook-pharos-checkbox>
       </div>
       <div>
-        <pharos-checkbox name="six" invalidated
-          ><span slot="label">Error checkbox</span></pharos-checkbox
+        <storybook-pharos-checkbox name="six" invalidated
+          ><span slot="label">Error checkbox</span></storybook-pharos-checkbox
         >
       </div>
       <div>
-        <pharos-checkbox name="seven"
+        <storybook-pharos-checkbox name="seven"
           ><span slot="label"
-            >Label with a <pharos-link href="#">link</pharos-link></span
-          ></pharos-checkbox
+            >Label with a <storybook-pharos-link href="#">link</storybook-pharos-link></span
+          ></storybook-pharos-checkbox
         >
       </div>
       <div>
-        <pharos-checkbox name="eight" indeterminate
-          ><span slot="label">Indeterminate checkbox</span></pharos-checkbox
+        <storybook-pharos-checkbox name="eight" indeterminate
+          ><span slot="label">Indeterminate checkbox</span></storybook-pharos-checkbox
         >
       </div>
     `,
@@ -78,14 +82,14 @@ export const States = {
 
 export const Events = {
   render: () =>
-    html` <pharos-checkbox
+    html` <storybook-pharos-checkbox
       value="My value"
       @change="${(e) => action('Change')(e.target.checked)}"
       @input="${(e) => action('Input')(e.target.value)}"
       @click="${(e) => action('Click')(e.target.checked)}"
     >
       <span slot="label">I fire events</span>
-    </pharos-checkbox>`,
+    </storybook-pharos-checkbox>`,
   parameters: {
     options: { selectedPanel: 'addon-actions' },
   },
@@ -106,19 +110,19 @@ export const OnBackground = {
   render: () =>
     html`
       <div style="background-color: #000000; padding: 1rem;">
-        <pharos-checkbox name="on-background" on-background>
+        <storybook-pharos-checkbox name="on-background" on-background>
           <span slot="label">Unchecked</span>
-        </pharos-checkbox>
+        </storybook-pharos-checkbox>
       </div>
       <div style="background-color: #000000; padding: 1rem;">
-        <pharos-checkbox name="on-background" on-background checked>
+        <storybook-pharos-checkbox name="on-background" on-background checked>
           <span slot="label">Checked</span>
-        </pharos-checkbox>
+        </storybook-pharos-checkbox>
       </div>
       <div style="background-color: #000000; padding: 1rem;">
-        <pharos-checkbox name="indeterminate" on-background indeterminate>
+        <storybook-pharos-checkbox name="indeterminate" on-background indeterminate>
           <span slot="label">Indeterminate</span>
-        </pharos-checkbox>
+        </storybook-pharos-checkbox>
       </div>
     `,
 };

--- a/packages/pharos/src/components/combobox/PharosCombobox.react.stories.jsx
+++ b/packages/pharos/src/components/combobox/PharosCombobox.react.stories.jsx
@@ -4,10 +4,18 @@ import { PharosButton, PharosCombobox } from '../../react-components';
 import createFormData from '../../utils/createFormData';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Combobox',
   component: PharosCombobox,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('combobox') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/combobox/pharos-combobox.test.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.test.ts
@@ -13,12 +13,12 @@ describe('pharos-combobox', () => {
   beforeEach(async () => {
     component = await fixture(
       html`
-        <pharos-combobox>
+        <test-pharos-combobox>
           <span slot="label">I am a label</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-combobox>
+        </test-pharos-combobox>
       `
     );
   });
@@ -35,7 +35,9 @@ describe('pharos-combobox', () => {
 
   it('is accessible when disabled', async () => {
     component = await fixture(
-      html`<pharos-combobox disabled><span slot="label">test combobox</span></pharos-combobox>`
+      html`<test-pharos-combobox disabled
+        ><span slot="label">test combobox</span></test-pharos-combobox
+      >`
     );
     await expect(component).to.be.accessible();
   });
@@ -46,10 +48,10 @@ describe('pharos-combobox', () => {
       eventSource = event.composedPath()[0] as Element;
     };
     component = await fixture(html`
-      <pharos-combobox @change=${onChange}>
+      <test-pharos-combobox @change=${onChange}>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
 
     component['_input'].value = 'test';
@@ -96,7 +98,9 @@ describe('pharos-combobox', () => {
     const clearButton = component.renderRoot.querySelector(
       '.combobox__clear-button'
     ) as PharosButton;
-    const clearTooltip = component.renderRoot.querySelector('pharos-tooltip') as PharosTooltip;
+    const clearTooltip = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosTooltip"]'
+    ) as PharosTooltip;
 
     expect(clearButton).to.not.be.null;
     expect(clearTooltip).to.not.be.null;
@@ -167,12 +171,12 @@ describe('pharos-combobox', () => {
 
   it('query matches text when loose-match is enabled and query contains accent', async () => {
     component = await fixture(html`
-      <pharos-combobox loose-match>
+      <test-pharos-combobox loose-match>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
         <option value="2">Oṕtion 2</option>
         <option value="3">Option 3</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
     component['_input'].value = 'Oṕtion';
     component['_input'].dispatchEvent(new Event('input'));
@@ -406,11 +410,11 @@ describe('pharos-combobox', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-combobox name="my-combobox" value="1">
+        <test-pharos-combobox name="my-combobox" value="1">
           <span slot="label">I am a label</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-combobox>
+        </test-pharos-combobox>
       `,
       { parentNode }
     );
@@ -426,11 +430,11 @@ describe('pharos-combobox', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-combobox name="my-combo" value="1" disabled>
+        <test-pharos-combobox name="my-combo" value="1" disabled>
           <span slot="label">I am a label</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-combobox>
+        </test-pharos-combobox>
       `,
       { parentNode }
     );
@@ -444,11 +448,11 @@ describe('pharos-combobox', () => {
   it('updates the displayed selection for asynchronously added options', async () => {
     component = await fixture(
       html`
-        <pharos-combobox name="my-combobox" value="3">
+        <test-pharos-combobox name="my-combobox" value="3">
           <span slot="label">I am a label</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-combobox>
+        </test-pharos-combobox>
       `
     );
 
@@ -464,11 +468,11 @@ describe('pharos-combobox', () => {
   it('does not update the displayed value when no matching options exist', async () => {
     component = await fixture(
       html`
-        <pharos-combobox name="my-combobox" value="3">
+        <test-pharos-combobox name="my-combobox" value="3">
           <span slot="label">I am a label</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-combobox>
+        </test-pharos-combobox>
       `
     );
     expect(component['_input'].value).to.equal('');
@@ -477,11 +481,11 @@ describe('pharos-combobox', () => {
   it('updates the displayed value when the value attribute changes', async () => {
     component = await fixture(
       html`
-        <pharos-combobox name="my-combobox" value="2">
+        <test-pharos-combobox name="my-combobox" value="2">
           <span slot="label">I am a label</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-combobox>
+        </test-pharos-combobox>
       `
     );
     component.value = '1';
@@ -508,11 +512,11 @@ describe('pharos-combobox', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-combobox name="my-combobox" value="1">
+        <test-pharos-combobox name="my-combobox" value="1">
           <span slot="label">I am a label</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-combobox>
+        </test-pharos-combobox>
       `,
       { parentNode }
     );
@@ -530,12 +534,12 @@ describe('pharos-combobox', () => {
 
   it('sets the value on input in search mode', async () => {
     component = await fixture(html`
-      <pharos-combobox search-mode>
+      <test-pharos-combobox search-mode>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
 
     component['_input'].value = 'this is not an option in the list, but it is valid';
@@ -546,12 +550,12 @@ describe('pharos-combobox', () => {
 
   it('it does not highlight matching text in search mode', async () => {
     component = await fixture(html`
-      <pharos-combobox search-mode>
+      <test-pharos-combobox search-mode>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
 
     component['_input'].value = 'o';
@@ -570,12 +574,12 @@ describe('pharos-combobox', () => {
 
   it('does not render a checkmark on selected options in search mode', async () => {
     component = await fixture(html`
-      <pharos-combobox search-mode>
+      <test-pharos-combobox search-mode>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
     component['_input'].value = 'Option 2';
     component['_input'].dispatchEvent(new Event('input'));
@@ -600,12 +604,12 @@ describe('pharos-combobox', () => {
 
   it('does not filter search results in search mode', async () => {
     component = await fixture(html`
-      <pharos-combobox search-mode>
+      <test-pharos-combobox search-mode>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
     component['_input'].value = 'yay';
     component['_input'].dispatchEvent(new Event('input'));
@@ -627,10 +631,10 @@ describe('pharos-combobox', () => {
     };
 
     component = await fixture(html`
-      <pharos-combobox search-mode @change=${onChange}>
+      <test-pharos-combobox search-mode @change=${onChange}>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
 
     component['_input'].dispatchEvent(new KeyboardEvent('keydown', { key: 'Down' }));
@@ -643,9 +647,9 @@ describe('pharos-combobox', () => {
 
   it('does not show a no results message when there are no matching options in search mode', async () => {
     component = await fixture(html`
-      <pharos-combobox search-mode>
+      <test-pharos-combobox search-mode>
         <span slot="label">I am a label</span>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
     component['_input'].value = 'yay';
     component['_input'].dispatchEvent(new Event('input'));
@@ -660,10 +664,10 @@ describe('pharos-combobox', () => {
 
   it('will close the dropdown on enter when there is no option selected', async () => {
     component = await fixture(html`
-      <pharos-combobox>
+      <test-pharos-combobox>
         <span slot="label">I am a label</span>
         <option value="1">Option 1</option>
-      </pharos-combobox>
+      </test-pharos-combobox>
     `);
 
     component['_input'].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));

--- a/packages/pharos/src/components/combobox/pharos-combobox.wc.stories.jsx
+++ b/packages/pharos/src/components/combobox/pharos-combobox.wc.stories.jsx
@@ -21,7 +21,7 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-combobox
+      <storybook-pharos-combobox
         .value=${ifDefined(args.value)}
         .name=${ifDefined(args.name)}
         ?open=${args.open}
@@ -49,7 +49,7 @@ export const Base = {
         <option value="11">North Carolina</option>
         <option value="12">South Carolina</option>
         <option value="13">Georgia</option>
-      </pharos-combobox>
+      </storybook-pharos-combobox>
     `,
   args: defaultArgs,
 };
@@ -58,36 +58,36 @@ export const States = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 7rem; grid-template-columns: repeat(2, 300px);">
-        <pharos-combobox name="default">
+        <storybook-pharos-combobox name="default">
           <span slot="label">I am empty</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-combobox>
-        <pharos-combobox name="disabled" disabled>
+        </storybook-pharos-combobox>
+        <storybook-pharos-combobox name="disabled" disabled>
           <span slot="label">I am disabled</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-combobox>
-        <pharos-combobox name="placeholder" placeholder="Enter some text">
+        </storybook-pharos-combobox>
+        <storybook-pharos-combobox name="placeholder" placeholder="Enter some text">
           <span slot="label">I have a placeholder</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-combobox>
-        <pharos-combobox name="provided" value="2">
+        </storybook-pharos-combobox>
+        <storybook-pharos-combobox name="provided" value="2">
           <span slot="label">I have a value provided</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-combobox>
-        <pharos-combobox name="hidden" hide-label>
+        </storybook-pharos-combobox>
+        <storybook-pharos-combobox name="hidden" hide-label>
           <span slot="label">My label is hidden</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-combobox>
+        </storybook-pharos-combobox>
       </div>
     `,
 };
@@ -96,7 +96,7 @@ export const Events = {
   render: () =>
     html`
       <div style="display: grid; grid-template-columns: 300px;">
-        <pharos-combobox
+        <storybook-pharos-combobox
           placeholder="Select a state"
           @change="${(e) => action('Change')(e.target.value)}"
           @input="${(e) => action('Input')(e.target['_input'].value)}"
@@ -115,7 +115,7 @@ export const Events = {
           <option value="NC">North Carolina</option>
           <option value="SC">South Carolina</option>
           <option value="GA">Georgia</option>
-        </pharos-combobox>
+        </storybook-pharos-combobox>
       </div>
     `,
   parameters: {
@@ -126,7 +126,7 @@ export const Events = {
 export const SearchMode = {
   render: () =>
     html`
-      <pharos-combobox
+      <storybook-pharos-combobox
         placeholder="Search..."
         search-mode
         style="display: grid; grid-template-columns: 300px;"
@@ -135,7 +135,7 @@ export const SearchMode = {
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
-      </pharos-combobox>
+      </storybook-pharos-combobox>
     `,
 };
 
@@ -143,7 +143,7 @@ export const Validity = {
   render: (args) =>
     html`
       <div style="display: grid; grid-template-columns: 300px;">
-        <pharos-combobox
+        <storybook-pharos-combobox
           name="my-combobox"
           placeholder="Enter some text"
           @change="${(e) => action('Change')(e.target.value)}"
@@ -157,7 +157,7 @@ export const Validity = {
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-combobox>
+        </storybook-pharos-combobox>
       </div>
     `,
   args: {
@@ -173,7 +173,7 @@ export const FormData = {
     html`
       <div style="display: grid; grid-template-columns: 300px;">
         <form name="my-form" action="https://httpbin.org/post" method="POST">
-          <pharos-combobox
+          <storybook-pharos-combobox
             name="my-combobox"
             style="margin-bottom: 0.5rem;"
             placeholder="Enter some text"
@@ -185,8 +185,8 @@ export const FormData = {
             <option value="1">Option 1</option>
             <option value="2">Option 2</option>
             <option value="3">Option 3</option>
-          </pharos-combobox>
-          <pharos-button
+          </storybook-pharos-combobox>
+          <storybook-pharos-button
             type="submit"
             value="Submit"
             @click="${(e) => {
@@ -203,7 +203,7 @@ export const FormData = {
             }}"
           >
             Submit
-          </pharos-button>
+          </storybook-pharos-button>
         </form>
       </div>
     `,

--- a/packages/pharos/src/components/dropdown-menu-nav/PharosDropdownMenuNav.react.stories.jsx
+++ b/packages/pharos/src/components/dropdown-menu-nav/PharosDropdownMenuNav.react.stories.jsx
@@ -5,6 +5,7 @@ import {
   PharosDropdownMenuNavLink,
 } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Dropdown Menu Nav',
@@ -14,6 +15,13 @@ export default {
     PharosDropdownMenu,
     PharosDropdownMenuItem,
   },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('dropdown-menu-nav') },
   },

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.test.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.test.ts
@@ -8,12 +8,12 @@ describe('pharos-dropdown-menu-nav-link', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-dropdown-menu-nav-link
+      <test-pharos-dropdown-menu-nav-link
         href="#"
         id="smurfs-link"
         data-dropdown-menu-id="smurfs-menu"
         data-dropdown-menu-hover
-        >Smurfs</pharos-dropdown-menu-nav-link
+        >Smurfs</test-pharos-dropdown-menu-nav-link
       >
     `);
   });

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.test.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.test.ts
@@ -11,37 +11,37 @@ describe('pharos-dropdown-menu-nav', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-dropdown-menu-nav>
-        <pharos-dropdown-menu-nav-link
+      <test-pharos-dropdown-menu-nav>
+        <test-pharos-dropdown-menu-nav-link
           href="#"
           id="smurfs-link"
           data-dropdown-menu-id="smurfs-menu"
           data-dropdown-menu-hover
-          >Smurfs</pharos-dropdown-menu-nav-link
+          >Smurfs</test-pharos-dropdown-menu-nav-link
         >
-        <pharos-dropdown-menu id="smurfs-menu" data-dropdown-menu-hover>
-          <pharos-dropdown-menu-item>Papa</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Clumsy</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Smurfette</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-dropdown-menu-nav-link
+        <test-pharos-dropdown-menu id="smurfs-menu" data-dropdown-menu-hover>
+          <test-pharos-dropdown-menu-item>Papa</test-pharos-dropdown-menu-item>
+          <test-pharos-dropdown-menu-item>Clumsy</test-pharos-dropdown-menu-item>
+          <test-pharos-dropdown-menu-item>Smurfette</test-pharos-dropdown-menu-item>
+        </test-pharos-dropdown-menu>
+        <test-pharos-dropdown-menu-nav-link
           href="#"
           id="tmnt-link"
           data-dropdown-menu-id="tmnt-menu"
           data-dropdown-menu-hover
-          >Ninja Turtles</pharos-dropdown-menu-nav-link
+          >Ninja Turtles</test-pharos-dropdown-menu-nav-link
         >
-        <pharos-dropdown-menu id="tmnt-menu">
-          <pharos-dropdown-menu-item>Leonardo</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Donatello</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Raphael</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Michelangelo</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Master Splinter</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-dropdown-menu-nav-link href="#" id="other-link"
-          >Link to Other</pharos-dropdown-menu-nav-link
+        <test-pharos-dropdown-menu id="tmnt-menu">
+          <test-pharos-dropdown-menu-item>Leonardo</test-pharos-dropdown-menu-item>
+          <test-pharos-dropdown-menu-item>Donatello</test-pharos-dropdown-menu-item>
+          <test-pharos-dropdown-menu-item>Raphael</test-pharos-dropdown-menu-item>
+          <test-pharos-dropdown-menu-item>Michelangelo</test-pharos-dropdown-menu-item>
+          <test-pharos-dropdown-menu-item>Master Splinter</test-pharos-dropdown-menu-item>
+        </test-pharos-dropdown-menu>
+        <test-pharos-dropdown-menu-nav-link href="#" id="other-link"
+          >Link to Other</test-pharos-dropdown-menu-nav-link
         >
-      </pharos-dropdown-menu-nav>
+      </test-pharos-dropdown-menu-nav>
     `);
   });
 
@@ -78,7 +78,7 @@ describe('pharos-dropdown-menu-nav', () => {
     menu.open = true;
     await menu.updateComplete;
 
-    const item = menu.querySelector('pharos-dropdown-menu-item') as PharosDropdownMenuItem;
+    const item = menu.querySelector('test-pharos-dropdown-menu-item') as PharosDropdownMenuItem;
     item.focus();
     await component.updateComplete;
 

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.wc.stories.jsx
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav.wc.stories.jsx
@@ -18,38 +18,38 @@ export default {
 export const Base = {
   render: () =>
     html`
-      <pharos-dropdown-menu-nav>
-        <pharos-dropdown-menu-nav-link
+      <storybook-pharos-dropdown-menu-nav>
+        <storybook-pharos-dropdown-menu-nav-link
           href="#"
           id="category1-link"
           data-dropdown-menu-id="category1-menu"
           data-dropdown-menu-hover
           target="_blank"
-          >Category 1</pharos-dropdown-menu-nav-link
+          >Category 1</storybook-pharos-dropdown-menu-nav-link
         >
-        <pharos-dropdown-menu id="category1-menu" data-dropdown-menu-hover>
-          <pharos-dropdown-menu-item>Item 1.1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 1.2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 1.3</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-dropdown-menu-nav-link
+        <storybook-pharos-dropdown-menu id="category1-menu" data-dropdown-menu-hover>
+          <storybook-pharos-dropdown-menu-item>Item 1.1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 1.2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 1.3</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+        <storybook-pharos-dropdown-menu-nav-link
           href="#"
           id="category2-link"
           data-dropdown-menu-id="category2-menu"
           data-dropdown-menu-hover
           target="_blank"
-          >Category 2</pharos-dropdown-menu-nav-link
+          >Category 2</storybook-pharos-dropdown-menu-nav-link
         >
-        <pharos-dropdown-menu id="category2-menu">
-          <pharos-dropdown-menu-item>Item 2.1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 2.2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 2.3</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 2.4</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-dropdown-menu-nav-link href="#" id="other-link" target="_blank"
-          >Link</pharos-dropdown-menu-nav-link
+        <storybook-pharos-dropdown-menu id="category2-menu">
+          <storybook-pharos-dropdown-menu-item>Item 2.1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 2.2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 2.3</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 2.4</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+        <storybook-pharos-dropdown-menu-nav-link href="#" id="other-link" target="_blank"
+          >Link</storybook-pharos-dropdown-menu-nav-link
         >
-      </pharos-dropdown-menu-nav>
+      </storybook-pharos-dropdown-menu-nav>
     `,
   parameters: { chromatic: { viewports: [320, 1200] } },
 };

--- a/packages/pharos/src/components/dropdown-menu/PharosDropdownMenu.react.stories.jsx
+++ b/packages/pharos/src/components/dropdown-menu/PharosDropdownMenu.react.stories.jsx
@@ -9,11 +9,19 @@ import {
   PharosButton,
 } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Dropdown Menu',
   component: PharosDropdownMenu,
   subcomponents: { PharosDropdownMenuItem },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('dropdown-menu') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.test.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.test.ts
@@ -11,23 +11,25 @@ describe('pharos-dropdown-menu-item', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-dropdown-menu-item>I am an item</pharos-dropdown-menu-item>
+      <test-pharos-dropdown-menu-item>I am an item</test-pharos-dropdown-menu-item>
     `);
   });
 
   it('is accessible', async () => {
-    const parentNode = document.createElement('pharos-dropdown-menu');
+    const parentNode = document.createElement('test-pharos-dropdown-menu');
     component = await fixture(
-      html` <pharos-dropdown-menu-item>I am an item</pharos-dropdown-menu-item> `,
+      html` <test-pharos-dropdown-menu-item>I am an item</test-pharos-dropdown-menu-item> `,
       { parentNode }
     );
     await expect(component).to.be.accessible();
   });
 
   it('is accessible when disabled', async () => {
-    const parentNode = document.createElement('pharos-dropdown-menu');
+    const parentNode = document.createElement('test-pharos-dropdown-menu');
     component = await fixture(
-      html` <pharos-dropdown-menu-item disabled>I am an item</pharos-dropdown-menu-item> `,
+      html`
+        <test-pharos-dropdown-menu-item disabled>I am an item</test-pharos-dropdown-menu-item>
+      `,
       { parentNode }
     );
     await expect(component).to.be.accessible();
@@ -74,10 +76,10 @@ describe('pharos-dropdown-menu-item', () => {
 
   it('has a slot to contain a description of the item', async () => {
     component = await fixture(html`
-      <pharos-dropdown-menu-item>
+      <test-pharos-dropdown-menu-item>
         I am an item
         <span slot="description">I am a description</span>
-      </pharos-dropdown-menu-item>
+      </test-pharos-dropdown-menu-item>
     `);
 
     const itemDescription = component.renderRoot.querySelector('.dropdown-menu-item__description');
@@ -85,10 +87,12 @@ describe('pharos-dropdown-menu-item', () => {
   });
 
   it('renders a checkmark when selected and its parent menu has showSelected', async () => {
-    const parentNode = document.createElement('pharos-dropdown-menu');
+    const parentNode = document.createElement('test-pharos-dropdown-menu');
     parentNode.showSelected = true;
     component = await fixture(
-      html` <pharos-dropdown-menu-item selected>I am an item</pharos-dropdown-menu-item> `,
+      html`
+        <test-pharos-dropdown-menu-item selected>I am an item</test-pharos-dropdown-menu-item>
+      `,
       { parentNode }
     );
 
@@ -126,8 +130,8 @@ describe('pharos-dropdown-menu-item', () => {
   it('does not propagate a click event when disabled with click handler present', async () => {
     const event = new MouseEvent('click');
     component = await fixture(html`
-      <pharos-dropdown-menu-item disabled @click="${() => alert('clicked')}"
-        >I am an item</pharos-dropdown-menu-item
+      <test-pharos-dropdown-menu-item disabled @click="${() => alert('clicked')}"
+        >I am an item</test-pharos-dropdown-menu-item
       >
     `);
     await component.updateComplete;

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.test.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.test.ts
@@ -9,37 +9,37 @@ describe('pharos-dropdown-menu', () => {
 
   const getSimpleDropdown = () => {
     return html`
-      <pharos-dropdown-menu id="my-dropdown">
-        <pharos-dropdown-menu-item>I am an item</pharos-dropdown-menu-item>
-      </pharos-dropdown-menu>
+      <test-pharos-dropdown-menu id="my-dropdown">
+        <test-pharos-dropdown-menu-item>I am an item</test-pharos-dropdown-menu-item>
+      </test-pharos-dropdown-menu>
     `;
   };
 
   const getMultipleItemDropdown = () => {
     return html`
-      <pharos-dropdown-menu id="my-dropdown">
-        <pharos-dropdown-menu-item>I am item 1</pharos-dropdown-menu-item>
-        <pharos-dropdown-menu-item>I am item 2</pharos-dropdown-menu-item>
-        <pharos-dropdown-menu-item>I am item 3</pharos-dropdown-menu-item>
-      </pharos-dropdown-menu>
+      <test-pharos-dropdown-menu id="my-dropdown">
+        <test-pharos-dropdown-menu-item>I am item 1</test-pharos-dropdown-menu-item>
+        <test-pharos-dropdown-menu-item>I am item 2</test-pharos-dropdown-menu-item>
+        <test-pharos-dropdown-menu-item>I am item 3</test-pharos-dropdown-menu-item>
+      </test-pharos-dropdown-menu>
     `;
   };
 
   const getNoItemDropdown = () => {
     return html`
-      <pharos-dropdown-menu id="my-dropdown">
+      <test-pharos-dropdown-menu id="my-dropdown">
         <div>Hi there!</div>
-      </pharos-dropdown-menu>
+      </test-pharos-dropdown-menu>
     `;
   };
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-dropdown-menu id="my-dropdown">
-        <pharos-dropdown-menu-item>I am item 1</pharos-dropdown-menu-item>
-        <pharos-dropdown-menu-item>I am item 2</pharos-dropdown-menu-item>
-        <pharos-dropdown-menu-item>I am item 3</pharos-dropdown-menu-item>
-      </pharos-dropdown-menu>
+      <test-pharos-dropdown-menu id="my-dropdown">
+        <test-pharos-dropdown-menu-item>I am item 1</test-pharos-dropdown-menu-item>
+        <test-pharos-dropdown-menu-item>I am item 2</test-pharos-dropdown-menu-item>
+        <test-pharos-dropdown-menu-item>I am item 3</test-pharos-dropdown-menu-item>
+      </test-pharos-dropdown-menu>
     `);
   });
 
@@ -264,7 +264,7 @@ describe('pharos-dropdown-menu', () => {
     await aTimeout(1);
 
     const items = Array.prototype.slice.call(
-      component.querySelectorAll('pharos-dropdown-menu-item')
+      component.querySelectorAll('test-pharos-dropdown-menu-item')
     ) as PharosDropdownMenuItem[];
     const firstItem = items[0].renderRoot.querySelector('.dropdown-menu-item__button');
 
@@ -291,7 +291,7 @@ describe('pharos-dropdown-menu', () => {
     await aTimeout(1);
 
     const items = Array.prototype.slice.call(
-      component.querySelectorAll('pharos-dropdown-menu-item')
+      component.querySelectorAll('test-pharos-dropdown-menu-item')
     ) as PharosDropdownMenuItem[];
     const lastItem = items[items.length - 1].renderRoot.querySelector(
       '.dropdown-menu-item__button'
@@ -421,9 +421,9 @@ describe('pharos-dropdown-menu', () => {
     document.body.appendChild(trigger);
 
     component = await fixture(html`
-      <pharos-dropdown-menu id="my-dropdown" full-width>
-        <pharos-dropdown-menu-item>I am an item</pharos-dropdown-menu-item>
-      </pharos-dropdown-menu>
+      <test-pharos-dropdown-menu id="my-dropdown" full-width>
+        <test-pharos-dropdown-menu-item>I am an item</test-pharos-dropdown-menu-item>
+      </test-pharos-dropdown-menu>
     `);
 
     trigger.click();
@@ -466,7 +466,7 @@ describe('pharos-dropdown-menu', () => {
     await component.updateComplete;
 
     const items = Array.prototype.slice.call(
-      component.querySelectorAll('pharos-dropdown-menu-item')
+      component.querySelectorAll('test-pharos-dropdown-menu-item')
     ) as PharosDropdownMenuItem[];
     const secondItem = items[1].renderRoot.querySelector('.dropdown-menu-item__button');
 
@@ -497,7 +497,7 @@ describe('pharos-dropdown-menu', () => {
     await component.updateComplete;
 
     const items = Array.prototype.slice.call(
-      component.querySelectorAll('pharos-dropdown-menu-item')
+      component.querySelectorAll('test-pharos-dropdown-menu-item')
     ) as PharosDropdownMenuItem[];
     const firstItem = items[0].renderRoot.querySelector('.dropdown-menu-item__button');
 
@@ -528,7 +528,7 @@ describe('pharos-dropdown-menu', () => {
     await component.updateComplete;
 
     const items = Array.prototype.slice.call(
-      component.querySelectorAll('pharos-dropdown-menu-item')
+      component.querySelectorAll('test-pharos-dropdown-menu-item')
     ) as PharosDropdownMenuItem[];
     const firstItem = items[0].renderRoot.querySelector('.dropdown-menu-item__button');
 
@@ -557,7 +557,7 @@ describe('pharos-dropdown-menu', () => {
     await component.updateComplete;
 
     const items = Array.prototype.slice.call(
-      component.querySelectorAll('pharos-dropdown-menu-item')
+      component.querySelectorAll('test-pharos-dropdown-menu-item')
     ) as PharosDropdownMenuItem[];
     const lastItem = items[items.length - 1].renderRoot.querySelector(
       '.dropdown-menu-item__button'
@@ -578,7 +578,9 @@ describe('pharos-dropdown-menu', () => {
     trigger.click();
     await component.updateComplete;
 
-    const item = component.querySelector('pharos-dropdown-menu-item') as PharosDropdownMenuItem;
+    const item = component.querySelector(
+      'test-pharos-dropdown-menu-item'
+    ) as PharosDropdownMenuItem;
     item.click();
     await aTimeout(150);
 
@@ -593,7 +595,9 @@ describe('pharos-dropdown-menu', () => {
     component.open = true;
     await component.updateComplete;
 
-    const item = component.querySelector('pharos-dropdown-menu-item') as PharosDropdownMenuItem;
+    const item = component.querySelector(
+      'test-pharos-dropdown-menu-item'
+    ) as PharosDropdownMenuItem;
     item.click();
     await aTimeout(150);
 
@@ -610,7 +614,9 @@ describe('pharos-dropdown-menu', () => {
     component.open = true;
     await component.updateComplete;
 
-    const item = component.querySelector('pharos-dropdown-menu-item') as PharosDropdownMenuItem;
+    const item = component.querySelector(
+      'test-pharos-dropdown-menu-item'
+    ) as PharosDropdownMenuItem;
     item.click();
     await aTimeout(150);
 
@@ -678,7 +684,7 @@ describe('pharos-dropdown-menu', () => {
   });
 
   it('does not contain a focus trap when in a menu nav', async () => {
-    const parentNode = document.createElement('pharos-dropdown-menu-nav');
+    const parentNode = document.createElement('test-pharos-dropdown-menu-nav');
 
     component = await fixture(getNoItemDropdown(), {
       parentNode,
@@ -729,13 +735,13 @@ describe('pharos-dropdown-menu', () => {
   });
 
   it('updates the last item when a new item is added dynamically', async () => {
-    const item = document.createElement('pharos-dropdown-menu-item');
+    const item = document.createElement('test-pharos-dropdown-menu-item');
     item.textContent = 'I am a new item';
     component.appendChild(item);
     await component.updateComplete;
 
     const items = Array.prototype.slice.call(
-      component.querySelectorAll('pharos-dropdown-menu-item')
+      component.querySelectorAll('test-pharos-dropdown-menu-item')
     ) as PharosDropdownMenuItem[];
     const lastItem = items[items.length - 1];
 

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.wc.stories.jsx
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.wc.stories.jsx
@@ -20,14 +20,17 @@ export const Base = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button id="my-button" data-dropdown-menu-id="my-menu" icon-right="chevron-down"
-          >Click Me</pharos-button
+        <storybook-pharos-button
+          id="my-button"
+          data-dropdown-menu-id="my-menu"
+          icon-right="chevron-down"
+          >Click Me</storybook-pharos-button
         >
-        <pharos-dropdown-menu id="my-menu">
-          <pharos-dropdown-menu-item>Menu item 1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Menu item 2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Menu item 3</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
+        <storybook-pharos-dropdown-menu id="my-menu">
+          <storybook-pharos-dropdown-menu-item>Menu item 1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Menu item 2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Menu item 3</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
       </div>
     `,
   args: defaultArgs,
@@ -37,23 +40,23 @@ export const Events = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button
+        <storybook-pharos-button
           id="my-button-events"
           data-dropdown-menu-id="my-menu-events"
           icon-right="chevron-down"
         >
           Click Me
-        </pharos-button>
-        <pharos-dropdown-menu
+        </storybook-pharos-button>
+        <storybook-pharos-dropdown-menu
           id="my-menu-events"
           show-selected
           @pharos-dropdown-menu-select="${(e) => action('Select')(e.detail)}"
           @pharos-dropdown-menu-selected="${(e) => action('Selected')(e.detail)}"
         >
-          <pharos-dropdown-menu-item>Menu item 1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Menu item 2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Menu item 3</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
+          <storybook-pharos-dropdown-menu-item>Menu item 1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Menu item 2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Menu item 3</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
       </div>
     `,
   parameters: { options: { selectedPanel: 'addon-actions' } },
@@ -71,18 +74,24 @@ export const Icons = {
     effect();
     return html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button
+        <storybook-pharos-button
           id="my-button-icons"
           data-dropdown-menu-id="my-menu-icons"
           icon-right="chevron-down"
         >
           With icons
-        </pharos-button>
-        <pharos-dropdown-menu id="my-menu-icons" show-selected>
-          <pharos-dropdown-menu-item icon="view-gallery">Item one</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item icon="view-list" selected>Item two</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item icon="image">Item three</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
+        </storybook-pharos-button>
+        <storybook-pharos-dropdown-menu id="my-menu-icons" show-selected>
+          <storybook-pharos-dropdown-menu-item icon="view-gallery"
+            >Item one</storybook-pharos-dropdown-menu-item
+          >
+          <storybook-pharos-dropdown-menu-item icon="view-list" selected
+            >Item two</storybook-pharos-dropdown-menu-item
+          >
+          <storybook-pharos-dropdown-menu-item icon="image"
+            >Item three</storybook-pharos-dropdown-menu-item
+          >
+        </storybook-pharos-dropdown-menu>
       </div>
     `;
   },
@@ -100,35 +109,35 @@ export const Descriptions = {
     effect();
     return html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button
+        <storybook-pharos-button
           id="my-button-descriptions"
           data-dropdown-menu-id="my-menu-descriptions"
           icon-right="chevron-down"
         >
           With descriptions
-        </pharos-button>
-        <pharos-dropdown-menu id="my-menu-descriptions" show-selected>
-          <pharos-dropdown-menu-item selected>
+        </storybook-pharos-button>
+        <storybook-pharos-dropdown-menu id="my-menu-descriptions" show-selected>
+          <storybook-pharos-dropdown-menu-item selected>
             Item 1
             <span slot="description">Description for item 1</span>
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>
             Item 2
             <span slot="description">Description for item 2</span>
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>
             Item 3
             <span slot="description">Description for item 3</span>
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>
             Item 4
             <span slot="description">Description for item 4</span>
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item disabled>
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item disabled>
             Disabled
             <span slot="description">This item has been disabled</span>
-          </pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
+          </storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
       </div>
     `;
   },
@@ -146,24 +155,24 @@ export const FullWidth = {
     effect();
     return html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button
+        <storybook-pharos-button
           id="my-button-full"
           data-dropdown-menu-id="my-menu-full"
           icon-right="chevron-down"
         >
           With attribute full-width to match the width of the trigger
-        </pharos-button>
-        <pharos-dropdown-menu id="my-menu-full" full-width>
-          <pharos-dropdown-menu-item>
+        </storybook-pharos-button>
+        <storybook-pharos-dropdown-menu id="my-menu-full" full-width>
+          <storybook-pharos-dropdown-menu-item>
             Use full-width to display lengthy text
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>
             <span style="white-space: normal">
               Even if longer text is placed in the item, it will span multiple lines to keep the
               width of the item the same size as the trigger
             </span>
-          </pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
+          </storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
       </div>
     `;
   },
@@ -181,7 +190,7 @@ export const Links = {
     effect();
     return html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-link
+        <storybook-pharos-link
           id="my-link"
           href="https://www.google.com/"
           target="_blank"
@@ -189,24 +198,24 @@ export const Links = {
           data-dropdown-menu-hover
         >
           With links
-        </pharos-link>
-        <pharos-dropdown-menu id="my-menu-links">
-          <pharos-dropdown-menu-item
+        </storybook-pharos-link>
+        <storybook-pharos-dropdown-menu id="my-menu-links">
+          <storybook-pharos-dropdown-menu-item
             link="https://www.youtube.com/watch?v=gkTb9GP9lVI"
             target="_blank"
-            >Menu item 1</pharos-dropdown-menu-item
+            >Menu item 1</storybook-pharos-dropdown-menu-item
           >
-          <pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu-item
             link="https://www.youtube.com/watch?v=ZXsQAXx_ao0"
             target="_blank"
-            >Menu item 2</pharos-dropdown-menu-item
+            >Menu item 2</storybook-pharos-dropdown-menu-item
           >
-          <pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu-item
             link="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
             target="_blank"
-            >Menu item 3</pharos-dropdown-menu-item
+            >Menu item 3</storybook-pharos-dropdown-menu-item
           >
-        </pharos-dropdown-menu>
+        </storybook-pharos-dropdown-menu>
       </div>
     `;
   },
@@ -218,26 +227,26 @@ export const MultipleTriggers = {
       <div
         style="display: grid; grid-template-columns: repeat(3, auto); grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;"
       >
-        <pharos-button data-dropdown-menu-id="my-menu-multiple" icon-right="chevron-down">
+        <storybook-pharos-button data-dropdown-menu-id="my-menu-multiple" icon-right="chevron-down">
           Click Me
-        </pharos-button>
-        <pharos-dropdown-menu id="my-menu-multiple">
-          <pharos-dropdown-menu-item>Item 1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 3</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 4</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 5</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-button
+        </storybook-pharos-button>
+        <storybook-pharos-dropdown-menu id="my-menu-multiple">
+          <storybook-pharos-dropdown-menu-item>Item 1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 3</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 4</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 5</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+        <storybook-pharos-button
           data-dropdown-menu-id="my-menu-multiple"
           data-dropdown-menu-hover
           icon-right="chevron-down"
         >
           Hover here
-        </pharos-button>
-        <pharos-button data-dropdown-menu-id="my-menu-multiple" icon-right="chevron-down">
+        </storybook-pharos-button>
+        <storybook-pharos-button data-dropdown-menu-id="my-menu-multiple" icon-right="chevron-down">
           Click Me Too
-        </pharos-button>
+        </storybook-pharos-button>
       </div>
     `,
 };
@@ -248,12 +257,12 @@ export const MultipleDynamicTriggers = {
       <div
         style="display: grid; grid-template-columns: repeat(3, auto); grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;"
       >
-        <pharos-dropdown-menu id="my-menu-multiple-dynamic-triggers">
-          <pharos-dropdown-menu-item>Item 1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 3</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-button
+        <storybook-pharos-dropdown-menu id="my-menu-multiple-dynamic-triggers">
+          <storybook-pharos-dropdown-menu-item>Item 1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 3</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+        <storybook-pharos-button
           @click="${(e) => {
             const trigger = e.target;
             const menu = document.querySelector('#my-menu-multiple-dynamic-triggers');
@@ -261,8 +270,8 @@ export const MultipleDynamicTriggers = {
           }}"
         >
           One
-        </pharos-button>
-        <pharos-button
+        </storybook-pharos-button>
+        <storybook-pharos-button
           @click="${(e) => {
             const trigger = e.target;
             const menu = document.querySelector('#my-menu-multiple-dynamic-triggers');
@@ -270,8 +279,8 @@ export const MultipleDynamicTriggers = {
           }}"
         >
           Two
-        </pharos-button>
-        <pharos-button
+        </storybook-pharos-button>
+        <storybook-pharos-button
           @click="${(e) => {
             const trigger = e.target;
             const menu = document.querySelector('#my-menu-multiple-dynamic-triggers');
@@ -279,7 +288,7 @@ export const MultipleDynamicTriggers = {
           }}"
         >
           Three
-        </pharos-button>
+        </storybook-pharos-button>
       </div>
     `,
 };
@@ -296,26 +305,29 @@ export const Composition = {
     effect();
     return html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button
+        <storybook-pharos-button
           id="my-button-composition"
           data-dropdown-menu-id="my-menu-composition"
           icon-right="chevron-down"
         >
           Save
-        </pharos-button>
-        <pharos-dropdown-menu id="my-menu-composition">
+        </storybook-pharos-button>
+        <storybook-pharos-dropdown-menu id="my-menu-composition">
           <div
             style="padding: 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--pharos-dropdown-menu-item-color-border-base)"
           >
-            <pharos-heading level="1" preset="2">Save to...</pharos-heading>
+            <storybook-pharos-heading level="1" preset="2">Save to...</storybook-pharos-heading>
           </div>
-          <pharos-dropdown-menu-item>Workspace</pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Workspace</storybook-pharos-dropdown-menu-item>
           <div style="margin: 0.5rem 1rem; display: flex; flex-grow: 1; flex-direction: column;">
-            <pharos-text-input hide-label placeholder="New folder name" style="margin: 0.5rem 0"
-              ><span slot="label">My label is hidden</span></pharos-text-input
+            <storybook-pharos-text-input
+              hide-label
+              placeholder="New folder name"
+              style="margin: 0.5rem 0"
+              ><span slot="label">My label is hidden</span></storybook-pharos-text-input
             >
             <div style="display: flex; align-items: center;">
-              <pharos-button
+              <storybook-pharos-button
                 type="button"
                 style="margin-right: auto"
                 @click="${() => {
@@ -324,8 +336,8 @@ export const Composition = {
                 }}"
               >
                 Create
-              </pharos-button>
-              <pharos-button
+              </storybook-pharos-button>
+              <storybook-pharos-button
                 type="button"
                 variant="secondary"
                 style="margin-left: auto"
@@ -335,10 +347,10 @@ export const Composition = {
                 }}"
               >
                 Cancel
-              </pharos-button>
+              </storybook-pharos-button>
             </div>
           </div>
-        </pharos-dropdown-menu>
+        </storybook-pharos-dropdown-menu>
       </div>
     `;
   },
@@ -348,13 +360,13 @@ export const CoordinatingDropdowns = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button
+        <storybook-pharos-button
           id="coordinating-dropdown-trigger-button"
           data-dropdown-menu-id="first-dropdown"
         >
           Click Me
-        </pharos-button>
-        <pharos-dropdown-menu
+        </storybook-pharos-button>
+        <storybook-pharos-dropdown-menu
           id="first-dropdown"
           @pharos-dropdown-menu-selected="${() => {
             const triggerElement = document.querySelector('#coordinating-dropdown-trigger-button');
@@ -362,21 +374,21 @@ export const CoordinatingDropdowns = {
             secondDropdown.openWithTrigger(triggerElement);
           }}"
         >
-          <pharos-dropdown-menu-item>Click</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>any of these</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>options</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-dropdown-menu
+          <storybook-pharos-dropdown-menu-item>Click</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>any of these</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>options</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+        <storybook-pharos-dropdown-menu
           id="second-dropdown"
           @pharos-dropdown-menu-closed="${() => {
             const secondDropdown = document.querySelector('#second-dropdown');
             secondDropdown.removeAllTriggers();
           }}"
         >
-          <pharos-dropdown-menu-item>I am</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>a new</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>dropdown!</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
+          <storybook-pharos-dropdown-menu-item>I am</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>a new</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>dropdown!</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
       </div>
     `,
 };

--- a/packages/pharos/src/components/footer/PharosFooter.react.stories.jsx
+++ b/packages/pharos/src/components/footer/PharosFooter.react.stories.jsx
@@ -1,10 +1,18 @@
 import { Footer } from '../../pages/shared/react/Footer';
 import { PharosFooter } from '../../../lib/react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Organisms/Footer',
   component: PharosFooter,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('footer') },
     layout: 'fullscreen',

--- a/packages/pharos/src/components/footer/pharos-footer.test.ts
+++ b/packages/pharos/src/components/footer/pharos-footer.test.ts
@@ -8,222 +8,230 @@ describe('pharos-footer', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-footer>
+      <test-pharos-footer>
         <ul slot="links-group">
           <li>
-            <pharos-link on-background subtle href="/subjects" target="_blank"
-              >By Subject</pharos-link
+            <test-pharos-link on-background subtle href="/subjects" target="_blank"
+              >By Subject</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="/action/showJournals?browseType=title"
               target="_blank"
-              >By Title</pharos-link
+              >By Title</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="/site/collection-list" target="_blank"
-              >By Collections</pharos-link
+            <test-pharos-link on-background subtle href="/site/collection-list" target="_blank"
+              >By Collections</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="/publishers" target="_blank"
-              >By Publisher</pharos-link
+            <test-pharos-link on-background subtle href="/publishers" target="_blank"
+              >By Publisher</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="/action/showAdvancedSearch" target="_blank"
-              >Advanced Search</pharos-link
+            <test-pharos-link on-background subtle href="/action/showAdvancedSearch" target="_blank"
+              >Advanced Search</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="/dfr" target="_blank"
-              >Data for Research</pharos-link
+            <test-pharos-link on-background subtle href="/dfr" target="_blank"
+              >Data for Research</test-pharos-link
             >
           </li>
         </ul>
         <ul slot="links-group">
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://support.jstor.org/hc/en-us/articles/360000313328-Need-Help-Logging-in-To-JSTOR"
               target="_blank"
-              >Get Access</pharos-link
+              >Get Access</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="https://support.jstor.org" target="_blank"
-              >Support</pharos-link
+            <test-pharos-link on-background subtle href="https://support.jstor.org" target="_blank"
+              >Support</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="https://guides.jstor.org" target="_blank"
-              >LibGuides</pharos-link
+            <test-pharos-link on-background subtle href="https://guides.jstor.org" target="_blank"
+              >LibGuides</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://guides.jstor.org/researchbasics"
               target="_blank"
-              >Research Basics</pharos-link
+              >Research Basics</test-pharos-link
             >
           </li>
         </ul>
         <ul slot="links-group">
           <li>
-            <pharos-link on-background subtle href="https://about.jstor.org" target="_blank"
-              >About JSTOR</pharos-link
+            <test-pharos-link on-background subtle href="https://about.jstor.org" target="_blank"
+              >About JSTOR</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://about.jstor.org/mission-history/"
               target="_blank"
-              >Mission and History</pharos-link
+              >Mission and History</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://about.jstor.org/whats-in-jstor/"
               target="_blank"
-              >What's in JSTOR</pharos-link
+              >What's in JSTOR</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://about.jstor.org/get-jstor/"
               target="_blank"
-              >Get JSTOR</pharos-link
+              >Get JSTOR</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="https://about.jstor.org/news/" target="_blank"
-              >News</pharos-link
+            <test-pharos-link
+              on-background
+              subtle
+              href="https://about.jstor.org/news/"
+              target="_blank"
+              >News</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://about.jstor.org/webinars/"
               target="_blank"
-              >Webinars</pharos-link
+              >Webinars</test-pharos-link
             >
           </li>
         </ul>
         <ul slot="links-group">
           <li>
-            <pharos-link on-background subtle href="https://labs.jstor.org/" target="_blank"
-              >JSTOR Labs</pharos-link
+            <test-pharos-link on-background subtle href="https://labs.jstor.org/" target="_blank"
+              >JSTOR Labs</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="https://daily.jstor.org/" target="_blank"
-              >JSTOR Daily</pharos-link
+            <test-pharos-link on-background subtle href="https://daily.jstor.org/" target="_blank"
+              >JSTOR Daily</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="https://www.ithaka.org/careers/" target="_blank"
-              >Careers</pharos-link
+            <test-pharos-link
+              on-background
+              subtle
+              href="https://www.ithaka.org/careers/"
+              target="_blank"
+              >Careers</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="/contact-us/" target="_blank"
-              >Contact Us</pharos-link
+            <test-pharos-link on-background subtle href="/contact-us/" target="_blank"
+              >Contact Us</test-pharos-link
             >
           </li>
         </ul>
         <ul slot="button-links">
           <li>
-            <pharos-button
+            <test-pharos-button
               variant="secondary"
               on-background
               href="https://about.jstor.org/librarians/"
               target="_blank"
-              >For Librarians</pharos-button
+              >For Librarians</test-pharos-button
             >
           </li>
           <li>
-            <pharos-button
+            <test-pharos-button
               variant="secondary"
               on-background
               href="https://about.jstor.org/publishers/"
               target="_blank"
-              >For Publishers</pharos-button
+              >For Publishers</test-pharos-button
             >
           </li>
         </ul>
         <ul slot="social-links">
           <li>
-            <pharos-link
+            <test-pharos-link
               href="https://twitter.com/JSTOR"
               target="_blank"
               label="twitter - This link opens in a new window"
             >
-              <pharos-icon name="twitter"></pharos-icon>
-            </pharos-link>
+              <test-pharos-icon name="twitter"></test-pharos-icon>
+            </test-pharos-link>
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               href="https://www.facebook.com/JSTOR.org"
               target="_blank"
               label="facebook - This link opens in a new window"
             >
-              <pharos-icon name="facebook"></pharos-icon>
-            </pharos-link>
+              <test-pharos-icon name="facebook"></test-pharos-icon>
+            </test-pharos-link>
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               href="https://www.instagram.com/jstor_org"
               target="_blank"
               label="instagram - This link opens in a new window"
             >
-              <pharos-icon name="instagram"></pharos-icon>
-            </pharos-link>
+              <test-pharos-icon name="instagram"></test-pharos-icon>
+            </test-pharos-link>
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               href="https://www.youtube.com/channel/UCQM-7sUBV6Z-PVas0S4k0lw"
               target="_blank"
               label="youtube - This link opens in a new window"
             >
-              <pharos-icon name="youtube"></pharos-icon>
-            </pharos-link>
+              <test-pharos-icon name="youtube"></test-pharos-icon>
+            </test-pharos-link>
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               href="https://www.linkedin.com/company/ithaka"
               target="_blank"
               label="linkedin - This link opens in a new window"
             >
-              <pharos-icon name="linkedin"></pharos-icon>
-            </pharos-link>
+              <test-pharos-icon name="linkedin"></test-pharos-icon>
+            </test-pharos-link>
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               href="https://jstor.tumblr.com"
               target="_blank"
               label="tumblr - This link opens in a new window"
             >
-              <pharos-icon name="tumblr"></pharos-icon>
-            </pharos-link>
+              <test-pharos-icon name="tumblr"></test-pharos-icon>
+            </test-pharos-link>
           </li>
         </ul>
         <span slot="mission-statement"
           >JSTOR is part of
-          <pharos-link on-background href="https://www.ithaka.org">ITHAKA</pharos-link>, a
+          <test-pharos-link on-background href="https://www.ithaka.org">ITHAKA</test-pharos-link>, a
           not-for-profit organization helping the academic community use digital technologies to
           preserve the scholarly record and to advance research and teaching in sustainable
           ways.</span
@@ -235,36 +243,44 @@ describe('pharos-footer', () => {
         >
         <ul slot="legal-links">
           <li>
-            <pharos-link on-background subtle href="https://about.jstor.org/terms" target="_blank"
-              >Terms & Conditions of Use</pharos-link
+            <test-pharos-link
+              on-background
+              subtle
+              href="https://about.jstor.org/terms"
+              target="_blank"
+              >Terms & Conditions of Use</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://www.ithaka.org/privacypolicy"
               target="_blank"
-              >Privacy Policy</pharos-link
+              >Privacy Policy</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link on-background subtle href="https://www.ithaka.org/cookies" target="_blank"
-              >Cookie Policy</pharos-link
+            <test-pharos-link
+              on-background
+              subtle
+              href="https://www.ithaka.org/cookies"
+              target="_blank"
+              >Cookie Policy</test-pharos-link
             >
           </li>
           <li>
-            <pharos-link
+            <test-pharos-link
               on-background
               subtle
               href="https://about.jstor.org/accessibility"
               target="_blank"
-              >Accessibility</pharos-link
+              >Accessibility</test-pharos-link
             >
           </li>
         </ul>
         <div slot="google-widget" id="google_translate_element" aria-hidden="true"></div>
-      </pharos-footer>
+      </test-pharos-footer>
     `);
   });
 
@@ -288,7 +304,7 @@ describe('pharos-footer', () => {
     await component.updateComplete;
     await nextFrame();
 
-    expect(translateButton.querySelector('pharos-icon[name="google"]')).not.to.be.null;
-    expect(translateButton.querySelector('pharos-icon[name="chevron-down"]')).not.to.be.null;
+    expect(translateButton.querySelector('test-pharos-icon[name="google"]')).not.to.be.null;
+    expect(translateButton.querySelector('test-pharos-icon[name="chevron-down"]')).not.to.be.null;
   });
 });

--- a/packages/pharos/src/components/header/PharosHeader.react.stories.jsx
+++ b/packages/pharos/src/components/header/PharosHeader.react.stories.jsx
@@ -10,10 +10,18 @@ import {
   PharosIcon,
 } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Organisms/Header',
   component: PharosHeader,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('haeder') },
     layout: 'fullscreen',

--- a/packages/pharos/src/components/header/pharos-header.test.ts
+++ b/packages/pharos/src/components/header/pharos-header.test.ts
@@ -8,62 +8,72 @@ describe('pharos-header', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-header>
-        <pharos-link slot="start" href="/" id="jstor-logo">
+      <test-pharos-header>
+        <test-pharos-link slot="start" href="/" id="jstor-logo">
           <img alt="JSTOR Home" width="65" height="90" />
-        </pharos-link>
+        </test-pharos-link>
         <div slot="center">
-          <pharos-dropdown-menu-nav label="main navigation">
-            <pharos-dropdown-menu-nav-link href="/action/showAdvancedSearch" id="adv-search-link"
-              >Advanced Search</pharos-dropdown-menu-nav-link
+          <test-pharos-dropdown-menu-nav label="main navigation">
+            <test-pharos-dropdown-menu-nav-link
+              href="/action/showAdvancedSearch"
+              id="adv-search-link"
+              >Advanced Search</test-pharos-dropdown-menu-nav-link
             >
-            <pharos-dropdown-menu-nav-link
+            <test-pharos-dropdown-menu-nav-link
               href="/subjects"
               id="browse-link"
               data-dropdown-menu-id="browse-menu"
               data-dropdown-menu-hover
-              >Browse</pharos-dropdown-menu-nav-link
+              >Browse</test-pharos-dropdown-menu-nav-link
             >
-            <pharos-dropdown-menu id="browse-menu">
-              <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
-              <pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
-                >by Title</pharos-dropdown-menu-item
+            <test-pharos-dropdown-menu id="browse-menu">
+              <test-pharos-dropdown-menu-item link="/subjects"
+                >by Subject</test-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/site/collection-list"
-                >by Collections</pharos-dropdown-menu-item
+              <test-pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
+                >by Title</test-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/publishers">by Publisher</pharos-dropdown-menu-item>
-            </pharos-dropdown-menu>
-            <pharos-dropdown-menu-nav-link
+              <test-pharos-dropdown-menu-item link="/site/collection-list"
+                >by Collections</test-pharos-dropdown-menu-item
+              >
+              <test-pharos-dropdown-menu-item link="/publishers"
+                >by Publisher</test-pharos-dropdown-menu-item
+              >
+            </test-pharos-dropdown-menu>
+            <test-pharos-dropdown-menu-nav-link
               href="/account/workspace"
               id="tools-link"
               data-dropdown-menu-id="tools-menu"
               data-dropdown-menu-hover
-              >Tools</pharos-dropdown-menu-nav-link
+              >Tools</test-pharos-dropdown-menu-nav-link
             >
-            <pharos-dropdown-menu id="tools-menu">
-              <pharos-dropdown-menu-item link="/account/workspace"
-                >Workspace</pharos-dropdown-menu-item
+            <test-pharos-dropdown-menu id="tools-menu">
+              <test-pharos-dropdown-menu-item link="/account/workspace"
+                >Workspace</test-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/analyze">Text Analyzer</pharos-dropdown-menu-item>
-              <pharos-dropdown-menu-item link="/understand"
-                >The JSTOR Understanding Series</pharos-dropdown-menu-item
+              <test-pharos-dropdown-menu-item link="/analyze"
+                >Text Analyzer</test-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/dfr">Data for Research</pharos-dropdown-menu-item>
-            </pharos-dropdown-menu>
-          </pharos-dropdown-menu-nav>
+              <test-pharos-dropdown-menu-item link="/understand"
+                >The JSTOR Understanding Series</test-pharos-dropdown-menu-item
+              >
+              <test-pharos-dropdown-menu-item link="/dfr"
+                >Data for Research</test-pharos-dropdown-menu-item
+              >
+            </test-pharos-dropdown-menu>
+          </test-pharos-dropdown-menu-nav>
         </div>
         <div slot="end" style="display: grid; grid-template-rows: 1fr 1fr; row-gap: 1.5rem">
           <div style="display: grid; grid-template-columns: 1fr 1fr; column-gap: 0.5rem">
-            <pharos-link href="#" target="_blank">Log In</pharos-link>
-            <pharos-link href="#" target="_blank">Register</pharos-link>
+            <test-pharos-link href="#" target="_blank">Log In</test-pharos-link>
+            <test-pharos-link href="#" target="_blank">Register</test-pharos-link>
           </div>
           <div style="display: grid; grid-template-columns: 1fr 1fr; column-gap: 0.5rem">
-            <pharos-link href="//about.jstor.org" target="_blank">About</pharos-link>
-            <pharos-link href="//support.jstor.org" target="_blank">Support</pharos-link>
+            <test-pharos-link href="//about.jstor.org" target="_blank">About</test-pharos-link>
+            <test-pharos-link href="//support.jstor.org" target="_blank">Support</test-pharos-link>
           </div>
         </div>
-      </pharos-header>
+      </test-pharos-header>
     `);
   });
 

--- a/packages/pharos/src/components/header/pharos-header.wc.stories.jsx
+++ b/packages/pharos/src/components/header/pharos-header.wc.stories.jsx
@@ -14,8 +14,8 @@ export default {
 export const Base = {
   render: () => {
     const accountNav = (section) => html`
-      <pharos-dropdown-menu-nav label="profile">
-        <pharos-dropdown-menu-nav-link
+      <storybook-pharos-dropdown-menu-nav label="profile">
+        <storybook-pharos-dropdown-menu-nav-link
           href="/account/profile"
           id="profile-link-${section}"
           data-dropdown-menu-id="profile-menu-${section}"
@@ -23,32 +23,40 @@ export const Base = {
           ><span class="hide-for-small">human@ithaka.org</span
           ><span class="show-for-small" style="display: none"
             >Account</span
-          ></pharos-dropdown-menu-nav-link
+          ></storybook-pharos-dropdown-menu-nav-link
         >
-        <pharos-dropdown-menu id="profile-menu-${section}">
-          <pharos-dropdown-menu-item link="/account/profile" id="profile-link-${section}"
-            >Profile</pharos-dropdown-menu-item
+        <storybook-pharos-dropdown-menu id="profile-menu-${section}">
+          <storybook-pharos-dropdown-menu-item link="/account/profile" id="profile-link-${section}"
+            >Profile</storybook-pharos-dropdown-menu-item
           >
-          <pharos-dropdown-menu-item link="/account/workspace" id="workspace-link-${section}"
-            >Workspace</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu-item
+            link="/account/workspace"
+            id="workspace-link-${section}"
+            >Workspace</storybook-pharos-dropdown-menu-item
           >
-          <pharos-dropdown-menu-item link="/account/read-online" id="article-link-${section}"
-            >Free Article Views</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu-item
+            link="/account/read-online"
+            id="article-link-${section}"
+            >Free Article Views</storybook-pharos-dropdown-menu-item
           >
-          <pharos-dropdown-menu-item link="/account/subscriptions" id="jpass-link-${section}"
-            >JPASS Downloads</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu-item
+            link="/account/subscriptions"
+            id="jpass-link-${section}"
+            >JPASS Downloads</storybook-pharos-dropdown-menu-item
           >
-          <pharos-dropdown-menu-item link="/account/purchases" id="purchase-link-${section}"
-            >Purchase History</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu-item
+            link="/account/purchases"
+            id="purchase-link-${section}"
+            >Purchase History</storybook-pharos-dropdown-menu-item
           >
-          <pharos-dropdown-menu-item link="/action/doLogout" id="logout-link-${section}"
-            >Logout</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu-item link="/action/doLogout" id="logout-link-${section}"
+            >Logout</storybook-pharos-dropdown-menu-item
           >
-        </pharos-dropdown-menu>
-      </pharos-dropdown-menu-nav>
+        </storybook-pharos-dropdown-menu>
+      </storybook-pharos-dropdown-menu-nav>
     `;
     return html`
-      <pharos-header>
+      <storybook-pharos-header>
         <div id="pds" slot="top" class="hide-for-small">
           <div
             tabindex="0"
@@ -58,93 +66,93 @@ export const Base = {
           >
             <span>Access provided by&nbsp;</span>
             <span style="font-weight: bold">JSTOR</span>
-            <pharos-icon name="chevron-down" style="margin-left: 1rem"></pharos-icon>
+            <storybook-pharos-icon name="chevron-down" style="margin-left: 1rem"></storybook-pharos-icon>
           </div>
-          <pharos-dropdown-menu id="pds-menu" placement="bottom">
+          <storybook-pharos-dropdown-menu id="pds-menu" placement="bottom">
             <div style="padding: 1rem">
               <p>
                 Please contact
-                <pharos-link href="//jstor.org">JSTOR</pharos-link> for additional help and
+                <storybook-pharos-link href="//jstor.org">JSTOR</storybook-pharos-link> for additional help and
                 information.
               </p>
             </div>
-          </pharos-dropdown-menu>
+          </storybook-pharos-dropdown-menu>
         </div>
         <span slot="top" class="show-for-small" style="display: none; font-weight: bold"
           >JSTOR</span
         >
-        <pharos-link slot="start" href="/" id="jstor-logo">
+        <storybook-pharos-link slot="start" href="/" id="jstor-logo">
           <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
-        </pharos-link>
+        </storybook-pharos-link>
         <div slot="center">
-          <pharos-input-group
+          <storybook-pharos-input-group
             name="my-input-group"
             hide-label
             placeholder="Search JSTOR"
             class="header-example__input-group"
           >
             <span slot="label">Search JSTOR</span>
-            <pharos-button
+            <storybook-pharos-button
               name="search-button"
               icon="search"
               variant="subtle"
               label="search"
-            ></pharos-button>
-          </pharos-input-group>
+            ></storybook-pharos-button>
+          </storybook-pharos-input-group>
         </div>
         <div slot="end-top"">
           <div>${accountNav('end')}</div>
         </div>
         <div slot="end-bottom" style="display: flex;">
-          <pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
-            <pharos-dropdown-menu-nav-link
+          <storybook-pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
+            <storybook-pharos-dropdown-menu-nav-link
               href="action/showAdvancedSearch"
               id="adv-search-link"
-              >Advanced Search</pharos-dropdown-menu-nav-link
+              >Advanced Search</storybook-pharos-dropdown-menu-nav-link
             >
-            <pharos-dropdown-menu-nav-link
+            <storybook-pharos-dropdown-menu-nav-link
               href="/subjects"
               id="browse-link"
               data-dropdown-menu-id="browse-menu"
               data-dropdown-menu-hover
-              >Browse</pharos-dropdown-menu-nav-link
+              >Browse</storybook-pharos-dropdown-menu-nav-link
             >
-            <pharos-dropdown-menu id="browse-menu">
-              <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
-              <pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
-                >by Title</pharos-dropdown-menu-item
+            <storybook-pharos-dropdown-menu id="browse-menu">
+              <storybook-pharos-dropdown-menu-item link="/subjects">by Subject</storybook-pharos-dropdown-menu-item>
+              <storybook-pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
+                >by Title</storybook-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/site/collection-list"
-                >by Collections</pharos-dropdown-menu-item
+              <storybook-pharos-dropdown-menu-item link="/site/collection-list"
+                >by Collections</storybook-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/publishers"
-                >by Publisher</pharos-dropdown-menu-item
+              <storybook-pharos-dropdown-menu-item link="/publishers"
+                >by Publisher</storybook-pharos-dropdown-menu-item
               >
-            </pharos-dropdown-menu>
-            <pharos-dropdown-menu-nav-link
+            </storybook-pharos-dropdown-menu>
+            <storybook-pharos-dropdown-menu-nav-link
               href="/account/workspace"
               id="tools-link"
               data-dropdown-menu-id="tools-menu"
               data-dropdown-menu-hover
-              >Tools</pharos-dropdown-menu-nav-link
+              >Tools</storybook-pharos-dropdown-menu-nav-link
             >
-            <pharos-dropdown-menu id="tools-menu">
-              <pharos-dropdown-menu-item link="/account/workspace"
-                >Workspace</pharos-dropdown-menu-item
+            <storybook-pharos-dropdown-menu id="tools-menu">
+              <storybook-pharos-dropdown-menu-item link="/account/workspace"
+                >Workspace</storybook-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/analyze"
-                >Text Analyzer</pharos-dropdown-menu-item
+              <storybook-pharos-dropdown-menu-item link="/analyze"
+                >Text Analyzer</storybook-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/understand"
-                >The JSTOR Understanding Series</pharos-dropdown-menu-item
+              <storybook-pharos-dropdown-menu-item link="/understand"
+                >The JSTOR Understanding Series</storybook-pharos-dropdown-menu-item
               >
-              <pharos-dropdown-menu-item link="/dfr"
-                >Data for Research</pharos-dropdown-menu-item
+              <storybook-pharos-dropdown-menu-item link="/dfr"
+                >Data for Research</storybook-pharos-dropdown-menu-item
               >
-            </pharos-dropdown-menu>
-          </pharos-dropdown-menu-nav>
+            </storybook-pharos-dropdown-menu>
+          </storybook-pharos-dropdown-menu-nav>
         </div>
-      </pharos-header>
+      </storybook-pharos-header>
     `;
   },
   parameters: { chromatic: { viewports: [320, 1200] } },

--- a/packages/pharos/src/components/heading/PharosHeading.react.stories.jsx
+++ b/packages/pharos/src/components/heading/PharosHeading.react.stories.jsx
@@ -2,10 +2,18 @@ import { PharosHeading, PharosCheckboxGroup, PharosCheckbox } from '../../react-
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
 import { allPresets } from './pharos-heading';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Heading',
   component: PharosHeading,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('heading') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/heading/pharos-heading.test.ts
+++ b/packages/pharos/src/components/heading/pharos-heading.test.ts
@@ -8,7 +8,7 @@ describe('pharos-heading', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html` <pharos-heading level="1"> This is a heading </pharos-heading> `
+      html` <test-pharos-heading level="1"> This is a heading </test-pharos-heading> `
     );
   });
 
@@ -18,16 +18,16 @@ describe('pharos-heading', () => {
 
   it('sets its default attributes', async () => {
     component = await fixture(
-      html` <pharos-heading level="1" preset="1"> This is a heading </pharos-heading> `
+      html` <test-pharos-heading level="1" preset="1"> This is a heading </test-pharos-heading> `
     );
     expect(component).dom.to.equal(
-      `<pharos-heading data-pharos-component="PharosHeading" level="1" preset="1">This is a heading</pharos-heading>`
+      `<test-pharos-heading data-pharos-component="PharosHeading" level="1" preset="1">This is a heading</test-pharos-heading>`
     );
   });
 
   it('renders the correct heading level', async () => {
     component = await fixture(html`
-      <pharos-heading level="2" preset="1"> This is a heading </pharos-heading>
+      <test-pharos-heading level="2" preset="1"> This is a heading </test-pharos-heading>
     `);
     expect(component).shadowDom.to.equal(`
       <h2 class="heading">
@@ -37,22 +37,22 @@ describe('pharos-heading', () => {
   });
 
   it('throws an error for a missing level value', async () => {
-    component = await fixture(html` <pharos-heading> This is a heading </pharos-heading> `).catch(
-      (e) => e
-    );
+    component = await fixture(
+      html` <test-pharos-heading> This is a heading </test-pharos-heading> `
+    ).catch((e) => e);
     expect('level is a required attribute.').to.be.thrown;
   });
 
   it('throws an error for an invalid level value', async () => {
     component = await fixture(html`
-      <pharos-heading level="7"> This is a heading </pharos-heading>
+      <test-pharos-heading level="7"> This is a heading </test-pharos-heading>
     `).catch((e) => e);
     expect('7 is not a valid heading level. Valid levels are: 1, 2, 3, 4, 5, 6').to.be.thrown;
   });
 
   it('throws an error for an invalid preset value', async () => {
     component = await fixture(html`
-      <pharos-heading level="1" preset="9"> This is a heading </pharos-heading>
+      <test-pharos-heading level="1" preset="9"> This is a heading </test-pharos-heading>
     `).catch((e) => e);
     expect(
       '9 is not a valid preset. Available presets are 1, 1--bold, 2, 2--bold, 3, 3--bold, 4, 4--bold, 5, 5--bold, 6, 6--bold, 7, 7--bold, legend.'

--- a/packages/pharos/src/components/heading/pharos-heading.wc.stories.jsx
+++ b/packages/pharos/src/components/heading/pharos-heading.wc.stories.jsx
@@ -17,9 +17,13 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-heading level=${args.level} preset=${args.preset} ?no-margin=${args.noMargin}>
+      <storybook-pharos-heading
+        level=${args.level}
+        preset=${args.preset}
+        ?no-margin=${args.noMargin}
+      >
         ${args.text}<br />second line
-      </pharos-heading>
+      </storybook-pharos-heading>
     `,
   args: defaultArgs,
   argTypes: {
@@ -49,13 +53,17 @@ export const Bold = {
 export const Legend = {
   render: (args) =>
     html`
-      <pharos-checkbox-group>
-        <pharos-heading slot="legend" level="${args.level}" preset="${args.preset}"
-          >${args.text}</pharos-heading
+      <storybook-pharos-checkbox-group>
+        <storybook-pharos-heading slot="legend" level="${args.level}" preset="${args.preset}"
+          >${args.text}</storybook-pharos-heading
         >
-        <pharos-checkbox value="1"><span slot="label">Checkbox 1</span></pharos-checkbox>
-        <pharos-checkbox value="2"><span slot="label">Checkbox 2</span></pharos-checkbox>
-      </pharos-checkbox-group>
+        <storybook-pharos-checkbox value="1"
+          ><span slot="label">Checkbox 1</span></storybook-pharos-checkbox
+        >
+        <storybook-pharos-checkbox value="2"
+          ><span slot="label">Checkbox 2</span></storybook-pharos-checkbox
+        >
+      </storybook-pharos-checkbox-group>
     `,
   args: {
     ...Base.args,

--- a/packages/pharos/src/components/icon/PharosIcon.react.stories.jsx
+++ b/packages/pharos/src/components/icon/PharosIcon.react.stories.jsx
@@ -2,10 +2,18 @@ import { PharosIcon } from '../../react-components';
 import { iconNames } from '../../utils/iconNames';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Icon',
   component: PharosIcon,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('icon') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/icon/pharos-icon.test.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.test.ts
@@ -18,7 +18,7 @@ describe('pharos-icon', () => {
     component = await fixture(html` <test-pharos-icon name="fake"></test-pharos-icon> `).catch(
       (e) => e
     );
-    expect('No icon named "fake"').to.be.thrown;
+    expect('Could not get icon named "fake"').to.be.thrown;
   });
 
   it('uses dimensions 24x24 when the icon name does not end in "-small"', async () => {

--- a/packages/pharos/src/components/icon/pharos-icon.test.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.test.ts
@@ -7,7 +7,7 @@ describe('pharos-icon', () => {
   let component: PharosIcon;
 
   beforeEach(async () => {
-    component = await fixture(html`<pharos-icon name="base"></pharos-icon>`);
+    component = await fixture(html`<test-pharos-icon name="base"></test-pharos-icon>`);
   });
 
   it('is accessible', async () => {
@@ -15,7 +15,9 @@ describe('pharos-icon', () => {
   });
 
   it('throws an error for an invalid icon name', async () => {
-    component = await fixture(html` <pharos-icon name="fake"></pharos-icon> `).catch((e) => e);
+    component = await fixture(html` <test-pharos-icon name="fake"></test-pharos-icon> `).catch(
+      (e) => e
+    );
     expect('No icon named "fake"').to.be.thrown;
   });
 

--- a/packages/pharos/src/components/icon/pharos-icon.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.ts
@@ -44,7 +44,7 @@ export class PharosIcon extends PharosElement {
   protected override async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('name')) {
       try {
-        const icon = await import(/* webpackMode: "lazy" */ `../../styles/icons/${this.name}`);
+        const icon = await import(`../../styles/icons/${this.name}`);
         this._svg = atob(icon.default);
       } catch (e) {
         console.log(e);

--- a/packages/pharos/src/components/icon/pharos-icon.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.ts
@@ -47,7 +47,8 @@ export class PharosIcon extends PharosElement {
         const icon = await import(`../../styles/icons/${this.name}`);
         this._svg = atob(icon.default);
       } catch (e) {
-        throw new Error(`No icon named "${this.name}"`);
+        console.log(e);
+        throw new Error(`Could not get icon named "${this.name}"`);
       }
     }
   }

--- a/packages/pharos/src/components/icon/pharos-icon.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.ts
@@ -44,7 +44,7 @@ export class PharosIcon extends PharosElement {
   protected override async updated(changedProperties: PropertyValues): Promise<void> {
     if (changedProperties.has('name')) {
       try {
-        const icon = await import(`../../styles/icons/${this.name}`);
+        const icon = await import(/* webpackMode: "lazy" */ `../../styles/icons/${this.name}`);
         this._svg = atob(icon.default);
       } catch (e) {
         console.log(e);

--- a/packages/pharos/src/components/icon/pharos-icon.wc.stories.jsx
+++ b/packages/pharos/src/components/icon/pharos-icon.wc.stories.jsx
@@ -16,7 +16,9 @@ export default {
 
 export const Base = {
   render: (args) =>
-    html` <pharos-icon name=${args.name} class="icon-example__icon"></pharos-icon> `,
+    html`
+      <storybook-pharos-icon name=${args.name} class="icon-example__icon"></storybook-pharos-icon>
+    `,
   args: defaultArgs,
 };
 
@@ -28,7 +30,10 @@ export const Names = {
       >
         ${iconNames.map((name) => {
           return html` <div class="icon-example__container">
-            <pharos-icon name="${name}" class="icon-example__icon"></pharos-icon>
+            <storybook-pharos-icon
+              name="${name}"
+              class="icon-example__icon"
+            ></storybook-pharos-icon>
             <div class="icon-example__name">${name}</div>
           </div>`;
         })}

--- a/packages/pharos/src/components/image-card/PharosImageCard.react.stories.jsx
+++ b/packages/pharos/src/components/image-card/PharosImageCard.react.stories.jsx
@@ -13,10 +13,18 @@ import {
 import { items, collections } from '../../pages/item-detail/mocks';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Image Card',
   component: PharosImageCard,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('image-card') },
     viewport: viewports,

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -10,7 +10,7 @@ describe('pharos-image-card', () => {
   let component: PharosImageCard;
 
   beforeEach(async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       title="Card Title"
       link="#"
       image-link-label="Label for card image link"
@@ -22,8 +22,10 @@ describe('pharos-image-card', () => {
       />
       <div slot="metadata">Creator of the item</div>
       <div slot="metadata">1990-2000</div>
-      <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
-    </pharos-image-card>`);
+      <div slot="metadata">
+        Part of <test-pharos-link href="#">An Example Collection</test-pharos-link>
+      </div>
+    </test-pharos-image-card>`);
   });
 
   it('is accessible', async () => {
@@ -43,7 +45,7 @@ describe('pharos-image-card', () => {
   });
 
   it('is accessible as the collection variant', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       title="Card Title"
       link="#"
       variant="collection"
@@ -55,12 +57,12 @@ describe('pharos-image-card', () => {
       />
       <strong slot="metadata">100 items</strong>
       <div slot="metadata">Description of collection.</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
     await expect(component).to.be.accessible();
   });
 
   it('is accessible as the promotional variant', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       title="Card Title"
       link="#"
       variant="promotional"
@@ -72,12 +74,12 @@ describe('pharos-image-card', () => {
       />
       <strong slot="metadata">100 items</strong>
       <div slot="metadata">Description of collection.</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
     await expect(component).to.be.accessible();
   });
 
   it('is accessible as the selectable variant', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       title="Card Title"
       link="#"
       variant="selectable"
@@ -89,12 +91,12 @@ describe('pharos-image-card', () => {
       />
       <strong slot="metadata">100 items</strong>
       <div slot="metadata">Description of collection.</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
     await expect(component).to.be.accessible();
   });
 
   it('is accessible as the selectable-collection variant', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       title="Card Title"
       link="#"
       variant="selectable-collection"
@@ -106,12 +108,12 @@ describe('pharos-image-card', () => {
       />
       <strong slot="metadata">100 items</strong>
       <div slot="metadata">Description of collection.</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
     await expect(component).to.be.accessible();
   });
 
   it('is accessible as the selectable subtle-select variant', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       title="Card Title"
       link="#"
       variant="selectable"
@@ -124,25 +126,25 @@ describe('pharos-image-card', () => {
       />
       <strong slot="metadata">100 items</strong>
       <div slot="metadata">Description of collection.</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
     await expect(component).to.be.accessible();
   });
 
   it('throws an error for an invalid variant value', async () => {
     component = await fixture(html`
-      <pharos-image-card title="Card Title" link="#" variant="fake"></pharos-image-card>
+      <test-pharos-image-card title="Card Title" link="#" variant="fake"></test-pharos-image-card>
     `).catch((e) => e);
     expect('fake is not a valid variant. Valid variants are: base, collection').to.be.thrown;
   });
 
   it('throws an error when using subtle-select with non-selectable variants', async () => {
     component = await fixture(html`
-      <pharos-image-card
+      <test-pharos-image-card
         title="Card Title"
         link="#"
         subtle-select="true"
         variant="collection"
-      ></pharos-image-card>
+      ></test-pharos-image-card>
     `).catch((e) => e);
     expect(
       'collection is not a valid variant to use with subtle-select. Only the selectable variants can be used with subtle-select.'
@@ -151,12 +153,12 @@ describe('pharos-image-card', () => {
 
   it('throws an error when using the selected prop is used with a non-selectable variant', async () => {
     component = await fixture(html`
-      <pharos-image-card
+      <test-pharos-image-card
         title="Card Title"
         link="#"
         selected="true"
         variant="collection"
-      ></pharos-image-card>
+      ></test-pharos-image-card>
     `).catch((e) => e);
     expect(
       'Image card with variant type collection cannot be selected. Only the selectable variants can be selected.'
@@ -167,15 +169,15 @@ describe('pharos-image-card', () => {
     component.actionMenu = 'menu-id';
     await component.updateComplete;
 
-    const menu = document.createElement('pharos-dropdown-menu');
+    const menu = document.createElement('test-pharos-dropdown-menu');
     menu.id = 'menu-id';
-    const item = document.createElement('pharos-dropdown-menu-item');
+    const item = document.createElement('test-pharos-dropdown-menu-item');
     item.textContent = 'Menu Item';
     menu.appendChild(item);
     document.body.appendChild(menu);
 
     const button: PharosButton | null = component.renderRoot.querySelector(
-      'pharos-button[icon="ellipses-vertical"]'
+      '[data-pharos-component="PharosButton"][icon="ellipses-vertical"]'
     );
     button?.click();
     await aTimeout(100);
@@ -185,21 +187,23 @@ describe('pharos-image-card', () => {
   });
 
   it('uses a default heading level when not supplied', async () => {
-    const heading = component.renderRoot.querySelector('pharos-heading');
+    const heading = component.renderRoot.querySelector('[data-pharos-component="PharosHeading"]');
     expect(heading?.getAttribute('level')).to.equal('3');
   });
 
   it('uses the supplied heading level', async () => {
     component.headingLevel = 2;
     await component.updateComplete;
-    const heading = component.renderRoot.querySelector('pharos-heading');
+    const heading = component.renderRoot.querySelector('[data-pharos-component="PharosHeading"]');
     expect(heading?.getAttribute('level')).to.equal('2');
   });
 
   it('uses the supplied indicate link visited', async () => {
     component.indicateLinkVisited = true;
     await component.updateComplete;
-    const link = component.renderRoot.querySelector('pharos-link.card__link--title');
+    const link = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"].card__link--title'
+    );
     expect(link?.hasAttribute('indicate-visited')).to.be.true;
   });
 
@@ -212,7 +216,7 @@ describe('pharos-image-card', () => {
   });
 
   it('does not set the title link hover state when the card is disabled and the link title is hovered', async () => {
-    component = await fixture(html`<pharos-image-card disabled="true" link="#">
+    component = await fixture(html`<test-pharos-image-card disabled="true" link="#">
       <img
         slot="image"
         alt="Card Title"
@@ -221,8 +225,10 @@ describe('pharos-image-card', () => {
       <span slot="title">Card Title</span>
       <div slot="metadata">Creator of the item</div>
       <div slot="metadata">1990-2000</div>
-      <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
-    </pharos-image-card>`);
+      <div slot="metadata">
+        Part of <test-pharos-link href="#">An Example Collection</test-pharos-link>
+      </div>
+    </test-pharos-image-card>`);
     const imageLink = component.renderRoot.querySelector('.card__link--image');
     imageLink?.parentElement?.dispatchEvent(new Event('mouseenter'));
 
@@ -234,12 +240,14 @@ describe('pharos-image-card', () => {
     component.actionMenu = 'menu-id';
     await component.updateComplete;
 
-    const button = component.renderRoot.querySelector('pharos-button[icon="ellipses-vertical"]');
+    const button = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosButton"][icon="ellipses-vertical"]'
+    );
     expect(button).not.to.be.null;
   });
 
   it('renders the action-button via a slot when the action menu id property is not provided', async () => {
-    component = await fixture(html`<pharos-image-card link="#">
+    component = await fixture(html`<test-pharos-image-card link="#">
       <img
         slot="image"
         alt="Card Title"
@@ -248,21 +256,27 @@ describe('pharos-image-card', () => {
       <span slot="title">Card Title</span>
       <div slot="metadata">Creator of the item</div>
       <div slot="metadata">1990-2000</div>
-      <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
+      <div slot="metadata">
+        Part of <test-pharos-link href="#">An Example Collection</test-pharos-link>
+      </div>
       <div slot="action-button">ActionButtonComponent</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const actionMenuSlot = component.renderRoot.querySelector('slot[name="action-button"]');
     expect(actionMenuSlot).not.to.be.null;
   });
 
   it('does not render an action button when an action menu id is not provided', async () => {
-    const button = component.renderRoot.querySelector('pharos-button[icon="ellipses-vertical"]');
+    const button = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosButton"][icon="ellipses-vertical"]'
+    );
     expect(button).to.be.null;
   });
 
   it('renders a heading with preset "1--bold" for the base variant', async () => {
-    const heading = component.renderRoot.querySelector('pharos-heading.card__heading');
+    const heading = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosHeading"].card__heading'
+    );
     expect(heading?.getAttribute('preset')).to.equal('1--bold');
   });
 
@@ -270,7 +284,9 @@ describe('pharos-image-card', () => {
     component.variant = 'collection';
     await component.updateComplete;
 
-    const heading = component.renderRoot.querySelector('pharos-heading.card__heading');
+    const heading = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosHeading"].card__heading'
+    );
     expect(heading?.getAttribute('preset')).to.equal('2');
   });
 
@@ -278,12 +294,14 @@ describe('pharos-image-card', () => {
     component.variant = 'promotional';
     await component.updateComplete;
 
-    const heading = component.renderRoot.querySelector('pharos-heading.card__heading');
+    const heading = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosHeading"].card__heading'
+    );
     expect(heading?.getAttribute('preset')).to.equal('4');
   });
 
   it('renders the title via a slot when the title property is not set', async () => {
-    component = await fixture(html`<pharos-image-card link="#">
+    component = await fixture(html`<test-pharos-image-card link="#">
       <img
         slot="image"
         alt="Card Title"
@@ -292,8 +310,10 @@ describe('pharos-image-card', () => {
       <span slot="title">Card Title</span>
       <div slot="metadata">Creator of the item</div>
       <div slot="metadata">1990-2000</div>
-      <div slot="metadata">Part of <pharos-link href="#">An Example Collection</pharos-link></div>
-    </pharos-image-card>`);
+      <div slot="metadata">
+        Part of <test-pharos-link href="#">An Example Collection</test-pharos-link>
+      </div>
+    </test-pharos-image-card>`);
 
     const titleSlot = component.renderRoot.querySelector('slot[name="title"]');
     expect(titleSlot).not.to.be.null;
@@ -303,7 +323,9 @@ describe('pharos-image-card', () => {
     component.error = true;
     await component.updateComplete;
 
-    const icon = component.renderRoot.querySelector('pharos-icon[name="exclamation-inverse"]');
+    const icon = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosIcon"][name="exclamation-inverse"]'
+    );
     expect(icon).not.to.be.null;
   });
 
@@ -330,7 +352,9 @@ describe('pharos-image-card', () => {
   });
 
   it('renders a link around the image for the base variant', async () => {
-    const link = component.renderRoot.querySelector('pharos-link.card__link--image');
+    const link = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"].card__link--image'
+    );
     expect(link).not.to.be.null;
   });
 
@@ -345,7 +369,9 @@ describe('pharos-image-card', () => {
     component.error = true;
     await component.updateComplete;
 
-    const link = component.renderRoot.querySelector('pharos-link.card__link--image');
+    const link = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"].card__link--image'
+    );
     expect(link).not.to.be.null;
   });
 
@@ -353,12 +379,16 @@ describe('pharos-image-card', () => {
     component.variant = 'collection';
     await component.updateComplete;
 
-    const link = component.renderRoot.querySelector('pharos-link.card__link--collection');
+    const link = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"].card__link--collection'
+    );
     expect(link).not.to.be.null;
   });
 
   it('renders a label for the link around the image for the base variant', async () => {
-    const link = component.renderRoot.querySelector('pharos-link.card__link--image');
+    const link = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"].card__link--image'
+    );
     expect(link?.getAttribute('label')).to.equal('Label for card image link');
   });
 
@@ -366,7 +396,9 @@ describe('pharos-image-card', () => {
     component.variant = 'collection';
     await component.updateComplete;
 
-    const link = component.renderRoot.querySelector('pharos-link.card__link--collection');
+    const link = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosLink"].card__link--collection'
+    );
     expect(link?.getAttribute('label')).to.equal('Label for card image link');
   });
 
@@ -375,7 +407,9 @@ describe('pharos-image-card', () => {
     component.title = 'pick me';
     await component.updateComplete;
 
-    const checkbox = component.renderRoot.querySelector('pharos-checkbox.card__checkbox');
+    const checkbox = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosCheckbox"].card__checkbox'
+    );
     expect(checkbox?.getAttribute('name')).to.equal('Select pick me');
   });
 
@@ -383,20 +417,22 @@ describe('pharos-image-card', () => {
     component.variant = 'selectable-collection';
     component.title = 'pick me';
     await component.updateComplete;
-    const checkbox = component.renderRoot.querySelector('pharos-checkbox.card__checkbox');
+    const checkbox = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosCheckbox"].card__checkbox'
+    );
 
     expect(checkbox?.getAttribute('name')).to.equal('Select pick me');
   });
 
   it('dispatches the mouseenter event on pharos link mouseenter', async () => {
-    component = await fixture(html`<pharos-image-card link="#">
+    component = await fixture(html`<test-pharos-image-card link="#">
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     let hovered = false;
     const onMouseEnter = (): void => {
@@ -411,7 +447,7 @@ describe('pharos-image-card', () => {
   });
 
   it('will show not show a checkbox when subtle-select is true', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       variant="selectable"
       subtle-select="true"
       link="#"
@@ -422,15 +458,17 @@ describe('pharos-image-card', () => {
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     let checkboxElement = null;
-    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    checkboxElement = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosCheckbox"]'
+    );
     expect(checkboxElement).to.be.null;
   });
 
   it('will show a checkbox when hovered and subtle-select is true', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       variant="selectable"
       subtle-select="true"
       link="#"
@@ -441,7 +479,7 @@ describe('pharos-image-card', () => {
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     let checkboxElement = null;
     const imageLink = component.renderRoot.querySelector('.card__link--image');
@@ -450,12 +488,14 @@ describe('pharos-image-card', () => {
     await aTimeout(100);
     await elementUpdated(component);
 
-    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    checkboxElement = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosCheckbox"]'
+    );
     expect(checkboxElement).not.to.be.null;
   });
 
   it('will show a checkbox when hovered while subtle and subtle-select are true', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       variant="selectable"
       subtle-select="true"
       subtle="true"
@@ -467,7 +507,7 @@ describe('pharos-image-card', () => {
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     let checkboxElement = null;
     const imageLink = component.renderRoot.querySelector('.card__link--image');
@@ -476,19 +516,25 @@ describe('pharos-image-card', () => {
     await aTimeout(100);
     await elementUpdated(component);
 
-    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    checkboxElement = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosCheckbox"]'
+    );
     expect(checkboxElement).not.to.be.null;
   });
 
   it('will show a checkbox when hovered while subtle is true', async () => {
-    component = await fixture(html`<pharos-image-card variant="selectable" subtle="true" link="#">
+    component = await fixture(html`<test-pharos-image-card
+      variant="selectable"
+      subtle="true"
+      link="#"
+    >
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     let checkboxElement = null;
     const imageLink = component.renderRoot.querySelector('.card__link--image');
@@ -497,19 +543,21 @@ describe('pharos-image-card', () => {
     await aTimeout(100);
     await elementUpdated(component);
 
-    checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    checkboxElement = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosCheckbox"]'
+    );
     expect(checkboxElement).not.to.be.null;
   });
 
   it('dispatches the mouseleave event on pharos link mouseleave', async () => {
-    component = await fixture(html`<pharos-image-card link="#">
+    component = await fixture(html`<test-pharos-image-card link="#">
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     let hovered = true;
     const onMouseLeave = (): void => {
@@ -524,17 +572,17 @@ describe('pharos-image-card', () => {
   });
 
   it('dispatches pharos-image-card-selected when the title of the select variant is clicked', async () => {
-    component = await fixture(html`<pharos-image-card variant="selectable" link="#">
+    component = await fixture(html`<test-pharos-image-card variant="selectable" link="#">
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const title: PharosLink | null = component.renderRoot.querySelector(
-      'pharos-link.card__link--title'
+      '[data-pharos-component="PharosLink"].card__link--title'
     );
 
     let selected = false;
@@ -549,17 +597,17 @@ describe('pharos-image-card', () => {
   });
 
   it('dispatches pharos-image-card-selected when the thumbnail of the select variant is clicked', async () => {
-    component = await fixture(html`<pharos-image-card variant="selectable" link="#">
+    component = await fixture(html`<test-pharos-image-card variant="selectable" link="#">
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const title: PharosLink | null = component.renderRoot.querySelector(
-      'pharos-link.card__link--image'
+      '[data-pharos-component="PharosLink"].card__link--image'
     );
 
     let selected = false;
@@ -574,17 +622,17 @@ describe('pharos-image-card', () => {
   });
 
   it('dispatches pharos-image-card-selected when the thumbnail of the thumbnail of a select variant card is clicked', async () => {
-    component = await fixture(html`<pharos-image-card variant="selectable" subtle link="#">
+    component = await fixture(html`<test-pharos-image-card variant="selectable" subtle link="#">
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const title: PharosLink | null = component.renderRoot.querySelector(
-      'pharos-link.card__link--image'
+      '[data-pharos-component="PharosLink"].card__link--image'
     );
 
     let selected = false;
@@ -599,17 +647,21 @@ describe('pharos-image-card', () => {
   });
 
   it('does not dispatch pharos-image-card-selected when the disabled thumbnail of the select variant is clicked', async () => {
-    component = await fixture(html`<pharos-image-card variant="selectable" disabled="true" link="#">
+    component = await fixture(html`<test-pharos-image-card
+      variant="selectable"
+      disabled="true"
+      link="#"
+    >
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const title: PharosLink | null = component.renderRoot.querySelector(
-      'pharos-link.card__link--image'
+      '[data-pharos-component="PharosLink"].card__link--image'
     );
 
     let selected = false;
@@ -624,7 +676,7 @@ describe('pharos-image-card', () => {
   });
 
   it('does not dispatch pharos-image-card-selected when the disabled thumbnail of subtle-select is clicked', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       variant="selectable"
       subtle-select="true"
       link="#"
@@ -635,10 +687,10 @@ describe('pharos-image-card', () => {
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const title: PharosLink | null = component.renderRoot.querySelector(
-      'pharos-link.card__link--image'
+      '[data-pharos-component="PharosLink"].card__link--image'
     );
 
     let selected = false;
@@ -653,17 +705,21 @@ describe('pharos-image-card', () => {
   });
 
   it('does not dispatch pharos-image-card-selected when the title of the select variant is clicked in subtle-select mode', async () => {
-    component = await fixture(html`<pharos-image-card variant="selectable" subtle-select link="#">
+    component = await fixture(html`<test-pharos-image-card
+      variant="selectable"
+      subtle-select
+      link="#"
+    >
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const title: PharosLink | null = component.renderRoot.querySelector(
-      'pharos-link.card__link--image'
+      '[data-pharos-component="PharosLink"].card__link--image'
     );
 
     let selected = false;
@@ -678,7 +734,7 @@ describe('pharos-image-card', () => {
   });
 
   it('does not dispatch pharos-image-card-selected when the title of the select variant is clicked in subtle/subtle-select mode', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       variant="selectable"
       subtle-select
       subtle
@@ -690,10 +746,10 @@ describe('pharos-image-card', () => {
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     const title: PharosLink | null = component.renderRoot.querySelector(
-      'pharos-link.card__link--image'
+      '[data-pharos-component="PharosLink"].card__link--image'
     );
 
     let selected = false;
@@ -708,20 +764,20 @@ describe('pharos-image-card', () => {
   });
 
   it('renders the overlay slot content', async () => {
-    component = await fixture(html`<pharos-image-card link="#">
+    component = await fixture(html`<test-pharos-image-card link="#">
       <img
         slot="image"
         alt="Card Title"
         src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E"
       />
       <div slot="overlay">Card overlay</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     expect(component.innerHTML).contains('Card overlay');
   });
 
   it('can be navigated with a keyboard when subtle and selectable', async () => {
-    component = await fixture(html`<pharos-image-card
+    component = await fixture(html`<test-pharos-image-card
       title="Card Title"
       link="#"
       variant="selectable"
@@ -734,11 +790,13 @@ describe('pharos-image-card', () => {
       />
       <strong slot="metadata">100 items</strong>
       <div slot="metadata">Description of collection.</div>
-    </pharos-image-card>`);
+    </test-pharos-image-card>`);
 
     component.focus();
     await sendKeys({ down: 'Tab' });
-    const checkboxElement = component.renderRoot.querySelector('pharos-checkbox');
+    const checkboxElement = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosCheckbox"]'
+    );
     expect(checkboxElement).not.to.be.null;
   });
 });

--- a/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.jsx
+++ b/packages/pharos/src/components/image-card/pharos-image-card.wc.stories.jsx
@@ -16,8 +16,8 @@ export default {
 
 const Template = {
   render: (args) =>
-    html`<pharos-layout style="margin: 1rem 0"
-      ><pharos-image-card
+    html`<storybook-pharos-layout style="margin: 1rem 0"
+      ><storybook-pharos-image-card
         title="South Hall"
         link="https://www.jstor.org/stable/10.2307/community.26220188"
         ?error=${args.error}
@@ -30,23 +30,23 @@ const Template = {
         <div id="item-date" slot="metadata">1889-1892 (creation)</div>
         <div id="collection" slot="metadata">
           Part of
-          <pharos-link
+          <storybook-pharos-link
             href="https://www.jstor.org/site/pratt/buildings-image"
             ?on-background=${args.subtle}
-            >Pratt Institute Buildings Image Collection</pharos-link
+            >Pratt Institute Buildings Image Collection</storybook-pharos-link
           >
         </div>
-      </pharos-image-card></pharos-layout
+      </storybook-pharos-image-card></storybook-pharos-layout
     >`,
   args: defaultArgs,
 };
 
 export const Base = {
   render: () =>
-    html` <pharos-layout tag="ol" style="margin: 1rem 0">
+    html` <storybook-pharos-layout tag="ol" style="margin: 1rem 0">
       ${items.map((item, index) => {
         return html` <li style="grid-column: span 2">
-          <pharos-image-card id="card-${index}" title="Card Title" link="#">
+          <storybook-pharos-image-card id="card-${index}" title="Card Title" link="#">
             <img
               id="image-${index}"
               src="./images/item-detail/${item.image}"
@@ -57,22 +57,27 @@ export const Base = {
             <div id="item-date-${index}" slot="metadata">1990-2000</div>
             <div id="collection-${index}" slot="metadata">
               Part of
-              <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+              <storybook-pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
                 >An Example Collection
-              </pharos-link>
+              </storybook-pharos-link>
             </div>
-          </pharos-image-card>
+          </storybook-pharos-image-card>
         </li>`;
       })}
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };
 
 export const WithSourceTypes = {
   render: () =>
-    html` <pharos-layout tag="ol" style="margin: 1rem 0">
+    html` <storybook-pharos-layout tag="ol" style="margin: 1rem 0">
       ${items.map((item, index) => {
         return html` <li style="grid-column: span 2">
-          <pharos-image-card id="card-${index}" title="Card Title" link="#" source-type="Image">
+          <storybook-pharos-image-card
+            id="card-${index}"
+            title="Card Title"
+            link="#"
+            source-type="Image"
+          >
             <img
               id="image-${index}"
               src="./images/item-detail/${item.image}"
@@ -83,22 +88,22 @@ export const WithSourceTypes = {
             <div id="item-date-${index}" slot="metadata">1990-2000</div>
             <div id="collection-${index}" slot="metadata">
               Part of
-              <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+              <storybook-pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
                 >An Example Collection
-              </pharos-link>
+              </storybook-pharos-link>
             </div>
-          </pharos-image-card>
+          </storybook-pharos-image-card>
         </li>`;
       })}
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };
 
 export const Collection = {
   render: () =>
-    html` <pharos-layout tag="ol" style="margin: 1rem 0">
+    html` <storybook-pharos-layout tag="ol" style="margin: 1rem 0">
       ${collections.map((collection, index) => {
         return html` <li class="image-card-example__card--collection">
-          <pharos-image-card
+          <storybook-pharos-image-card
             id="card-${index}"
             title="${collection.title}"
             link="#"
@@ -114,17 +119,17 @@ export const Collection = {
             <div id="description-${index}" slot="metadata">
               Selections from the global permanent collection.
             </div>
-          </pharos-image-card>
+          </storybook-pharos-image-card>
         </li>`;
       })}
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };
 
 export const Promotional = {
   render: () =>
-    html` <pharos-layout style="margin: 1rem 0">
+    html` <storybook-pharos-layout style="margin: 1rem 0">
       <div class="image-card-example__card--promotional">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Bring your work to life with images"
           link="#"
           variant="promotional"
@@ -133,22 +138,27 @@ export const Promotional = {
           <p slot="metadata">
             Harness the power of visual materials—explore more than 3 million images now on JSTOR.
           </p>
-        </pharos-image-card>
-        <pharos-button variant="secondary">Search for images</pharos-button>
+        </storybook-pharos-image-card>
+        <storybook-pharos-button variant="secondary">Search for images</storybook-pharos-button>
       </div>
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };
 
 export const Selectable = {
   render: () =>
-    html` <pharos-layout tag="ol" style="margin: 1rem 0">
+    html` <storybook-pharos-layout tag="ol" style="margin: 1rem 0">
       <li style="grid-column: span 3">
-        <pharos-image-card title="Selectable" link="#" source-type="Image" variant="selectable">
+        <storybook-pharos-image-card
+          title="Selectable"
+          link="#"
+          source-type="Image"
+          variant="selectable"
+        >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Subtle select"
           link="#"
           source-type="Image"
@@ -156,10 +166,10 @@ export const Selectable = {
           subtle-select="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selected Disabled"
           link="#"
           source-type="Image"
@@ -168,10 +178,10 @@ export const Selectable = {
           selected="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selectable Error State"
           link="#"
           source-type="Image"
@@ -179,10 +189,10 @@ export const Selectable = {
           error="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Subtle Select Error State"
           link="#"
           source-type="Image"
@@ -191,16 +201,16 @@ export const Selectable = {
           subtle-select="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };
 
 export const SubtleSelectable = {
   render: () =>
-    html` <pharos-layout tag="ol" style="margin: 1rem 0">
+    html` <storybook-pharos-layout tag="ol" style="margin: 1rem 0">
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selectable"
           link="#"
           source-type="Image"
@@ -208,10 +218,10 @@ export const SubtleSelectable = {
           subtle="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Subtle select"
           link="#"
           source-type="Image"
@@ -220,16 +230,16 @@ export const SubtleSelectable = {
           subtle-select="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-          <pharos-button
+          <storybook-pharos-button
             slot="overlay"
             variant="overlay"
             icon="save"
             style="float:right;margin-top:-40px;margin-right:20px;"
-          ></pharos-button>
-        </pharos-image-card>
+          ></storybook-pharos-button>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selected Disabled"
           link="#"
           source-type="Image"
@@ -239,10 +249,10 @@ export const SubtleSelectable = {
           selected="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selectable Error State"
           link="#"
           source-type="Image"
@@ -251,10 +261,10 @@ export const SubtleSelectable = {
           error="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Subtle Select Error State"
           link="#"
           source-type="Image"
@@ -264,9 +274,9 @@ export const SubtleSelectable = {
           subtle-select="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };
 
 export const ErrorState = {
@@ -296,8 +306,8 @@ export const VisitedTitleLink = {
 export const WithActionMenu = {
   render: () =>
     html`
-      <pharos-layout style="margin: 1rem 0">
-        <pharos-image-card
+      <storybook-pharos-layout style="margin: 1rem 0">
+        <storybook-pharos-image-card
           title="South Hall"
           link="https://www.jstor.org/stable/10.2307/community.26220188"
           action-menu="my-dropdown-menu"
@@ -313,25 +323,25 @@ export const WithActionMenu = {
           <div id="item-date" slot="metadata">1889-1892 (creation)</div>
           <div id="collection" slot="metadata">
             Part of
-            <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-              >Pratt Institute Buildings Image Collection</pharos-link
+            <storybook-pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+              >Pratt Institute Buildings Image Collection</storybook-pharos-link
             >
           </div>
-        </pharos-image-card>
-      </pharos-layout>
-      <pharos-dropdown-menu id="my-dropdown-menu">
-        <pharos-dropdown-menu-item>Item 1</pharos-dropdown-menu-item>
-        <pharos-dropdown-menu-item>Item 2</pharos-dropdown-menu-item>
-        <pharos-dropdown-menu-item>Item 3</pharos-dropdown-menu-item>
-      </pharos-dropdown-menu>
+        </storybook-pharos-image-card>
+      </storybook-pharos-layout>
+      <storybook-pharos-dropdown-menu id="my-dropdown-menu">
+        <storybook-pharos-dropdown-menu-item>Item 1</storybook-pharos-dropdown-menu-item>
+        <storybook-pharos-dropdown-menu-item>Item 2</storybook-pharos-dropdown-menu-item>
+        <storybook-pharos-dropdown-menu-item>Item 3</storybook-pharos-dropdown-menu-item>
+      </storybook-pharos-dropdown-menu>
     `,
 };
 
 export const WithActionButtonSlot = {
   render: () =>
     html`
-      <pharos-layout style="margin: 1rem 0">
-        <pharos-image-card
+      <storybook-pharos-layout style="margin: 1rem 0">
+        <storybook-pharos-image-card
           title="South Hall"
           link="https://www.jstor.org/stable/10.2307/community.26220188"
           style="grid-column: span 2"
@@ -346,39 +356,39 @@ export const WithActionButtonSlot = {
           <div id="item-date" slot="metadata">1889-1892 (creation)</div>
           <div id="collection" slot="metadata">
             Part of
-            <pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
-              >Pratt Institute Buildings Image Collection</pharos-link
+            <storybook-pharos-link href="https://www.jstor.org/site/pratt/buildings-image"
+              >Pratt Institute Buildings Image Collection</storybook-pharos-link
             >
           </div>
-          <pharos-button
+          <storybook-pharos-button
             slot="action-button"
             data-dropdown-menu-id="dropdownId"
             icon="ellipses-vertical"
             icon-condensed
             variant="subtle"
-          ></pharos-button>
-        </pharos-image-card>
-        <pharos-dropdown-menu id="dropdownId">
-          <pharos-dropdown-menu-item>Item 1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Item 3</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-      </pharos-layout>
+          ></storybook-pharos-button>
+        </storybook-pharos-image-card>
+        <storybook-pharos-dropdown-menu id="dropdownId">
+          <storybook-pharos-dropdown-menu-item>Item 1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Item 3</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+      </storybook-pharos-layout>
     `,
 };
 
 export const SelectableCollection = {
   render: () =>
-    html` <pharos-layout tag="ol" style="margin: 1rem 0">
+    html` <storybook-pharos-layout tag="ol" style="margin: 1rem 0">
       <li class="image-card-example__card--collection">
-        <pharos-image-card title="Selectable" link="#" variant="selectable-collection">
+        <storybook-pharos-image-card title="Selectable" link="#" variant="selectable-collection">
           <img src="./images/item-detail/open_collection_1.png" slot="image" />
           <strong slot="metadata">50 items</strong>
           <div slot="metadata">Selections from the global permanent collection.</div>
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li class="image-card-example__card--collection">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Subtle Select"
           link="#"
           variant="selectable-collection"
@@ -387,10 +397,10 @@ export const SelectableCollection = {
           <img src="./images/item-detail/open_collection_2.png" slot="image" />
           <strong slot="metadata">50 items</strong>
           <div slot="metadata">Selections from the global permanent collection.</div>
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li class="image-card-example__card--collection">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selected Disabled"
           link="#"
           variant="selectable-collection"
@@ -400,21 +410,21 @@ export const SelectableCollection = {
           <img src="./images/item-detail/open_collection_3.png" slot="image" />
           <strong slot="metadata">50 items</strong>
           <div slot="metadata">Selections from the global permanent collection.</div>
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };
 
 export const Disabled = {
   render: () =>
-    html` <pharos-layout tag="ol" style="margin: 1rem 0">
+    html` <storybook-pharos-layout tag="ol" style="margin: 1rem 0">
       <li style="grid-column: span 3">
-        <pharos-image-card title="Disabled" link="#" source-type="Image" disabled="true">
+        <storybook-pharos-image-card title="Disabled" link="#" source-type="Image" disabled="true">
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selectable Disabled"
           link="#"
           source-type="Image"
@@ -422,10 +432,10 @@ export const Disabled = {
           variant="selectable"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
       <li style="grid-column: span 3">
-        <pharos-image-card
+        <storybook-pharos-image-card
           title="Selected Disabled"
           link="#"
           source-type="Image"
@@ -434,7 +444,7 @@ export const Disabled = {
           selected="true"
         >
           <img src="./images/item-detail/collection_5.png" alt="Card Title" slot="image" />
-        </pharos-image-card>
+        </storybook-pharos-image-card>
       </li>
-    </pharos-layout>`,
+    </storybook-pharos-layout>`,
 };

--- a/packages/pharos/src/components/input-group/PharosInputGroup.react.stories.jsx
+++ b/packages/pharos/src/components/input-group/PharosInputGroup.react.stories.jsx
@@ -5,11 +5,19 @@ import {
   PharosIcon,
 } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Input Group',
   component: PharosInputGroup,
   subcomponents: { PharosInputGroupSelect },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('input-group') },
   },

--- a/packages/pharos/src/components/input-group/pharos-input-group-select.test.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group-select.test.ts
@@ -8,11 +8,11 @@ describe('pharos-input-group', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-input-group-select hide-label>
+      <test-pharos-input-group-select hide-label>
         <span slot="label">Search</span>
         <option value="">Search all content</option>
         <option value="book">Search within this book</option>
-      </pharos-input-group-select>
+      </test-pharos-input-group-select>
     `);
   });
 

--- a/packages/pharos/src/components/input-group/pharos-input-group.test.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group.test.ts
@@ -8,10 +8,10 @@ describe('pharos-input-group', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-input-group>
+      <test-pharos-input-group>
         <span slot="label">Search</span>
-        <pharos-button icon="search" variant="subtle" label="search"></pharos-button>
-      </pharos-input-group>
+        <test-pharos-button icon="search" variant="subtle" label="search"></test-pharos-button>
+      </test-pharos-input-group>
     `);
   });
 
@@ -32,15 +32,15 @@ describe('pharos-input-group', () => {
   it('adjusts its padding when elements are prepended to the group', async () => {
     component = await fixture(
       html`
-        <pharos-input-group>
+        <test-pharos-input-group>
           <span slot="label">I am a label</span>
-          <pharos-button
+          <test-pharos-button
             slot="prepend"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
+          ></test-pharos-button>
+        </test-pharos-input-group>
       `
     );
     await nextFrame();
@@ -99,7 +99,7 @@ describe('pharos-input-group', () => {
   });
 
   it('adjusts the validated icon position when elements are dynamically appended to the group', async () => {
-    const button = document.createElement('pharos-button');
+    const button = document.createElement('test-pharos-button');
     button.icon = 'close';
     component.appendChild(button);
     component.validated = true;

--- a/packages/pharos/src/components/input-group/pharos-input-group.wc.stories.jsx
+++ b/packages/pharos/src/components/input-group/pharos-input-group.wc.stories.jsx
@@ -15,15 +15,15 @@ export const Base = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 524px;">
-        <pharos-input-group name="my-input-group">
+        <storybook-pharos-input-group name="my-input-group">
           <span slot="label">Search</span>
-          <pharos-button
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
       </div>
     `,
 };
@@ -32,56 +32,56 @@ export const Prominent = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 524px;">
-        <pharos-input-group name="my-input-group" variant="prominent">
+        <storybook-pharos-input-group name="my-input-group" variant="prominent">
           <span slot="label">Basic</span>
-          <pharos-button
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
-        <pharos-input-group name="my-input-group" variant="prominent" invalidated>
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
+        <storybook-pharos-input-group name="my-input-group" variant="prominent" invalidated>
           <span slot="label">invalidated</span>
-          <pharos-button
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
-        <pharos-input-group name="prominent-prepend" variant="prominent">
-          <pharos-button
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
+        <storybook-pharos-input-group name="prominent-prepend" variant="prominent">
+          <storybook-pharos-button
             name="book-button"
             slot="prepend"
             icon="book"
             variant="subtle"
             label="book"
-          ></pharos-button>
+          ></storybook-pharos-button>
           <span slot="label">prominent Prepend</span>
-        </pharos-input-group>
-        <pharos-input-group name="prominent-buttons" variant="prominent">
-          <pharos-button
+        </storybook-pharos-input-group>
+        <storybook-pharos-input-group name="prominent-buttons" variant="prominent">
+          <storybook-pharos-button
             name="book-button"
             slot="prepend"
             icon="book"
             variant="subtle"
             label="book"
-          ></pharos-button>
+          ></storybook-pharos-button>
           <span slot="label">Multiple buttons</span>
-          <pharos-button
+          <storybook-pharos-button
             name="close-button"
             icon="close"
             variant="subtle"
             label="close"
-          ></pharos-button>
-          <pharos-button
+          ></storybook-pharos-button>
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
       </div>
     `,
 };
@@ -90,24 +90,24 @@ export const Validity = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 524px;">
-        <pharos-input-group invalidated value="not an email" name="my-input-group">
+        <storybook-pharos-input-group invalidated value="not an email" name="my-input-group">
           <span slot="label">Email</span>
-          <pharos-button
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
-        <pharos-input-group validated value="here@there.com" name="my-input-group">
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
+        <storybook-pharos-input-group validated value="here@there.com" name="my-input-group">
           <span slot="label">Email</span>
-          <pharos-button
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
       </div>
     `,
 };
@@ -116,49 +116,49 @@ export const Composition = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 524px;">
-        <pharos-input-group name="my-input-group-icon">
+        <storybook-pharos-input-group name="my-input-group-icon">
           <span slot="label">With icons</span>
-          <pharos-icon id="calendar" name="calendar"></pharos-icon>
-        </pharos-input-group>
-        <pharos-input-group name="my-input-group-buttons">
+          <storybook-pharos-icon id="calendar" name="calendar"></storybook-pharos-icon>
+        </storybook-pharos-input-group>
+        <storybook-pharos-input-group name="my-input-group-buttons">
           <span slot="label">Multiple buttons</span>
-          <pharos-button
+          <storybook-pharos-button
             name="close-button"
             icon="close"
             variant="subtle"
             label="close"
-          ></pharos-button>
-          <pharos-button
+          ></storybook-pharos-button>
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
-        <pharos-input-group name="my-input-group-select">
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
+        <storybook-pharos-input-group name="my-input-group-select">
           <span slot="label">With select</span>
-          <pharos-input-group-select name="my-group-select" hide-label>
+          <storybook-pharos-input-group-select name="my-group-select" hide-label>
             <span slot="label">Search</span>
             <option value="">Search all content</option>
             <option value="book">Search within this book</option>
-          </pharos-input-group-select>
-          <pharos-button
+          </storybook-pharos-input-group-select>
+          <storybook-pharos-button
             name="search-with-select-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
-        <pharos-input-group name="my-input-group-prepend">
-          <pharos-button
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
+        <storybook-pharos-input-group name="my-input-group-prepend">
+          <storybook-pharos-button
             name="book-button"
             slot="prepend"
             icon="book"
             variant="subtle"
             label="book"
-          ></pharos-button>
+          ></storybook-pharos-button>
           <span slot="label">Prepend</span>
-        </pharos-input-group>
+        </storybook-pharos-input-group>
       </div>
     `,
 };

--- a/packages/pharos/src/components/layout/PharosLayout.react.stories.jsx
+++ b/packages/pharos/src/components/layout/PharosLayout.react.stories.jsx
@@ -3,10 +3,18 @@ import { viewports } from '../../pages/shared/viewports';
 
 import { PharosLayout, PharosSidenav, PharosLink } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Layout',
   component: PharosLayout,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('layout') },
     viewport: {

--- a/packages/pharos/src/components/layout/pharos-layout.test.ts
+++ b/packages/pharos/src/components/layout/pharos-layout.test.ts
@@ -9,10 +9,10 @@ describe('pharos-layout', () => {
   beforeEach(async () => {
     component = await fixture(
       html`
-        <pharos-layout>
+        <test-pharos-layout>
           <div slot="top">Top Content</div>
           <div>Body Content</div>
-        </pharos-layout>
+        </test-pharos-layout>
       `
     );
   });
@@ -50,9 +50,9 @@ describe('pharos-layout', () => {
   });
 
   it('throws an error for an invalid preset value', async () => {
-    component = await fixture(html` <pharos-layout preset="fake-col"></pharos-layout> `).catch(
-      (e) => e
-    );
+    component = await fixture(
+      html` <test-pharos-layout preset="fake-col"></test-pharos-layout> `
+    ).catch((e) => e);
     expect(
       'fake-col is not a valid preset. Valid presets are: 1-col, 1-col--sidenav, 1-col--sidenav-comfy, 2-col'
     ).to.be.thrown;

--- a/packages/pharos/src/components/layout/pharos-layout.wc.stories.jsx
+++ b/packages/pharos/src/components/layout/pharos-layout.wc.stories.jsx
@@ -53,7 +53,7 @@ const _gridColumns = () => {
 
 export const OneColumn = {
   name: 'One column',
-  render: () => html` <pharos-layout>${_gridColumns()}</pharos-layout> `,
+  render: () => html` <storybook-pharos-layout>${_gridColumns()}</storybook-pharos-layout> `,
 };
 
 export const OneColumnWithSidenav = {
@@ -63,13 +63,15 @@ export const OneColumnWithSidenav = {
       <div
         style="display: grid; grid-template-areas: 'sidenav main'; grid-template-columns: max-content 1fr"
       >
-        <pharos-sidenav style="grid-area: sidenav">
-          <pharos-link slot="top" href="/" id="jstor-logo">
+        <storybook-pharos-sidenav style="grid-area: sidenav">
+          <storybook-pharos-link slot="top" href="/" id="jstor-logo">
             <img src="./images/jstor-logo-inverse.svg" alt="Pharos Home" width="72" height="100" />
-          </pharos-link>
-        </pharos-sidenav>
+          </storybook-pharos-link>
+        </storybook-pharos-sidenav>
         <main style="grid-area: main">
-          <pharos-layout preset="1-col--sidenav">${_gridColumns()}</pharos-layout>
+          <storybook-pharos-layout preset="1-col--sidenav"
+            >${_gridColumns()}</storybook-pharos-layout
+          >
         </main>
       </div>
     `,
@@ -82,13 +84,15 @@ export const OneColumnWithSidenavAndComfySpacing = {
       <div
         style="display: grid; grid-template-areas: 'sidenav main'; grid-template-columns: max-content 1fr"
       >
-        <pharos-sidenav style="grid-area: sidenav">
-          <pharos-link slot="top" href="/" id="jstor-logo">
+        <storybook-pharos-sidenav style="grid-area: sidenav">
+          <storybook-pharos-link slot="top" href="/" id="jstor-logo">
             <img src="./images/jstor-logo-inverse.svg" alt="Pharos Home" width="72" height="100" />
-          </pharos-link>
-        </pharos-sidenav>
+          </storybook-pharos-link>
+        </storybook-pharos-sidenav>
         <main style="grid-area: main">
-          <pharos-layout preset="1-col--sidenav-comfy">${_gridColumns()}</pharos-layout>
+          <storybook-pharos-layout preset="1-col--sidenav-comfy"
+            >${_gridColumns()}</storybook-pharos-layout
+          >
         </main>
       </div>
     `,
@@ -98,13 +102,13 @@ export const TwoColumn = {
   name: 'Two column',
   render: () =>
     html`
-      <pharos-layout preset="2-col">
+      <storybook-pharos-layout preset="2-col">
         <div class="layout-example__container--first"></div>
         <div class="layout-example__container--second"></div>
         <div class="layout-example__container--third"></div>
-      </pharos-layout>
-      <pharos-layout preset="2-col" style="position: absolute; top: 0; width: 100%"
-        >${_gridColumns()}</pharos-layout
+      </storybook-pharos-layout>
+      <storybook-pharos-layout preset="2-col" style="position: absolute; top: 0; width: 100%"
+        >${_gridColumns()}</storybook-pharos-layout
       >
     `,
 };
@@ -113,8 +117,8 @@ export const ColumnLayouts = {
   name: 'Column layouts',
   render: () =>
     html`
-      <pharos-layout style="margin: 1rem 0">
+      <storybook-pharos-layout style="margin: 1rem 0">
         ${_gridItems([1, 2, 3, 4, 6])} ${_comboItems([7, 8, 9, 10])}
-      </pharos-layout>
+      </storybook-pharos-layout>
     `,
 };

--- a/packages/pharos/src/components/link/PharosLink.react.stories.jsx
+++ b/packages/pharos/src/components/link/PharosLink.react.stories.jsx
@@ -3,10 +3,18 @@ import { Fragment } from 'react';
 import { PharosLink, PharosHeading } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Link',
   component: PharosLink,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('link') },
   },

--- a/packages/pharos/src/components/link/pharos-link.test.ts
+++ b/packages/pharos/src/components/link/pharos-link.test.ts
@@ -8,7 +8,7 @@ describe('pharos-link', () => {
   let component: PharosLink;
 
   beforeEach(async () => {
-    component = await fixture(html`<pharos-link href="#">I am a link</pharos-link>`);
+    component = await fixture(html`<test-pharos-link href="#">I am a link</test-pharos-link>`);
   });
 
   it('is accessible', async () => {
@@ -31,9 +31,12 @@ describe('pharos-link', () => {
     const parentNode = document.createElement('div');
     parentNode.style.backgroundColor = PharosColorBlack;
 
-    component = await fixture(html`<pharos-link href="#" on-background>I am a link</pharos-link>`, {
-      parentNode,
-    });
+    component = await fixture(
+      html`<test-pharos-link href="#" on-background>I am a link</test-pharos-link>`,
+      {
+        parentNode,
+      }
+    );
     await expect(component).to.be.accessible();
   });
 
@@ -53,7 +56,7 @@ describe('pharos-link', () => {
 
   it('throws an error for an invalid target value', async () => {
     component = await fixture(html`
-      <pharos-link href="#" target="fake">I am a link</pharos-link>
+      <test-pharos-link href="#" target="fake">I am a link</test-pharos-link>
     `).catch((e) => e);
     expect('fake is not a valid target. Valid targets are: _blank, _parent, _self, _top').to.be
       .thrown;
@@ -70,7 +73,7 @@ describe('pharos-link', () => {
     component.href = '#test';
     await component.updateComplete;
 
-    const link = document.createElement('pharos-link') as PharosLink;
+    const link = document.createElement('test-pharos-link') as PharosLink;
     link.id = 'test';
     link.href = '#';
     link.textContent = 'I am a link';

--- a/packages/pharos/src/components/link/pharos-link.wc.stories.jsx
+++ b/packages/pharos/src/components/link/pharos-link.wc.stories.jsx
@@ -15,7 +15,7 @@ export default {
 export const Base = {
   render: (args) =>
     html` <div style="display: grid; grid-gap: 1rem; grid-template-columns: 300px;">
-      <pharos-link
+      <storybook-pharos-link
         ?bold=${args.bold}
         download=${ifDefined(args.download)}
         ?flex=${args.flex}
@@ -33,7 +33,7 @@ export const Base = {
         type=${ifDefined(args.type)}
       >
         ${args.text}
-      </pharos-link>
+      </storybook-pharos-link>
     </div>`,
   args: defaultArgs,
 };
@@ -42,8 +42,8 @@ export const VisitedLink = {
   render: () =>
     html`
       <div style="margin-bottom: 1rem">
-        <pharos-link href="https://www.google.com" target="_blank" indicate-visited
-          >Visited link</pharos-link
+        <storybook-pharos-link href="https://www.google.com" target="_blank" indicate-visited
+          >Visited link</storybook-pharos-link
         >
       </div>
     `,
@@ -53,9 +53,9 @@ export const VisitedLinkHeading = {
   render: () =>
     html`
       <div style="margin-bottom: 1rem">
-        <pharos-link href="https://www.google.com" target="_blank" indicate-visited>
-          <pharos-heading level="1"> Visited link heading </pharos-heading>
-        </pharos-link>
+        <storybook-pharos-link href="https://www.google.com" target="_blank" indicate-visited>
+          <storybook-pharos-heading level="1"> Visited link heading </storybook-pharos-heading>
+        </storybook-pharos-link>
       </div>
     `,
 };
@@ -64,10 +64,12 @@ export const Button = {
   render: () =>
     html`
       <div style="margin-bottom: 1rem">
-        <pharos-link name="primary">I am a button</pharos-link>
+        <storybook-pharos-link name="primary">I am a button</storybook-pharos-link>
       </div>
       <div style="background-color: #000000; padding: 1rem; margin-bottom: 1rem">
-        <pharos-link name="on-background" on-background>On compliant background</pharos-link>
+        <storybook-pharos-link name="on-background" on-background
+          >On compliant background</storybook-pharos-link
+        >
       </div>
     `,
 };
@@ -76,22 +78,24 @@ export const Variants = {
   render: () =>
     html`
       <div style="margin-bottom: 1rem">
-        <pharos-link name="primary" href="#">Primary link</pharos-link>
+        <storybook-pharos-link name="primary" href="#">Primary link</storybook-pharos-link>
       </div>
       <div style="margin-bottom: 1rem">
-        <pharos-link name="subtle" href="#" subtle>Subtle link</pharos-link>
+        <storybook-pharos-link name="subtle" href="#" subtle>Subtle link</storybook-pharos-link>
       </div>
       <div style="width:100px; margin-bottom: 1rem">
-        <pharos-link name="multi" href="#">I have text that spans multiple lines</pharos-link>
-      </div>
-      <div style="background-color: #000000; padding: 1rem; margin-bottom: 1rem">
-        <pharos-link name="on-background" href="#" on-background
-          >On compliant background</pharos-link
+        <storybook-pharos-link name="multi" href="#"
+          >I have text that spans multiple lines</storybook-pharos-link
         >
       </div>
       <div style="background-color: #000000; padding: 1rem; margin-bottom: 1rem">
-        <pharos-link name="on-background-subtle" href="#" on-background subtle
-          >On compliant background with subtle</pharos-link
+        <storybook-pharos-link name="on-background" href="#" on-background
+          >On compliant background</storybook-pharos-link
+        >
+      </div>
+      <div style="background-color: #000000; padding: 1rem; margin-bottom: 1rem">
+        <storybook-pharos-link name="on-background-subtle" href="#" on-background subtle
+          >On compliant background with subtle</storybook-pharos-link
         >
       </div>
     `,

--- a/packages/pharos/src/components/loading-spinner/PharosLoadingSpinner.react.stories.jsx
+++ b/packages/pharos/src/components/loading-spinner/PharosLoadingSpinner.react.stories.jsx
@@ -2,10 +2,18 @@ import { action } from '@storybook/addon-actions';
 
 import { PharosLoadingSpinner, PharosHeading, PharosButton } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Loading Spinner',
   component: PharosLoadingSpinner,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('loading-spinner') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.test.ts
+++ b/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.test.ts
@@ -7,7 +7,7 @@ describe('pharos-loading-spinner', () => {
   let component: PharosLoadingSpinner;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-loading-spinner></pharos-loading-spinner> `);
+    component = await fixture(html` <test-pharos-loading-spinner></test-pharos-loading-spinner> `);
   });
 
   it('is accessible', async () => {
@@ -46,7 +46,7 @@ describe('pharos-loading-spinner', () => {
     component = await fixture(
       html`
         <button @click="${onClick}">Can't press me!</button>
-        <pharos-loading-spinner></pharos-loading-spinner>
+        <test-pharos-loading-spinner></test-pharos-loading-spinner>
       `
     );
     const button = component.querySelector('button');

--- a/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.wc.stories.jsx
+++ b/packages/pharos/src/components/loading-spinner/pharos-loading-spinner.wc.stories.jsx
@@ -16,9 +16,13 @@ export default {
 export const Base = {
   render: () =>
     html`
-      <pharos-loading-spinner></pharos-loading-spinner>
-      <pharos-heading level="1" preset="5">Loading spinner demonstration</pharos-heading>
-      <pharos-button @click="${() => action('Click')('Clicked')}">Can't press me!</pharos-button>
+      <storybook-pharos-loading-spinner></storybook-pharos-loading-spinner>
+      <storybook-pharos-heading level="1" preset="5"
+        >Loading spinner demonstration</storybook-pharos-heading
+      >
+      <storybook-pharos-button @click="${() => action('Click')('Clicked')}"
+        >Can't press me!</storybook-pharos-button
+      >
     `,
 };
 
@@ -26,7 +30,7 @@ export const Scoped = {
   render: () =>
     html`
       <div style="height: 5rem; width: 5rem; border: 1px solid black; position: relative;">
-        <pharos-loading-spinner></pharos-loading-spinner>
+        <storybook-pharos-loading-spinner></storybook-pharos-loading-spinner>
       </div>
     `,
 };

--- a/packages/pharos/src/components/modal/PharosModal.react.stories.jsx
+++ b/packages/pharos/src/components/modal/PharosModal.react.stories.jsx
@@ -10,10 +10,18 @@ import {
 } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Modal',
   component: PharosModal,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('modal') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/modal/pharos-modal.test.ts
+++ b/packages/pharos/src/components/modal/pharos-modal.test.ts
@@ -10,31 +10,31 @@ describe('pharos-modal', () => {
 
   const getSimpleModal = () => {
     return html`
-      <pharos-modal id="my-modal" header="Pharos modal">
+      <test-pharos-modal id="my-modal" header="Pharos modal">
         I am a modal
         <div slot="footer">
           <button type="button" data-modal-close>Cancel</button>
           <button type="button">Ok</button>
         </div>
-      </pharos-modal>
+      </test-pharos-modal>
     `;
   };
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-modal header="Pharos modal">
+      <test-pharos-modal header="Pharos modal">
         <p>I am a modal</p>
         <div slot="footer">
           <button type="button" data-modal-close>Cancel</button>
           <button type="button">Ok</button>
         </div>
-      </pharos-modal>
+      </test-pharos-modal>
     `);
 
     componentNoFooter = await fixture(html`
-      <pharos-modal header="Pharos modal">
+      <test-pharos-modal header="Pharos modal">
         <p>I am a modal</p>
-      </pharos-modal>
+      </test-pharos-modal>
     `);
   });
 
@@ -90,20 +90,20 @@ describe('pharos-modal', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-modal header="Pharos modal">
-        <pharos-text-input style="margin-bottom: 1.5rem" data-modal-focus>
+      <test-pharos-modal header="Pharos modal">
+        <test-pharos-text-input style="margin-bottom: 1.5rem" data-modal-focus>
           <span slot="label">Name</span>
-        </pharos-text-input>
+        </test-pharos-text-input>
         <div slot="footer">
           <button type="button" data-modal-close>Cancel</button>
           <button type="button">Ok</button>
         </div>
-      </pharos-modal>
+      </test-pharos-modal>
     `);
     component.open = true;
     await component.updateComplete;
 
-    const input = component.querySelector('pharos-text-input') as PharosTextInput;
+    const input = component.querySelector('test-pharos-text-input') as PharosTextInput;
 
     expect(activeElement === input['_input']).to.be.true;
     document.removeEventListener('focusin', onFocusIn);
@@ -118,7 +118,7 @@ describe('pharos-modal', () => {
 
     const trigger = document.createElement('button');
     const handleClick = (): void => {
-      const modal = document.querySelector('pharos-modal') as PharosModal;
+      const modal = document.querySelector('test-pharos-modal') as PharosModal;
       modal.open = true;
     };
     trigger.setAttribute('id', 'trigger');
@@ -366,9 +366,9 @@ describe('pharos-modal', () => {
   });
 
   it('throws an error for an invalid size value', async () => {
-    component = await fixture(html` <pharos-modal size="fake">Hi there!</pharos-modal> `).catch(
-      (e) => e
-    );
+    component = await fixture(
+      html` <test-pharos-modal size="fake">Hi there!</test-pharos-modal> `
+    ).catch((e) => e);
     expect('fake is not a valid size. Valid sizes are: small, medium, large').to.be.thrown;
   });
 

--- a/packages/pharos/src/components/modal/pharos-modal.wc.stories.jsx
+++ b/packages/pharos/src/components/modal/pharos-modal.wc.stories.jsx
@@ -18,7 +18,7 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-button
+      <storybook-pharos-button
         @click="${(e) => {
           e.target.focus();
           const modal = document.querySelector('pharos-modal');
@@ -26,18 +26,18 @@ export const Base = {
         }}"
       >
         Open modal
-      </pharos-button>
-      <pharos-modal
+      </storybook-pharos-button>
+      <storybook-pharos-modal
         ?footer-divider=${ifDefined(args.footerDivider)}
         header=${ifDefined(args.header)}
         ?open=${ifDefined(args.open)}
         size=${ifDefined(args.size)}
       >
         <p>I am a modal</p>
-        <pharos-button slot="footer" type="button" variant="secondary" data-modal-close>
+        <storybook-pharos-button slot="footer" type="button" variant="secondary" data-modal-close>
           Cancel
-        </pharos-button>
-        <pharos-button
+        </storybook-pharos-button>
+        <storybook-pharos-button
           slot="footer"
           type="button"
           @click="${() => {
@@ -46,8 +46,8 @@ export const Base = {
           }}"
         >
           Ok
-        </pharos-button>
-      </pharos-modal>
+        </storybook-pharos-button>
+      </storybook-pharos-modal>
     `,
   args: defaultArgs,
 };
@@ -55,7 +55,7 @@ export const Base = {
 export const NoFooter = {
   render: () =>
     html`
-      <pharos-button
+      <storybook-pharos-button
         @click="${(e) => {
           e.target.focus();
           const modal = document.querySelector('pharos-modal');
@@ -63,17 +63,17 @@ export const NoFooter = {
         }}"
       >
         Open modal
-      </pharos-button>
-      <pharos-modal header="Pharos modal" size="medium">
+      </storybook-pharos-button>
+      <storybook-pharos-modal header="Pharos modal" size="medium">
         <p>I am a modal</p>
-      </pharos-modal>
+      </storybook-pharos-modal>
     `,
 };
 
 export const Events = {
   render: () =>
     html`
-      <pharos-button
+      <storybook-pharos-button
         type="button"
         data-modal-id="my-event-modal"
         @click="${(e) => {
@@ -81,8 +81,8 @@ export const Events = {
         }}"
       >
         Open modal
-      </pharos-button>
-      <pharos-modal
+      </storybook-pharos-button>
+      <storybook-pharos-modal
         id="my-event-modal"
         header="Event modal"
         open
@@ -92,20 +92,20 @@ export const Events = {
         @pharos-modal-closed="${(e) => action('Closed')(e.detail)}"
       >
         <p slot="description">Description for the modal</p>
-        <pharos-text-input style="margin-bottom: 1rem" data-modal-focus>
+        <storybook-pharos-text-input style="margin-bottom: 1rem" data-modal-focus>
           <span slot="label">Name</span>
-        </pharos-text-input>
-        <pharos-text-input style="margin-bottom: 1rem">
+        </storybook-pharos-text-input>
+        <storybook-pharos-text-input style="margin-bottom: 1rem">
           <span slot="label">User ID</span>
-        </pharos-text-input>
-        <pharos-text-input style="margin-bottom: 1rem">
+        </storybook-pharos-text-input>
+        <storybook-pharos-text-input style="margin-bottom: 1rem">
           <span slot="label">Favorite Color</span>
-        </pharos-text-input>
-        <pharos-button slot="footer" type="button" variant="secondary" data-modal-close>
+        </storybook-pharos-text-input>
+        <storybook-pharos-button slot="footer" type="button" variant="secondary" data-modal-close>
           Cancel
-        </pharos-button>
-        <pharos-button slot="footer" type="button">Submit</pharos-button>
-      </pharos-modal>
+        </storybook-pharos-button>
+        <storybook-pharos-button slot="footer" type="button">Submit</storybook-pharos-button>
+      </storybook-pharos-modal>
     `,
   parameters: { selectedPanel: 'addon-actions' },
 };
@@ -113,7 +113,7 @@ export const Events = {
 export const Composition = {
   render: () =>
     html`
-      <pharos-button
+      <storybook-pharos-button
         type="button"
         data-modal-id="my-alert-modal"
         @click="${(e) => {
@@ -121,22 +121,24 @@ export const Composition = {
         }}"
       >
         Open modal
-      </pharos-button>
-      <pharos-modal id="my-alert-modal" header="Add external link" open>
+      </storybook-pharos-button>
+      <storybook-pharos-modal id="my-alert-modal" header="Add external link" open>
         <div>
-          <pharos-alert style="margin-bottom: 1rem" status="error"
+          <storybook-pharos-alert style="margin-bottom: 1rem" status="error"
             >We're sorry, we experienced an issue submitting your report. Please try again. If the
             issue persists, contact
-            <pharos-link id="support-link" href="#">support@jstor.org</pharos-link>.
-          </pharos-alert>
-          <pharos-text-input name="link" required style="margin-bottom: 1rem">
+            <storybook-pharos-link id="support-link" href="#"
+              >support@jstor.org</storybook-pharos-link
+            >.
+          </storybook-pharos-alert>
+          <storybook-pharos-text-input name="link" required style="margin-bottom: 1rem">
             <span slot="label">Link</span>
-          </pharos-text-input>
-          <pharos-text-input name="text" required style="margin-bottom: 1rem">
+          </storybook-pharos-text-input>
+          <storybook-pharos-text-input name="text" required style="margin-bottom: 1rem">
             <span slot="label">Text</span>
-          </pharos-text-input>
+          </storybook-pharos-text-input>
         </div>
-        <pharos-button
+        <storybook-pharos-button
           id="cancel-button"
           slot="footer"
           type="button"
@@ -144,9 +146,11 @@ export const Composition = {
           data-modal-close
         >
           Cancel
-        </pharos-button>
-        <pharos-button id="add-button" slot="footer" type="button">Add</pharos-button>
-      </pharos-modal>
+        </storybook-pharos-button>
+        <storybook-pharos-button id="add-button" slot="footer" type="button"
+          >Add</storybook-pharos-button
+        >
+      </storybook-pharos-modal>
     `,
   parameters: { chromatic: { viewports: [320, 1200] } },
 };

--- a/packages/pharos/src/components/pagination/PharosPagination.react.stories.jsx
+++ b/packages/pharos/src/components/pagination/PharosPagination.react.stories.jsx
@@ -3,10 +3,18 @@ import { action } from '@storybook/addon-actions';
 import { PharosPagination } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Pagination',
   component: PharosPagination,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('pagination') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/pagination/pharos-pagination.test.ts
+++ b/packages/pharos/src/components/pagination/pharos-pagination.test.ts
@@ -7,7 +7,7 @@ describe('pharos-pagination', () => {
   let component: PharosPagination;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-pagination></pharos-pagination> `);
+    component = await fixture(html` <test-pharos-pagination></test-pharos-pagination> `);
   });
 
   it('is accessible', async () => {
@@ -15,21 +15,29 @@ describe('pharos-pagination', () => {
   });
 
   it('sets its default attributes', async () => {
-    component = await fixture(html` <pharos-pagination></pharos-pagination> `);
+    component = await fixture(html` <test-pharos-pagination></test-pharos-pagination> `);
     expect(component).dom.to.equal(
-      `<pharos-pagination current-page="1" data-pharos-component="PharosPagination" total-results="0" page-size="25"></pharos-pagination>`
+      `<test-pharos-pagination current-page="1" data-pharos-component="PharosPagination" total-results="0" page-size="25"></test-pharos-pagination>`
     );
   });
 
   it('shows/hides previous page link correctly', async () => {
     component = await fixture(html`
-      <pharos-pagination current-page="1" total-results="0" page-size="25"></pharos-pagination>
+      <test-pharos-pagination
+        current-page="1"
+        total-results="0"
+        page-size="25"
+      ></test-pharos-pagination>
     `);
     let prevLink = component.renderRoot.querySelector('.prev') as HTMLElement;
     expect(prevLink).not.to.exist;
 
     component = await fixture(html`
-      <pharos-pagination current-page="2" total-results="0" page-size="25"></pharos-pagination>
+      <test-pharos-pagination
+        current-page="2"
+        total-results="0"
+        page-size="25"
+      ></test-pharos-pagination>
     `);
     prevLink = component.renderRoot.querySelector('.prev') as HTMLElement;
     expect(prevLink).to.exist;
@@ -37,13 +45,21 @@ describe('pharos-pagination', () => {
 
   it('shows/hides next page link correctly', async () => {
     component = await fixture(html`
-      <pharos-pagination current-page="1" total-results="112" page-size="25"></pharos-pagination>
+      <test-pharos-pagination
+        current-page="1"
+        total-results="112"
+        page-size="25"
+      ></test-pharos-pagination>
     `);
     let nextLink = component.renderRoot.querySelector('.next') as HTMLElement;
     expect(nextLink).to.exist;
 
     component = await fixture(html`
-      <pharos-pagination current-page="5" total-results="112" page-size="25"></pharos-pagination>
+      <test-pharos-pagination
+        current-page="5"
+        total-results="112"
+        page-size="25"
+      ></test-pharos-pagination>
     `);
     nextLink = component.renderRoot.querySelector('.next') as HTMLElement;
     expect(nextLink).not.to.exist;
@@ -59,13 +75,13 @@ describe('pharos-pagination', () => {
       nextPageCount++;
     };
     component = await fixture(html`
-      <pharos-pagination
+      <test-pharos-pagination
         current-page="3"
         total-results="112"
         page-size="25"
         @prev-page="${onPrevClick}"
         @next-page="${onNextClick}"
-      ></pharos-pagination>
+      ></test-pharos-pagination>
     `);
 
     const prevLink = component.renderRoot.querySelector('.prev') as HTMLElement;
@@ -90,13 +106,13 @@ describe('pharos-pagination', () => {
       nextPageCount++;
     };
     component = await fixture(html`
-      <pharos-pagination
+      <test-pharos-pagination
         current-page="3"
         total-results="112"
         page-size="25"
         @prev-page="${onPrevClick}"
         @next-page="${onNextClick}"
-      ></pharos-pagination>
+      ></test-pharos-pagination>
     `);
 
     const prevLinkChildElement = component.renderRoot.querySelector('.prev')
@@ -115,7 +131,7 @@ describe('pharos-pagination', () => {
 
   it('throws an error for an invalid total results value', async () => {
     component = await fixture(
-      html` <pharos-pagination total-results="-1"></pharos-pagination> `
+      html` <test-pharos-pagination total-results="-1"></test-pharos-pagination> `
     ).catch((e) => e);
     expect("totalResults value '-1' is invalid. Can only be a number greater than or equal to 0").to
       .be.thrown;
@@ -123,7 +139,7 @@ describe('pharos-pagination', () => {
 
   it('throws an error for an invalid page size value', async () => {
     component = await fixture(
-      html` <pharos-pagination page-size="1.5"></pharos-pagination> `
+      html` <test-pharos-pagination page-size="1.5"></test-pharos-pagination> `
     ).catch((e) => e);
     expect("pageSize value '1.5' is invalid. Can only be a number greater than or equal to 1").to.be
       .thrown;
@@ -131,7 +147,7 @@ describe('pharos-pagination', () => {
 
   it('throws an error for an invalid current page value', async () => {
     component = await fixture(
-      html` <pharos-pagination current-page="0"></pharos-pagination> `
+      html` <test-pharos-pagination current-page="0"></test-pharos-pagination> `
     ).catch((e) => e);
     expect("currentPage value '0' is invalid. Can only be a number greater than or equal to 1").to
       .be.thrown;

--- a/packages/pharos/src/components/pagination/pharos-pagination.wc.stories.jsx
+++ b/packages/pharos/src/components/pagination/pharos-pagination.wc.stories.jsx
@@ -16,13 +16,13 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-pagination
+      <storybook-pharos-pagination
         total-results=${args.totalResults}
         page-size=${args.pageSize}
         current-page=${args.currentPage}
         @prev-page="${(e) => action('Prev Page')(JSON.stringify(e))}"
         @next-page="${(e) => action('Next Page')(JSON.stringify(e))}"
-      ></pharos-pagination>
+      ></storybook-pharos-pagination>
     `,
   args: defaultArgs,
 };

--- a/packages/pharos/src/components/progress-bar/PharosProgressBar.react.stories.jsx
+++ b/packages/pharos/src/components/progress-bar/PharosProgressBar.react.stories.jsx
@@ -1,10 +1,18 @@
 import { PharosProgressBar } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Progress Bar',
   component: PharosProgressBar,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('progress-bar') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/progress-bar/pharos-progress-bar.test.ts
+++ b/packages/pharos/src/components/progress-bar/pharos-progress-bar.test.ts
@@ -8,7 +8,7 @@ describe('pharos-progress-bar', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html` <pharos-progress-bar><div slot="title">Title.xls</div></pharos-progress-bar> `
+      html` <test-pharos-progress-bar><div slot="title">Title.xls</div></test-pharos-progress-bar> `
     );
   });
 
@@ -18,27 +18,31 @@ describe('pharos-progress-bar', () => {
 
   it('sets its default attributes', async () => {
     component = await fixture(html`
-      <pharos-progress-bar>
+      <test-pharos-progress-bar>
         <div slot="title">Click.xls</div>
         <div slot="description">Processing headers</div>
-      </pharos-progress-bar>
+      </test-pharos-progress-bar>
     `);
     expect(component).dom.to.equal(
-      `<pharos-progress-bar data-pharos-component="PharosProgressBar" value="0">
+      `<test-pharos-progress-bar data-pharos-component="PharosProgressBar" value="0">
         <div slot="title">Click.xls</div>
         <div slot="description">Processing headers</div>
-      </pharos-progress-bar>`
+      </test-pharos-progress-bar>`
     );
   });
 
   it('renders the progress bar with the inserted value and the correct width', async () => {
-    component = await fixture(html` <pharos-progress-bar value="20"></pharos-progress-bar> `);
+    component = await fixture(
+      html` <test-pharos-progress-bar value="20"></test-pharos-progress-bar> `
+    );
     const internalBar = component.renderRoot.querySelector('.progress-bar') as HTMLDivElement;
     expect(internalBar?.style.width).to.equal('20%');
   });
 
   it('renders the progress bar with the correct gradient percentage', async () => {
-    component = await fixture(html` <pharos-progress-bar value="40"></pharos-progress-bar> `);
+    component = await fixture(
+      html` <test-pharos-progress-bar value="40"></test-pharos-progress-bar> `
+    );
     const internalBar = component.renderRoot.querySelector('.progress-bar') as HTMLDivElement;
     const slicedBackgroundColor = internalBar?.style.background;
 

--- a/packages/pharos/src/components/progress-bar/pharos-progress-bar.wc.stories.jsx
+++ b/packages/pharos/src/components/progress-bar/pharos-progress-bar.wc.stories.jsx
@@ -16,10 +16,10 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-progress-bar value=${args.value}>
+      <storybook-pharos-progress-bar value=${args.value}>
         <div slot="title">${args.title}</div>
         <div slot="description">${args.description}</div>
-      </pharos-progress-bar>
+      </storybook-pharos-progress-bar>
     `,
   args: defaultArgs,
 };

--- a/packages/pharos/src/components/radio-button/PharosRadioButton.react.stories.jsx
+++ b/packages/pharos/src/components/radio-button/PharosRadioButton.react.stories.jsx
@@ -4,9 +4,18 @@ import { action } from '@storybook/addon-actions';
 import { PharosRadioButton, PharosLink } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Radio Button',
+  component: PharosRadioButton,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('radio-button') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.test.ts
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.test.ts
@@ -10,7 +10,9 @@ describe('pharos-radio-button', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html`<pharos-radio-button><span slot="label">test radio</span></pharos-radio-button>`
+      html`<test-pharos-radio-button
+        ><span slot="label">test radio</span></test-pharos-radio-button
+      >`
     );
   });
 
@@ -26,15 +28,17 @@ describe('pharos-radio-button', () => {
 
   it('is accessible when disabled', async () => {
     component = await fixture(html`
-      <pharos-radio-button disabled><span slot="label">test radio</span></pharos-radio-button>
+      <test-pharos-radio-button disabled
+        ><span slot="label">test radio</span></test-pharos-radio-button
+      >
     `);
     await expect(component).to.be.accessible();
   });
 
   it('has an attribute to set check value', async () => {
     component = await fixture(html`
-      <pharos-radio-button ?checked=${true}
-        ><span slot="label">test radio</span></pharos-radio-button
+      <test-pharos-radio-button ?checked=${true}
+        ><span slot="label">test radio</span></test-pharos-radio-button
       >
     `);
     await expect(component.checked).to.equal(true);
@@ -46,8 +50,8 @@ describe('pharos-radio-button', () => {
       eventSource = event.composedPath()[0] as Element;
     };
     component = await fixture(html`
-      <pharos-radio-button value="1" @change=${onChange}
-        ><span slot="label">test radio</span></pharos-radio-button
+      <test-pharos-radio-button value="1" @change=${onChange}
+        ><span slot="label">test radio</span></test-pharos-radio-button
       >
     `);
     component['_radio'].click();
@@ -77,7 +81,9 @@ describe('pharos-radio-button', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-button disabled><span slot="label">test radio</span></pharos-radio-button>
+      <test-pharos-radio-button disabled
+        ><span slot="label">test radio</span></test-pharos-radio-button
+      >
     `);
 
     component['_radio'].focus();
@@ -92,9 +98,9 @@ describe('pharos-radio-button', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-radio-button name="my-radio" value="test" checked>
+        <test-pharos-radio-button name="my-radio" value="test" checked>
           <span slot="label">test radio</span>
-        </pharos-radio-button>
+        </test-pharos-radio-button>
       `,
       { parentNode }
     );
@@ -110,9 +116,9 @@ describe('pharos-radio-button', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-radio-button name="my-radio" value="test" disabled>
+        <test-pharos-radio-button name="my-radio" value="test" disabled>
           <span slot="label">test radio</span>
-        </pharos-radio-button>
+        </test-pharos-radio-button>
       `,
       { parentNode }
     );
@@ -131,9 +137,9 @@ describe('pharos-radio-button', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-button hide-label>
+      <test-pharos-radio-button hide-label>
         <span slot="label">test radio</span>
-      </pharos-radio-button>
+      </test-pharos-radio-button>
     `);
 
     const icon = component.renderRoot.querySelector('svg') as SVGElement;
@@ -152,7 +158,7 @@ describe('pharos-radio-button', () => {
     };
     document.addEventListener('focusin', onFocusIn);
 
-    component = await fixture(html` <pharos-radio-button></pharos-radio-button> `);
+    component = await fixture(html` <test-pharos-radio-button></test-pharos-radio-button> `);
 
     const icon = component.renderRoot.querySelector('svg') as SVGElement;
     icon.dispatchEvent(new Event('click'));
@@ -178,8 +184,8 @@ describe('pharos-radio-button', () => {
 
   it('allows links in the label to be clicked', async () => {
     component = await fixture(html`
-      <pharos-radio-button
-        ><span slot="label">test radio with <a href="#">link</a></span></pharos-radio-button
+      <test-pharos-radio-button
+        ><span slot="label">test radio with <a href="#">link</a></span></test-pharos-radio-button
       >
     `);
     const link = component.renderRoot.querySelector('a');
@@ -191,13 +197,13 @@ describe('pharos-radio-button', () => {
 
   it('allows Pharos links in the label to be clicked', async () => {
     component = await fixture(html`
-      <pharos-radio-button
+      <test-pharos-radio-button
         ><span slot="label"
-          >test radio with <pharos-link href="#">link</pharos-link></span
-        ></pharos-radio-button
+          >test radio with <test-pharos-link href="#">link</test-pharos-link></span
+        ></test-pharos-radio-button
       >
     `);
-    const link = component.querySelector('pharos-link') as PharosLink;
+    const link = component.querySelector('test-pharos-link') as PharosLink;
     const anchor = link?.renderRoot.querySelector('#link-element') as HTMLAnchorElement;
     anchor.click();
     await component.updateComplete;
@@ -211,9 +217,9 @@ describe('pharos-radio-button', () => {
       count++;
     };
     component = await fixture(html`
-      <pharos-radio-button value="1" @click=${onClick}>
+      <test-pharos-radio-button value="1" @click=${onClick}>
         <span slot="label">test radio</span>
-      </pharos-radio-button>
+      </test-pharos-radio-button>
     `);
 
     const label = component.renderRoot.querySelector('label') as HTMLLabelElement;
@@ -227,9 +233,9 @@ describe('pharos-radio-button', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-radio-button name="my-radio" value="test" checked>
+        <test-pharos-radio-button name="my-radio" value="test" checked>
           <span slot="label">test radio</span>
-        </pharos-radio-button>
+        </test-pharos-radio-button>
       `,
       { parentNode }
     );

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.wc.stories.jsx
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.wc.stories.jsx
@@ -15,7 +15,7 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-radio-button
+      <storybook-pharos-radio-button
         ?checked=${args.checked}
         ?disabled=${args.disabled}
         ?hide-label=${args.hideLabel}
@@ -24,7 +24,7 @@ export const Base = {
         .message=${args.message}
       >
         <span slot="label">${args.label}</span>
-      </pharos-radio-button>
+      </storybook-pharos-radio-button>
     `,
   args: defaultArgs,
 };
@@ -33,36 +33,36 @@ export const States = {
   render: () =>
     html`
       <div>
-        <pharos-radio-button name="base"><span slot="label">Default Radio Button</span></pharos-radio-button>
+        <storybook-pharos-radio-button name="base"><span slot="label">Default Radio Button</span></storybook-pharos-radio-button>
       </div>
       <div>
-        <pharos-radio-button name="disabled" disabled><span slot="label">Disabled input</span></pharos-radio-button>
+        <storybook-pharos-radio-button name="disabled" disabled><span slot="label">Disabled input</span></storybook-pharos-radio-button>
       </div>
       <div>
-        <pharos-radio-button name="checked" checked><span slot="label">Checked button</span></pharos-radio-button>
+        <storybook-pharos-radio-button name="checked" checked><span slot="label">Checked button</span></storybook-pharos-radio-button>
       </div>
       <div>
-        <pharos-radio-button name="checked-disabled" checked disabled>
+        <storybook-pharos-radio-button name="checked-disabled" checked disabled>
           <span slot="label">Checked & Disabled</span>
-        </pharos-radio-button>
+        </storybook-pharos-radio-button>
       </div>
       <div>
-        <pharos-radio-button name="multi" checked>
+        <storybook-pharos-radio-button name="multi" checked>
           <div slot="label">
             <div>Checked button</div>
             <div>Multiple lines</div>
           </div>
-        </pharos-radio-button>
+        </storybook-pharos-radio-button>
       </div>
       <div>
-        <pharos-radio-button name="invalidated" invalidated><span slot="label">Error button</span></pharos-checkbox>
+        <storybook-pharos-radio-button name="invalidated" invalidated><span slot="label">Error button</span></storybook-pharos-checkbox>
       </div>
       <div>
-        <pharos-radio-button name="with-link">
+        <storybook-pharos-radio-button name="with-link">
           <span slot="label">
-            Label with a <pharos-link href="#">link</pharos-link>
+            Label with a <storybook-pharos-link href="#">link</storybook-pharos-link>
           </span>
-        </pharos-radio-button>
+        </storybook-pharos-radio-button>
       </div>
     `,
 };
@@ -70,14 +70,14 @@ export const States = {
 export const Events = {
   render: () =>
     html`
-      <pharos-radio-button
+      <storybook-pharos-radio-button
         value="My value"
         @change="${(e) => action('Change')(e.target.checked)}"
         @input="${(e) => action('Input')(e.target.value)}"
         @click="${(e) => action('Click')(e.target.checked)}"
       >
         <span slot="label">I fire events</span>
-      </pharos-radio-button>
+      </storybook-pharos-radio-button>
     `,
   parameters: { options: { selectedPanel: 'addon-actions' } },
 };

--- a/packages/pharos/src/components/radio-group/PharosRadioGroup.react.stories.jsx
+++ b/packages/pharos/src/components/radio-group/PharosRadioGroup.react.stories.jsx
@@ -4,11 +4,19 @@ import { PharosRadioGroup, PharosRadioButton, PharosButton } from '../../react-c
 import createFormData from '../../utils/createFormData';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Radio Group',
   component: PharosRadioGroup,
   subcomponents: { PharosRadioButton },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('radio-group') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.test.ts
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.test.ts
@@ -11,15 +11,15 @@ describe('pharos-radio-group', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-radio-group name="radio-group">
+      <test-pharos-radio-group name="radio-group">
         <span slot="legend">Radio Group Header</span>
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
   });
 
@@ -35,28 +35,28 @@ describe('pharos-radio-group', () => {
 
   it('updates value when a child radio is checked', async () => {
     component = await fixture(html`
-      <pharos-radio-group>
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group>
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2" checked
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2" checked
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
     expect(component.value).to.equal('2');
   });
 
   it('has an attribute to set orientation', async () => {
     component = await fixture(html`
-      <pharos-radio-group horizontal>
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group horizontal>
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2" checked
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2" checked
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
     const fieldset = component.renderRoot.querySelector('fieldset') as HTMLElement;
     expect(fieldset.classList.contains('radio-group--horizontal')).to.be.true;
@@ -68,16 +68,18 @@ describe('pharos-radio-group', () => {
       eventSource = event.composedPath()[0] as Element;
     };
     component = await fixture(html`
-      <pharos-radio-group @change=${onChange}>
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group @change=${onChange}>
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
-    const radio = component.querySelector('pharos-radio-button[value="2"]') as PharosRadioButton;
+    const radio = component.querySelector(
+      'test-pharos-radio-button[value="2"]'
+    ) as PharosRadioButton;
     radio['_radio'].click();
     await component.updateComplete;
 
@@ -86,17 +88,17 @@ describe('pharos-radio-group', () => {
 
   it('sets the name for each radio in the group', async () => {
     component = await fixture(html`
-      <pharos-radio-group name="group1">
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group name="group1">
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
     const buttons = component.querySelectorAll(
-      'pharos-radio-button'
+      'test-pharos-radio-button'
     ) as NodeListOf<PharosRadioButton>;
     buttons.forEach((button) => {
       expect(button.name).to.equal('group1');
@@ -111,19 +113,21 @@ describe('pharos-radio-group', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-group name="group1">
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group name="group1">
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="3"
-          ><span slot="label">Radio Button 3</span></pharos-radio-button
+        <test-pharos-radio-button value="3"
+          ><span slot="label">Radio Button 3</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
-    const radio = component.querySelector('pharos-radio-button[value="2"]') as PharosRadioButton;
+    const radio = component.querySelector(
+      'test-pharos-radio-button[value="2"]'
+    ) as PharosRadioButton;
     radio['_radio'].click();
     await component.updateComplete;
 
@@ -131,7 +135,7 @@ describe('pharos-radio-group', () => {
     await component.updateComplete;
 
     const checkedRadio = component.querySelector(
-      'pharos-radio-button[checked]'
+      'test-pharos-radio-button[checked]'
     ) as PharosRadioButton;
 
     expect(checkedRadio.checked).to.equal(true);
@@ -148,19 +152,21 @@ describe('pharos-radio-group', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-group name="group1">
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group name="group1">
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="3"
-          ><span slot="label">Radio Button 3</span></pharos-radio-button
+        <test-pharos-radio-button value="3"
+          ><span slot="label">Radio Button 3</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
-    const radio = component.querySelector('pharos-radio-button[value="2"]') as PharosRadioButton;
+    const radio = component.querySelector(
+      'test-pharos-radio-button[value="2"]'
+    ) as PharosRadioButton;
     radio['_radio'].click();
     await component.updateComplete;
 
@@ -168,7 +174,7 @@ describe('pharos-radio-group', () => {
     await component.updateComplete;
 
     const checkedRadio = component.querySelector(
-      'pharos-radio-button[checked]'
+      'test-pharos-radio-button[checked]'
     ) as PharosRadioButton;
 
     expect(checkedRadio.checked).to.equal(true);
@@ -185,19 +191,21 @@ describe('pharos-radio-group', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-group name="group1">
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group name="group1">
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="3"
-          ><span slot="label">Radio Button 3</span></pharos-radio-button
+        <test-pharos-radio-button value="3"
+          ><span slot="label">Radio Button 3</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
-    const radio = component.querySelector('pharos-radio-button[value="3"]') as PharosRadioButton;
+    const radio = component.querySelector(
+      'test-pharos-radio-button[value="3"]'
+    ) as PharosRadioButton;
     radio['_radio'].click();
     await component.updateComplete;
 
@@ -205,7 +213,7 @@ describe('pharos-radio-group', () => {
     await component.updateComplete;
 
     const checkedRadio = component.querySelector(
-      'pharos-radio-button[checked]'
+      'test-pharos-radio-button[checked]'
     ) as PharosRadioButton;
 
     expect(checkedRadio.checked).to.equal(true);
@@ -222,19 +230,21 @@ describe('pharos-radio-group', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-group name="group1">
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group name="group1">
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="3"
-          ><span slot="label">Radio Button 3</span></pharos-radio-button
+        <test-pharos-radio-button value="3"
+          ><span slot="label">Radio Button 3</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
-    const radio = component.querySelector('pharos-radio-button[value="1"]') as PharosRadioButton;
+    const radio = component.querySelector(
+      'test-pharos-radio-button[value="1"]'
+    ) as PharosRadioButton;
     radio['_radio'].click();
     await component.updateComplete;
 
@@ -242,7 +252,7 @@ describe('pharos-radio-group', () => {
     await component.updateComplete;
 
     const checkedRadio = component.querySelector(
-      'pharos-radio-button[checked]'
+      'test-pharos-radio-button[checked]'
     ) as PharosRadioButton;
 
     expect(checkedRadio.checked).to.equal(true);
@@ -259,24 +269,26 @@ describe('pharos-radio-group', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-group name="group1">
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group name="group1">
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="3"
-          ><span slot="label">Radio Button 3</span></pharos-radio-button
+        <test-pharos-radio-button value="3"
+          ><span slot="label">Radio Button 3</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
-    const radio = component.querySelector('pharos-radio-button[value="2"]') as PharosRadioButton;
+    const radio = component.querySelector(
+      'test-pharos-radio-button[value="2"]'
+    ) as PharosRadioButton;
     radio['_radio'].click();
     await component.updateComplete;
 
     const checkedRadio = component.querySelector(
-      'pharos-radio-button[checked]'
+      'test-pharos-radio-button[checked]'
     ) as PharosRadioButton;
 
     expect(activeElement === checkedRadio['_radio']).to.be.true;
@@ -289,7 +301,7 @@ describe('pharos-radio-group', () => {
       activeElement = event.composedPath()[0];
     };
     document.addEventListener('focusin', onFocusIn);
-    const radio = component.querySelector('pharos-radio-button') as PharosRadioButton;
+    const radio = component.querySelector('test-pharos-radio-button') as PharosRadioButton;
 
     component.focus();
 
@@ -301,11 +313,15 @@ describe('pharos-radio-group', () => {
     const text = 'Please make a selection';
     component = await fixture(
       html`
-        <pharos-radio-group message="${text}">
+        <test-pharos-radio-group message="${text}">
           <span slot="legend">Radio Group Header</span>
-          <pharos-radio-button value="1"><span slot="label">Radio 1</span></pharos-radio-button>
-          <pharos-radio-button value="2"><span slot="label">Radio 2</span></pharos-radio-button>
-        </pharos-radio-group>
+          <test-pharos-radio-button value="1"
+            ><span slot="label">Radio 1</span></test-pharos-radio-button
+          >
+          <test-pharos-radio-button value="2"
+            ><span slot="label">Radio 2</span></test-pharos-radio-button
+          >
+        </test-pharos-radio-group>
       `
     );
     const message = component.renderRoot.querySelector('.input-message__text');
@@ -316,7 +332,9 @@ describe('pharos-radio-group', () => {
     const event = new Event('change');
     const changeSpy: SinonSpy = sinon.spy(event, 'stopPropagation');
 
-    const radio = component.querySelector('pharos-radio-button[value="2"]') as PharosRadioButton;
+    const radio = component.querySelector(
+      'test-pharos-radio-button[value="2"]'
+    ) as PharosRadioButton;
     radio.dispatchEvent(event);
     await component.updateComplete;
 
@@ -325,7 +343,7 @@ describe('pharos-radio-group', () => {
 
   it('updates the state of its children', async () => {
     const radios = component.querySelectorAll(
-      'pharos-radio-button'
+      'test-pharos-radio-button'
     ) as NodeListOf<PharosRadioButton>;
     component.disabled = true;
     await component.updateComplete;
@@ -352,24 +370,24 @@ describe('pharos-radio-group', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(html`
-      <pharos-radio-group>
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+      <test-pharos-radio-group>
+        <test-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></test-pharos-radio-button
         >
-        <pharos-radio-button value="2" checked
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <test-pharos-radio-button value="2" checked
+          ><span slot="label">Radio Button 2</span></test-pharos-radio-button
         >
-      </pharos-radio-group>
+      </test-pharos-radio-group>
     `);
 
     const firstRadio = component.querySelector(
-      'pharos-radio-button[value="1"]'
+      'test-pharos-radio-button[value="1"]'
     ) as PharosRadioButton;
     firstRadio.dispatchEvent(new Event('focusin'));
     await nextFrame();
 
     const checkedRadio = component.querySelector(
-      'pharos-radio-button[checked]'
+      'test-pharos-radio-button[checked]'
     ) as PharosRadioButton;
 
     expect(activeElement === checkedRadio['_radio']).to.be.true;

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.wc.stories.jsx
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.wc.stories.jsx
@@ -18,7 +18,7 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-radio-group
+      <storybook-pharos-radio-group
         name=${args.name}
         ?horizontal=${args.horizontal}
         ?disabled=${args.disabled}
@@ -29,36 +29,40 @@ export const Base = {
         .message=${args.message}
       >
         <span slot="legend">Radio Group Header</span>
-        <pharos-radio-button value="1"
-          ><span slot="label">Radio Button 1</span></pharos-radio-button
+        <storybook-pharos-radio-button value="1"
+          ><span slot="label">Radio Button 1</span></storybook-pharos-radio-button
         >
-        <pharos-radio-button value="2"
-          ><span slot="label">Radio Button 2</span></pharos-radio-button
+        <storybook-pharos-radio-button value="2"
+          ><span slot="label">Radio Button 2</span></storybook-pharos-radio-button
         >
-        <pharos-radio-button value="3"
-          ><span slot="label">Radio Button 3</span></pharos-radio-button
+        <storybook-pharos-radio-button value="3"
+          ><span slot="label">Radio Button 3</span></storybook-pharos-radio-button
         >
-        <pharos-radio-button value="4"
-          ><span slot="label">Radio Button 4</span></pharos-radio-button
+        <storybook-pharos-radio-button value="4"
+          ><span slot="label">Radio Button 4</span></storybook-pharos-radio-button
         >
-      </pharos-radio-group>
+      </storybook-pharos-radio-group>
     `,
   args: defaultArgs,
 };
 
 export const Events = {
   render: () =>
-    html` <pharos-radio-group
+    html` <storybook-pharos-radio-group
       @change="${(e) => action('Change')(e.target.value)}"
       name="radio-group2"
     >
       <span slot="legend">Radio Group Header</span>
-      <pharos-radio-button value="1"><span slot="label">Radio Button 1</span></pharos-radio-button>
-      <pharos-radio-button value="2" checked
-        ><span slot="label">Radio Button 2</span></pharos-radio-button
+      <storybook-pharos-radio-button value="1"
+        ><span slot="label">Radio Button 1</span></storybook-pharos-radio-button
       >
-      <pharos-radio-button value="3"><span slot="label">Radio Button 3</span></pharos-radio-button>
-    </pharos-radio-group>`,
+      <storybook-pharos-radio-button value="2" checked
+        ><span slot="label">Radio Button 2</span></storybook-pharos-radio-button
+      >
+      <storybook-pharos-radio-button value="3"
+        ><span slot="label">Radio Button 3</span></storybook-pharos-radio-button
+      >
+    </storybook-pharos-radio-group>`,
   parameters: { options: { selectedPanel: 'addon-actions' } },
 };
 
@@ -76,24 +80,24 @@ export const FormData = {
   render: () =>
     html`
       <form name="my-form" action="https://httpbin.org/post" method="POST">
-        <pharos-radio-group
+        <storybook-pharos-radio-group
           style="margin-bottom: 0.5rem;"
           @change="${(e) => action('Change')(e.target.value)}"
           name="radio-group4"
           required
         >
           <span slot="legend">Radio Group Header</span>
-          <pharos-radio-button value="1"
-            ><span slot="label">Radio Button 1</span></pharos-radio-button
+          <storybook-pharos-radio-button value="1"
+            ><span slot="label">Radio Button 1</span></storybook-pharos-radio-button
           >
-          <pharos-radio-button value="2"
-            ><span slot="label">Radio Button 2</span></pharos-radio-button
+          <storybook-pharos-radio-button value="2"
+            ><span slot="label">Radio Button 2</span></storybook-pharos-radio-button
           >
-          <pharos-radio-button value="3"
-            ><span slot="label">Radio Button 3</span></pharos-radio-button
+          <storybook-pharos-radio-button value="3"
+            ><span slot="label">Radio Button 3</span></storybook-pharos-radio-button
           >
-        </pharos-radio-group>
-        <pharos-button
+        </storybook-pharos-radio-group>
+        <storybook-pharos-button
           type="submit"
           value="Submit"
           @click="${(e) => {
@@ -108,7 +112,7 @@ export const FormData = {
             };
             xhr.send(formData);
           }}"
-          >Submit</pharos-button
+          >Submit</storybook-pharos-button
         >
       </form>
     `,

--- a/packages/pharos/src/components/select/PharosSelect.react.stories.jsx
+++ b/packages/pharos/src/components/select/PharosSelect.react.stories.jsx
@@ -5,10 +5,18 @@ import { PharosSelect, PharosButton } from '../../react-components';
 import createFormData from '../../utils/createFormData';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Select',
   component: PharosSelect,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('select') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/select/pharos-select.test.ts
+++ b/packages/pharos/src/components/select/pharos-select.test.ts
@@ -10,25 +10,25 @@ describe('pharos-select', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html`<pharos-select>
+      html`<test-pharos-select>
         <span slot="label">test</span>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3" selected>Option 3</option>
         <option value="4">Option 4</option>
         <option value="5">Option 5</option>
-      </pharos-select>`
+      </test-pharos-select>`
     );
 
     disabled = await fixture(
-      html`<pharos-select disabled>
+      html`<test-pharos-select disabled>
         <span slot="label">test</span>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3" selected>Option 3</option>
         <option value="4">Option 4</option>
         <option value="5">Option 5</option>
-      </pharos-select>`
+      </test-pharos-select>`
     );
   });
 
@@ -49,10 +49,10 @@ describe('pharos-select', () => {
   it('uses the first option by default', async () => {
     component = await fixture(
       html`
-        <pharos-select>
+        <test-pharos-select>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-select>
+        </test-pharos-select>
       `
     );
 
@@ -66,10 +66,10 @@ describe('pharos-select', () => {
     };
     component = await fixture(
       html`
-        <pharos-select @change=${onChange}>
+        <test-pharos-select @change=${onChange}>
           <span slot="label">test</span>
           <option value="1">Option 1</option>
-        </pharos-select>
+        </test-pharos-select>
       `
     );
 
@@ -83,11 +83,11 @@ describe('pharos-select', () => {
   it('updates the value on change', async () => {
     component = await fixture(
       html`
-        <pharos-select>
+        <test-pharos-select>
           <span slot="label">test</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
-        </pharos-select>
+        </test-pharos-select>
       `
     );
 
@@ -130,14 +130,14 @@ describe('pharos-select', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-select name="my-select">
+        <test-pharos-select name="my-select">
           <span slot="label">test</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3" selected>Option 3</option>
           <option value="4">Option 4</option>
           <option value="5">Option 5</option>
-        </pharos-select>
+        </test-pharos-select>
       `,
       { parentNode }
     );
@@ -153,14 +153,14 @@ describe('pharos-select', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-select name="my-select" disabled>
+        <test-pharos-select name="my-select" disabled>
           <span slot="label">test</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3" selected>Option 3</option>
           <option value="4">Option 4</option>
           <option value="5">Option 5</option>
-        </pharos-select>
+        </test-pharos-select>
       `,
       { parentNode }
     );
@@ -189,14 +189,14 @@ describe('pharos-select', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-select name="my-select">
+        <test-pharos-select name="my-select">
           <span slot="label">test</span>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3" selected>Option 3</option>
           <option value="4">Option 4</option>
           <option value="5">Option 5</option>
-        </pharos-select>
+        </test-pharos-select>
       `,
       { parentNode }
     );
@@ -235,14 +235,14 @@ describe('pharos-select', () => {
 
   it('sets the selection when a value is initially passed', async () => {
     component = await fixture(
-      html`<pharos-select value="2">
+      html`<test-pharos-select value="2">
         <span slot="label">test</span>
         <option value="1">Option 1</option>
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
         <option value="4">Option 4</option>
         <option value="5">Option 5</option>
-      </pharos-select>`
+      </test-pharos-select>`
     );
     await component.updateComplete;
     expect(component['_select'].value).to.equal('2');

--- a/packages/pharos/src/components/select/pharos-select.wc.stories.jsx
+++ b/packages/pharos/src/components/select/pharos-select.wc.stories.jsx
@@ -17,7 +17,7 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <pharos-select
+      <storybook-pharos-select
         ?disabled=${args.disabled}
         ?hide-label=${args.hideLabel}
         ?required=${args.required}
@@ -31,7 +31,7 @@ export const Base = {
         <option value="3" selected>Option 3</option>
         <option value="4">Option 4</option>
         <option value="5">Option 5</option>
-      </pharos-select>
+      </storybook-pharos-select>
     `,
   args: defaultArgs,
 };
@@ -39,21 +39,21 @@ export const Base = {
 export const States = {
   render: () =>
     html`
-      <pharos-select>
+      <storybook-pharos-select>
         <span slot="label">Normal Select</span>
         <option value="1">Option 1</option>
         <option value="2" selected>Option 2</option>
-      </pharos-select>
-      <pharos-select disabled>
+      </storybook-pharos-select>
+      <storybook-pharos-select disabled>
         <span slot="label">Disabled Select</span>
         <option value="1">Option 1</option>
         <option value="2" selected>Option 2</option>
-      </pharos-select>
-      <pharos-select invalidated>
+      </storybook-pharos-select>
+      <storybook-pharos-select invalidated>
         <span slot="label">Error Select</span>
         <option value="1">Option 1</option>
         <option value="2" selected>Option 2</option>
-      </pharos-select>
+      </storybook-pharos-select>
     `,
 };
 
@@ -61,7 +61,7 @@ export const WithOptionGroups = {
   name: 'With option groups',
   render: () =>
     html`
-      <pharos-select>
+      <storybook-pharos-select>
         <span slot="label">Normal Select</span>
         <optgroup label="Group 1">
           <option value="1">Option 1</option>
@@ -71,18 +71,18 @@ export const WithOptionGroups = {
           <option value="3">Option 3</option>
           <option value="4" selected>Option 4</option>
         </optgroup>
-      </pharos-select>
+      </storybook-pharos-select>
     `,
 };
 
 export const Events = {
   render: () =>
     html`
-      <pharos-select @change="${(e) => action('Change')(e.target.value)}">
+      <storybook-pharos-select @change="${(e) => action('Change')(e.target.value)}">
         <span slot="label">Normal Select</span>
         <option value="1">Option 1 (Value is 1)</option>
         <option value="2">Option 2 (Value is 2)</option>
-      </pharos-select>
+      </storybook-pharos-select>
     `,
   parameters: { options: { selectedPanel: 'addon-actions' } },
 };
@@ -101,15 +101,15 @@ export const FormData = {
   render: () =>
     html`
       <form name="my-form" action="https://httpbin.org/post" method="POST">
-        <pharos-select name="my-select" required style="margin-bottom: 0.5rem;">
+        <storybook-pharos-select name="my-select" required style="margin-bottom: 0.5rem;">
           <span slot="label">Select Demo</span>
           <option value="">Select an option</option>
           <option value="">----------------</option>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
-        </pharos-select>
-        <pharos-button
+        </storybook-pharos-select>
+        <storybook-pharos-button
           type="submit"
           value="Submit"
           @click="${(e) => {
@@ -124,7 +124,7 @@ export const FormData = {
             };
             xhr.send(formData);
           }}"
-          >Submit</pharos-button
+          >Submit</storybook-pharos-button
         >
       </form>
     `,

--- a/packages/pharos/src/components/sidenav/PharosSidenav.react.stories.jsx
+++ b/packages/pharos/src/components/sidenav/PharosSidenav.react.stories.jsx
@@ -11,10 +11,18 @@ import {
   PharosLink,
 } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Sidenav',
   component: PharosSidenav,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   subcomponents: {
     PharosSidenavMenu,
     PharosSidenavSection,

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-button.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-button.test.ts
@@ -9,7 +9,7 @@ describe('pharos-sidenav', () => {
 
   beforeEach(async () => {
     await setViewport({ width: 1055, height: 768 });
-    component = await fixture(html`<pharos-sidenav-button></pharos-sidenav-button>`);
+    component = await fixture(html`<test-pharos-sidenav-button></test-pharos-sidenav-button>`);
   });
 
   it('is accessible', async () => {
@@ -23,12 +23,12 @@ describe('pharos-sidenav', () => {
   });
 
   it('is visible when viewport is below than 1056px', async () => {
-    const button = document.querySelector('pharos-sidenav-button');
+    const button = document.querySelector('test-pharos-sidenav-button');
     expect(button).to.not.be.null;
   });
 
   it('slides in the sidenav when clicked', async () => {
-    const sidenav = document.createElement('pharos-sidenav');
+    const sidenav = document.createElement('test-pharos-sidenav');
     document.body.appendChild(sidenav);
 
     component.click();
@@ -36,13 +36,13 @@ describe('pharos-sidenav', () => {
   });
 
   it('focuses the sidenav after being clicked', async () => {
-    const sidenav = document.createElement('pharos-sidenav');
+    const sidenav = document.createElement('test-pharos-sidenav');
     document.body.appendChild(sidenav);
 
     component.click();
     await sidenav.updateComplete;
 
-    const renderedSidenav = document.body.querySelector('pharos-sidenav');
+    const renderedSidenav = document.body.querySelector('test-pharos-sidenav');
     expect(document.activeElement === renderedSidenav).to.be.true;
   });
 });

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-link.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-link.test.ts
@@ -7,7 +7,9 @@ describe('pharos-sidenav-link', () => {
   let component: PharosSidenavLink;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-sidenav-link href="#">Link</pharos-sidenav-link> `);
+    component = await fixture(
+      html`<test-pharos-sidenav-link href="#">Link</test-pharos-sidenav-link>`
+    );
   });
 
   it('is accessible', async () => {
@@ -18,7 +20,9 @@ describe('pharos-sidenav-link', () => {
     component.external = true;
     await component.updateComplete;
 
-    const icon = component.renderRoot.querySelector('pharos-icon[name="link-external"]');
+    const icon = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosIcon"][name="link-external"]'
+    );
     expect(icon).not.to.be.null;
   });
 });

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-menu.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-menu.test.ts
@@ -10,10 +10,10 @@ describe('pharos-sidenav-menu', () => {
   beforeEach(async () => {
     component = await fixture(
       html`
-        <pharos-sidenav-menu label="Menu">
-          <pharos-sidenav-link href="#">Link</pharos-sidenav-link>
-          <pharos-sidenav-link href="#">Link 2</pharos-sidenav-link>
-        </pharos-sidenav-menu>
+        <test-pharos-sidenav-menu label="Menu">
+          <test-pharos-sidenav-link href="#">Link</test-pharos-sidenav-link>
+          <test-pharos-sidenav-link href="#">Link 2</test-pharos-sidenav-link>
+        </test-pharos-sidenav-menu>
       `
     );
   });
@@ -23,7 +23,9 @@ describe('pharos-sidenav-menu', () => {
   });
 
   it('renders a chevron down icon when not expanded', async () => {
-    const icon = component.renderRoot.querySelector('pharos-icon[name="chevron-down"]');
+    const icon = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosIcon"][name="chevron-down"]'
+    );
     expect(icon).not.to.be.null;
   });
 
@@ -31,7 +33,9 @@ describe('pharos-sidenav-menu', () => {
     component.expanded = true;
     await component.updateComplete;
 
-    const icon = component.renderRoot.querySelector('pharos-icon[name="chevron-up"]');
+    const icon = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosIcon"][name="chevron-up"]'
+    );
     expect(icon).not.to.be.null;
   });
 
@@ -46,7 +50,7 @@ describe('pharos-sidenav-menu', () => {
 
   it('sets each slotted sidenav link as a menu item', async () => {
     const allLinks = component.querySelectorAll(
-      'pharos-sidenav-link'
+      'test-pharos-sidenav-link'
     ) as NodeListOf<PharosSidenavLink>;
 
     allLinks.forEach((link) => {

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-section.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-section.test.ts
@@ -9,9 +9,9 @@ describe('pharos-sidenav-section', () => {
   beforeEach(async () => {
     component = await fixture(
       html`
-        <pharos-sidenav-section>
-          <pharos-sidenav-link href="#">Link</pharos-sidenav-link>
-        </pharos-sidenav-section>
+        <test-pharos-sidenav-section>
+          <test-pharos-sidenav-link href="#">Link</test-pharos-sidenav-link>
+        </test-pharos-sidenav-section>
       `
     );
   });
@@ -24,7 +24,9 @@ describe('pharos-sidenav-section', () => {
     component.label = 'test';
     await component.updateComplete;
 
-    const heading = component.renderRoot.querySelector('pharos-heading[preset="legend"]');
+    const heading = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosHeading"][preset="legend"]'
+    );
     expect(heading).not.to.be.null;
   });
 

--- a/packages/pharos/src/components/sidenav/pharos-sidenav.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav.test.ts
@@ -12,9 +12,9 @@ describe('pharos-sidenav', () => {
     await setViewport({ width: 1440, height: 900 });
     component = await fixture(
       html`
-        <pharos-sidenav>
-          <pharos-link slot="top" href="/" id="jstor-logo">JSTOR</pharos-link>
-          <pharos-input-group
+        <test-pharos-sidenav>
+          <test-pharos-link slot="top" href="/" id="jstor-logo">JSTOR</test-pharos-link>
+          <test-pharos-input-group
             slot="top"
             name="my-input-group"
             placeholder="Search"
@@ -22,63 +22,63 @@ describe('pharos-sidenav', () => {
             on-background
           >
             <span slot="label">Search</span>
-            <pharos-button
+            <test-pharos-button
               name="search-button"
               icon="search"
               variant="subtle"
               label="search"
               on-background
-            ></pharos-button>
-          </pharos-input-group>
-          <pharos-sidenav-section show-divider>
-            <pharos-sidenav-link href="#">Menu item</pharos-sidenav-link>
-            <pharos-sidenav-menu label="Menu item w/accordion">
-              <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-            </pharos-sidenav-menu>
-            <pharos-sidenav-link href="#">Menu item</pharos-sidenav-link>
-            <pharos-sidenav-link href="#" target="_blank" external
-              >External link</pharos-sidenav-link
+            ></test-pharos-button>
+          </test-pharos-input-group>
+          <test-pharos-sidenav-section show-divider>
+            <test-pharos-sidenav-link href="#">Menu item</test-pharos-sidenav-link>
+            <test-pharos-sidenav-menu label="Menu item w/accordion">
+              <test-pharos-sidenav-link href="#">Menu item 1</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 2</test-pharos-sidenav-link>
+            </test-pharos-sidenav-menu>
+            <test-pharos-sidenav-link href="#">Menu item</test-pharos-sidenav-link>
+            <test-pharos-sidenav-link href="#" target="_blank" external
+              >External link</test-pharos-sidenav-link
             >
-            <pharos-sidenav-link href="#" target="_blank" external
-              >External link</pharos-sidenav-link
+            <test-pharos-sidenav-link href="#" target="_blank" external
+              >External link</test-pharos-sidenav-link
             >
-          </pharos-sidenav-section>
-          <pharos-sidenav-section label="Section Heading" show-divider>
-            <pharos-sidenav-menu label="Menu item w/accordion">
-              <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-            </pharos-sidenav-menu>
-            <pharos-sidenav-menu label="Menu item w/accordion">
-              <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-            </pharos-sidenav-menu>
-            <pharos-sidenav-menu label="Menu item w/accordion">
-              <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-            </pharos-sidenav-menu>
-          </pharos-sidenav-section>
-          <pharos-sidenav-section label="Section Heading">
-            <pharos-sidenav-menu label="Menu item w/accordion">
-              <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 4</pharos-sidenav-link>
-            </pharos-sidenav-menu>
-            <pharos-sidenav-menu label="Menu item w/accordion">
-              <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-            </pharos-sidenav-menu>
-            <pharos-sidenav-menu label="Menu item w/accordion">
-              <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-              <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-            </pharos-sidenav-menu>
-            <pharos-sidenav-link href="#">Menu item</pharos-sidenav-link>
-          </pharos-sidenav-section>
-        </pharos-sidenav>
+          </test-pharos-sidenav-section>
+          <test-pharos-sidenav-section label="Section Heading" show-divider>
+            <test-pharos-sidenav-menu label="Menu item w/accordion">
+              <test-pharos-sidenav-link href="#">Menu item 1</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 2</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 3</test-pharos-sidenav-link>
+            </test-pharos-sidenav-menu>
+            <test-pharos-sidenav-menu label="Menu item w/accordion">
+              <test-pharos-sidenav-link href="#">Menu item 1</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 2</test-pharos-sidenav-link>
+            </test-pharos-sidenav-menu>
+            <test-pharos-sidenav-menu label="Menu item w/accordion">
+              <test-pharos-sidenav-link href="#">Menu item 1</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 2</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 3</test-pharos-sidenav-link>
+            </test-pharos-sidenav-menu>
+          </test-pharos-sidenav-section>
+          <test-pharos-sidenav-section label="Section Heading">
+            <test-pharos-sidenav-menu label="Menu item w/accordion">
+              <test-pharos-sidenav-link href="#">Menu item 1</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 2</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 3</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 4</test-pharos-sidenav-link>
+            </test-pharos-sidenav-menu>
+            <test-pharos-sidenav-menu label="Menu item w/accordion">
+              <test-pharos-sidenav-link href="#">Menu item 1</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 2</test-pharos-sidenav-link>
+            </test-pharos-sidenav-menu>
+            <test-pharos-sidenav-menu label="Menu item w/accordion">
+              <test-pharos-sidenav-link href="#">Menu item 1</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 2</test-pharos-sidenav-link>
+              <test-pharos-sidenav-link href="#">Menu item 3</test-pharos-sidenav-link>
+            </test-pharos-sidenav-menu>
+            <test-pharos-sidenav-link href="#">Menu item</test-pharos-sidenav-link>
+          </test-pharos-sidenav-section>
+        </test-pharos-sidenav>
       `
     );
   });
@@ -115,7 +115,7 @@ describe('pharos-sidenav', () => {
   });
 
   it('delegates focus to the sidenav button after the close button is clicked', async () => {
-    const sidenavButton = document.createElement('pharos-sidenav-button');
+    const sidenavButton = document.createElement('test-pharos-sidenav-button');
     document.body.appendChild(sidenavButton);
     await setViewport({ width: 1055, height: 768 });
     component.slide = true;
@@ -125,7 +125,7 @@ describe('pharos-sidenav', () => {
     button?.click();
     await component.updateComplete;
 
-    const renderedButton = document.body.querySelector('pharos-sidenav-button');
+    const renderedButton = document.body.querySelector('test-pharos-sidenav-button');
     expect(document.activeElement === renderedButton).to.be.true;
   });
 

--- a/packages/pharos/src/components/sidenav/pharos-sidenav.wc.stories.jsx
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav.wc.stories.jsx
@@ -19,12 +19,12 @@ export default {
 export const Base = {
   render: () =>
     html`
-      <pharos-sidenav-button></pharos-sidenav-button>
-      <pharos-sidenav>
-        <pharos-link slot="top" href="/" id="jstor-logo">
+      <storybook-pharos-sidenav-button></storybook-pharos-sidenav-button>
+      <storybook-pharos-sidenav>
+        <storybook-pharos-link slot="top" href="/" id="jstor-logo">
           <img src="./images/jstor-logo-inverse.svg" alt="Pharos Home" width="72" height="100" />
-        </pharos-link>
-        <pharos-input-group
+        </storybook-pharos-link>
+        <storybook-pharos-input-group
           slot="top"
           name="my-input-group"
           placeholder="Search"
@@ -32,59 +32,63 @@ export const Base = {
           on-background
         >
           <span slot="label">Search</span>
-          <pharos-button
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
             on-background
-          ></pharos-button>
-        </pharos-input-group>
-        <pharos-sidenav-section show-divider>
-          <pharos-sidenav-link href="#">Menu item</pharos-sidenav-link>
-          <pharos-sidenav-menu label="Menu item w/accordion">
-            <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-          </pharos-sidenav-menu>
-          <pharos-sidenav-link href="#">Menu item</pharos-sidenav-link>
-          <pharos-sidenav-link href="#" target="_blank" external>External link</pharos-sidenav-link>
-          <pharos-sidenav-link href="#" target="_blank" external>External link</pharos-sidenav-link>
-        </pharos-sidenav-section>
-        <pharos-sidenav-section label="Section Heading" show-divider>
-          <pharos-sidenav-menu label="Menu item w/accordion">
-            <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-          </pharos-sidenav-menu>
-          <pharos-sidenav-menu label="Menu item w/accordion">
-            <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-          </pharos-sidenav-menu>
-          <pharos-sidenav-menu label="Menu item w/accordion">
-            <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-          </pharos-sidenav-menu>
-        </pharos-sidenav-section>
-        <pharos-sidenav-section label="Section Heading">
-          <pharos-sidenav-menu label="Menu item w/accordion">
-            <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 4</pharos-sidenav-link>
-          </pharos-sidenav-menu>
-          <pharos-sidenav-menu label="Menu item w/accordion">
-            <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-          </pharos-sidenav-menu>
-          <pharos-sidenav-menu label="Menu item w/accordion">
-            <pharos-sidenav-link href="#">Menu item 1</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 2</pharos-sidenav-link>
-            <pharos-sidenav-link href="#">Menu item 3</pharos-sidenav-link>
-          </pharos-sidenav-menu>
-          <pharos-sidenav-link href="#">Menu item</pharos-sidenav-link>
-        </pharos-sidenav-section>
-      </pharos-sidenav>
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
+        <storybook-pharos-sidenav-section show-divider>
+          <storybook-pharos-sidenav-link href="#">Menu item</storybook-pharos-sidenav-link>
+          <storybook-pharos-sidenav-menu label="Menu item w/accordion">
+            <storybook-pharos-sidenav-link href="#">Menu item 1</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
+          </storybook-pharos-sidenav-menu>
+          <storybook-pharos-sidenav-link href="#">Menu item</storybook-pharos-sidenav-link>
+          <storybook-pharos-sidenav-link href="#" target="_blank" external
+            >External link</storybook-pharos-sidenav-link
+          >
+          <storybook-pharos-sidenav-link href="#" target="_blank" external
+            >External link</storybook-pharos-sidenav-link
+          >
+        </storybook-pharos-sidenav-section>
+        <storybook-pharos-sidenav-section label="Section Heading" show-divider>
+          <storybook-pharos-sidenav-menu label="Menu item w/accordion">
+            <storybook-pharos-sidenav-link href="#">Menu item 1</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 3</storybook-pharos-sidenav-link>
+          </storybook-pharos-sidenav-menu>
+          <storybook-pharos-sidenav-menu label="Menu item w/accordion">
+            <storybook-pharos-sidenav-link href="#">Menu item 1</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
+          </storybook-pharos-sidenav-menu>
+          <storybook-pharos-sidenav-menu label="Menu item w/accordion">
+            <storybook-pharos-sidenav-link href="#">Menu item 1</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 3</storybook-pharos-sidenav-link>
+          </storybook-pharos-sidenav-menu>
+        </storybook-pharos-sidenav-section>
+        <storybook-pharos-sidenav-section label="Section Heading">
+          <storybook-pharos-sidenav-menu label="Menu item w/accordion">
+            <storybook-pharos-sidenav-link href="#">Menu item 1</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 3</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 4</storybook-pharos-sidenav-link>
+          </storybook-pharos-sidenav-menu>
+          <storybook-pharos-sidenav-menu label="Menu item w/accordion">
+            <storybook-pharos-sidenav-link href="#">Menu item 1</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
+          </storybook-pharos-sidenav-menu>
+          <storybook-pharos-sidenav-menu label="Menu item w/accordion">
+            <storybook-pharos-sidenav-link href="#">Menu item 1</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
+            <storybook-pharos-sidenav-link href="#">Menu item 3</storybook-pharos-sidenav-link>
+          </storybook-pharos-sidenav-menu>
+          <storybook-pharos-sidenav-link href="#">Menu item</storybook-pharos-sidenav-link>
+        </storybook-pharos-sidenav-section>
+      </storybook-pharos-sidenav>
     `,
   parameters: {
     chromatic: { viewports: [320, 1200] },

--- a/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
+++ b/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
@@ -2,11 +2,19 @@ import { action } from '@storybook/addon-actions';
 
 import { PharosTabs, PharosTab, PharosTabPanel } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Tabs',
   component: PharosTabs,
   subcomponents: { PharosTab, PharosTabPanel },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('tabs') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/tabs/pharos-tab-panel.test.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab-panel.test.ts
@@ -4,15 +4,17 @@ import { html } from 'lit/static-html.js';
 describe('pharos-tab-panel', () => {
   it('has a tabindex when it contains no focusable elements', async () => {
     const component = await fixture(
-      html`<pharos-tab-panel selected id="panel-1" slot="panel">Panel 1</pharos-tab-panel>`
+      html`<test-pharos-tab-panel selected id="panel-1" slot="panel"
+        >Panel 1</test-pharos-tab-panel
+      >`
     );
     await expect(component.getAttribute('tabindex')).to.equal('0');
   });
 
   it('does not have a tabindex when it contains focusable elements', async () => {
     const component = await fixture(
-      html`<pharos-tab-panel selected id="panel-1" slot="panel"
-        ><button>test</button></pharos-tab-panel
+      html`<test-pharos-tab-panel selected id="panel-1" slot="panel"
+        ><button>test</button></test-pharos-tab-panel
       >`
     );
     await expect(component.hasAttribute('tabindex')).to.be.false;

--- a/packages/pharos/src/components/tabs/pharos-tab.test.ts
+++ b/packages/pharos/src/components/tabs/pharos-tab.test.ts
@@ -7,15 +7,15 @@ describe('pharos-tab', () => {
   let component: PharosTab;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-tab>I am a tab</pharos-tab> `);
+    component = await fixture(html` <test-pharos-tab>I am a tab</test-pharos-tab> `);
   });
 
   it('is accessible', async () => {
-    const parentNode = document.createElement('pharos-tabs');
+    const parentNode = document.createElement('test-pharos-tabs');
     component = await fixture(
       html`
-        <pharos-tab id="tab-1" data-panel-id="panel-1">I am an tab</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
+        <test-pharos-tab id="tab-1" data-panel-id="panel-1">I am an tab</test-pharos-tab>
+        <test-pharos-tab-panel id="panel-1" slot="panel">Panel 1</test-pharos-tab-panel>
       `,
       { parentNode }
     );

--- a/packages/pharos/src/components/tabs/pharos-tabs.test.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.test.ts
@@ -10,25 +10,25 @@ describe('pharos-tabs', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-tabs>
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
-        <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
-        <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>
-      </pharos-tabs>
+      <test-pharos-tabs>
+        <test-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</test-pharos-tab>
+        <test-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</test-pharos-tab>
+        <test-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</test-pharos-tab>
+        <test-pharos-tab-panel id="panel-1" slot="panel">Panel 1</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-2" slot="panel">Panel 2</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-3" slot="panel">Panel 3</test-pharos-tab-panel>
+      </test-pharos-tabs>
     `);
 
     componentLastTabSelected = await fixture(html`
-      <pharos-tabs>
-        <pharos-tab id="tab-4" data-panel-id="panel-4">Tab 1</pharos-tab>
-        <pharos-tab id="tab-5" data-panel-id="panel-5">Tab 2</pharos-tab>
-        <pharos-tab id="tab-6" data-panel-id="panel-6" selected>Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-4" slot="panel">Panel 1</pharos-tab-panel>
-        <pharos-tab-panel id="panel-5" slot="panel">Panel 2</pharos-tab-panel>
-        <pharos-tab-panel id="panel-6" slot="panel">Panel 3</pharos-tab-panel>
-      </pharos-tabs>
+      <test-pharos-tabs>
+        <test-pharos-tab id="tab-4" data-panel-id="panel-4">Tab 1</test-pharos-tab>
+        <test-pharos-tab id="tab-5" data-panel-id="panel-5">Tab 2</test-pharos-tab>
+        <test-pharos-tab id="tab-6" data-panel-id="panel-6" selected>Tab 3</test-pharos-tab>
+        <test-pharos-tab-panel id="panel-4" slot="panel">Panel 1</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-5" slot="panel">Panel 2</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-6" slot="panel">Panel 3</test-pharos-tab-panel>
+      </test-pharos-tabs>
     `);
   });
 
@@ -48,7 +48,7 @@ describe('pharos-tabs', () => {
 
   it('has 3 tabs within the slot', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     expect(tabs.length).to.be.eq(3);
@@ -56,11 +56,11 @@ describe('pharos-tabs', () => {
 
   it('selects the first tab if no selection is defined', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     const panels = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab-panel`)
+      component.querySelectorAll(`test-pharos-tab-panel`)
     ) as PharosTabPanel[];
 
     expect(tabs[0].selected).to.be.true;
@@ -74,11 +74,11 @@ describe('pharos-tabs', () => {
 
   it('selects the defined tab', async () => {
     const tabs = Array.prototype.slice.call(
-      componentLastTabSelected.querySelectorAll(`pharos-tab`)
+      componentLastTabSelected.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     const panels = Array.prototype.slice.call(
-      componentLastTabSelected.querySelectorAll(`pharos-tab-panel`)
+      componentLastTabSelected.querySelectorAll(`test-pharos-tab-panel`)
     ) as PharosTabPanel[];
 
     await Promise.all(Array.from(tabs).map((tab) => tab.updateComplete));
@@ -95,7 +95,7 @@ describe('pharos-tabs', () => {
 
   it('changes the focus right with the right arrow key', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     tabs[0].focus();
@@ -108,7 +108,7 @@ describe('pharos-tabs', () => {
 
   it('changes the focus left with the left arrow key', async () => {
     const tabs = Array.prototype.slice.call(
-      componentLastTabSelected.querySelectorAll(`pharos-tab`)
+      componentLastTabSelected.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     tabs[2].focus();
@@ -121,7 +121,7 @@ describe('pharos-tabs', () => {
 
   it('changes the selection with keyboard', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     tabs[0].focus();
@@ -139,7 +139,7 @@ describe('pharos-tabs', () => {
 
   it('wraps focus to the last tab when left arrow is hit on the first tab', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     tabs[0].focus();
@@ -152,7 +152,7 @@ describe('pharos-tabs', () => {
 
   it('wraps focus to the first tab when left arrow is hit on the last tab', async () => {
     const tabs = Array.prototype.slice.call(
-      componentLastTabSelected.querySelectorAll(`pharos-tab`)
+      componentLastTabSelected.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     tabs[2].focus();
@@ -165,7 +165,7 @@ describe('pharos-tabs', () => {
 
   it('changes the selected tab on click', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     tabs[1].click();
@@ -179,7 +179,7 @@ describe('pharos-tabs', () => {
 
   it('shows the first panel by default', async () => {
     const panels = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab-panel`)
+      component.querySelectorAll(`test-pharos-tab-panel`)
     ) as PharosTabPanel[];
 
     expect(panels[0].selected).to.be.true;
@@ -189,11 +189,11 @@ describe('pharos-tabs', () => {
 
   it('changes the panel with keyboard selection', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     const panels = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab-panel`)
+      component.querySelectorAll(`test-pharos-tab-panel`)
     ) as PharosTabPanel[];
 
     tabs[0].focus();
@@ -211,11 +211,11 @@ describe('pharos-tabs', () => {
 
   it('changes the visible panel on click', async () => {
     const tabs = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab`)
+      component.querySelectorAll(`test-pharos-tab`)
     ) as PharosTab[];
 
     const panels = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-tab-panel`)
+      component.querySelectorAll(`test-pharos-tab-panel`)
     ) as PharosTabPanel[];
 
     tabs[1].click();
@@ -233,14 +233,16 @@ describe('pharos-tabs', () => {
       count++;
     };
     component = await fixture(html`
-      <pharos-tabs @keydown=${onKeydown}>
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel"><input type="text" /></pharos-tab-panel>
-        <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
-        <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>
-      </pharos-tabs>
+      <test-pharos-tabs @keydown=${onKeydown}>
+        <test-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</test-pharos-tab>
+        <test-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</test-pharos-tab>
+        <test-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</test-pharos-tab>
+        <test-pharos-tab-panel id="panel-1" slot="panel"
+          ><input type="text"
+        /></test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-2" slot="panel">Panel 2</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-3" slot="panel">Panel 3</test-pharos-tab-panel>
+      </test-pharos-tabs>
     `);
     const input = component.querySelector('input') as HTMLInputElement;
     input?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, composed: true }));
@@ -256,14 +258,14 @@ describe('pharos-tabs', () => {
 
   it('renders panel separator', async () => {
     component = await fixture(html`
-      <pharos-tabs panel-separator>
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
-        <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
-        <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>
-      </pharos-tabs>
+      <test-pharos-tabs panel-separator>
+        <test-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</test-pharos-tab>
+        <test-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</test-pharos-tab>
+        <test-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</test-pharos-tab>
+        <test-pharos-tab-panel id="panel-1" slot="panel">Panel 1</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-2" slot="panel">Panel 2</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-3" slot="panel">Panel 3</test-pharos-tab-panel>
+      </test-pharos-tabs>
     `);
 
     const spanElement = component.renderRoot.querySelector('.panel-separator') as HTMLDivElement;

--- a/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
+++ b/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
@@ -16,28 +16,30 @@ export default {
 export const Base = {
   render: () =>
     html`
-      <pharos-tabs>
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
-        <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
-        <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>
-      </pharos-tabs>
+      <storybook-pharos-tabs>
+        <storybook-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</storybook-pharos-tab>
+        <storybook-pharos-tab-panel id="panel-1" slot="panel">Panel 1</storybook-pharos-tab-panel>
+        <storybook-pharos-tab-panel id="panel-2" slot="panel">Panel 2</storybook-pharos-tab-panel>
+        <storybook-pharos-tab-panel id="panel-3" slot="panel">Panel 3</storybook-pharos-tab-panel>
+      </storybook-pharos-tabs>
     `,
 };
 
 export const Events = {
   render: () =>
     html`
-      <pharos-tabs @pharos-tab-selected="${(e) => action('Selected')(e.target.id)}">
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3" selected>Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel">Panel 1</pharos-tab-panel>
-        <pharos-tab-panel id="panel-2" slot="panel">Panel 2</pharos-tab-panel>
-        <pharos-tab-panel id="panel-3" slot="panel">Panel 3</pharos-tab-panel>
-      </pharos-tabs>
+      <storybook-pharos-tabs @pharos-tab-selected="${(e) => action('Selected')(e.target.id)}">
+        <storybook-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-3" data-panel-id="panel-3" selected
+          >Tab 3</storybook-pharos-tab
+        >
+        <storybook-pharos-tab-panel id="panel-1" slot="panel">Panel 1</storybook-pharos-tab-panel>
+        <storybook-pharos-tab-panel id="panel-2" slot="panel">Panel 2</storybook-pharos-tab-panel>
+        <storybook-pharos-tab-panel id="panel-3" slot="panel">Panel 3</storybook-pharos-tab-panel>
+      </storybook-pharos-tabs>
     `,
   parameters: { options: { selectedPanel: 'addon-controls' } },
 };
@@ -45,84 +47,86 @@ export const Events = {
 export const PanelOrder = {
   render: () =>
     html`
-      <pharos-tabs>
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-2" slot="panel"
-          >I am the panel for tab 2 but listed 1st in the DOM</pharos-tab-panel
+      <storybook-pharos-tabs>
+        <storybook-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</storybook-pharos-tab>
+        <storybook-pharos-tab-panel id="panel-2" slot="panel"
+          >I am the panel for tab 2 but listed 1st in the DOM</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-3" slot="panel"
-          >I am the panel for tab 3 but listed 2nd in the DOM</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-3" slot="panel"
+          >I am the panel for tab 3 but listed 2nd in the DOM</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-1" slot="panel"
-          >I am the panel for tab 1 but listed 3rd in the DOM</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-1" slot="panel"
+          >I am the panel for tab 1 but listed 3rd in the DOM</storybook-pharos-tab-panel
         >
-      </pharos-tabs>
+      </storybook-pharos-tabs>
     `,
 };
 
 export const PanelSeparator = {
   render: () =>
     html`
-      <pharos-tabs panel-separator style="width: 100%">
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel"
-          >Panel 1 with a panel separator</pharos-tab-panel
+      <storybook-pharos-tabs panel-separator style="width: 100%">
+        <storybook-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</storybook-pharos-tab>
+        <storybook-pharos-tab-panel id="panel-1" slot="panel"
+          >Panel 1 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-2" slot="panel"
-          >Panel 2 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-2" slot="panel"
+          >Panel 2 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-3" slot="panel"
-          >Panel 3 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-3" slot="panel"
+          >Panel 3 with a panel separator</storybook-pharos-tab-panel
         >
-      </pharos-tabs>
+      </storybook-pharos-tabs>
     `,
 };
 
 export const HorizontalScrolling = {
   render: () =>
     html`
-      <pharos-tabs panel-separator style="width: 100%">
-        <pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</pharos-tab>
-        <pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</pharos-tab>
-        <pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</pharos-tab>
-        <pharos-tab id="tab-4" data-panel-id="panel-4">Tab 4</pharos-tab>
-        <pharos-tab id="tab-5" data-panel-id="panel-5">Tab 5</pharos-tab>
-        <pharos-tab id="tab-6" data-panel-id="panel-6">Tab 6</pharos-tab>
-        <pharos-tab id="tab-7" data-panel-id="panel-7" selected>Tab 7</pharos-tab>
-        <pharos-tab id="tab-8" data-panel-id="panel-8">Tab 8</pharos-tab>
-        <pharos-tab id="tab-9" data-panel-id="panel-9">Tab 9</pharos-tab>
-        <pharos-tab-panel id="panel-1" slot="panel"
-          >Panel 1 with a panel separator</pharos-tab-panel
+      <storybook-pharos-tabs panel-separator style="width: 100%">
+        <storybook-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-4" data-panel-id="panel-4">Tab 4</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-5" data-panel-id="panel-5">Tab 5</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-6" data-panel-id="panel-6">Tab 6</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-7" data-panel-id="panel-7" selected
+          >Tab 7</storybook-pharos-tab
         >
-        <pharos-tab-panel id="panel-2" slot="panel"
-          >Panel 2 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab id="tab-8" data-panel-id="panel-8">Tab 8</storybook-pharos-tab>
+        <storybook-pharos-tab id="tab-9" data-panel-id="panel-9">Tab 9</storybook-pharos-tab>
+        <storybook-pharos-tab-panel id="panel-1" slot="panel"
+          >Panel 1 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-3" slot="panel"
-          >Panel 3 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-2" slot="panel"
+          >Panel 2 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-4" slot="panel"
-          >Panel 4 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-3" slot="panel"
+          >Panel 3 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-5" slot="panel"
-          >Panel 5 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-4" slot="panel"
+          >Panel 4 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-6" slot="panel"
-          >Panel 6 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-5" slot="panel"
+          >Panel 5 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-7" slot="panel"
-          >Panel 7 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-6" slot="panel"
+          >Panel 6 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-8" slot="panel"
-          >Panel 8 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-7" slot="panel"
+          >Panel 7 with a panel separator</storybook-pharos-tab-panel
         >
-        <pharos-tab-panel id="panel-9" slot="panel"
-          >Panel 9 with a panel separator</pharos-tab-panel
+        <storybook-pharos-tab-panel id="panel-8" slot="panel"
+          >Panel 8 with a panel separator</storybook-pharos-tab-panel
         >
-      </pharos-tabs>
+        <storybook-pharos-tab-panel id="panel-9" slot="panel"
+          >Panel 9 with a panel separator</storybook-pharos-tab-panel
+        >
+      </storybook-pharos-tabs>
     `,
   parameters: {
     viewport: { defaultViewport: 'mobile1' },

--- a/packages/pharos/src/components/text-input/PharosTextInput.react.stories.jsx
+++ b/packages/pharos/src/components/text-input/PharosTextInput.react.stories.jsx
@@ -4,10 +4,18 @@ import { PharosTextInput, PharosButton } from '../../react-components';
 import createFormData from '../../utils/createFormData';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Text Input',
   components: PharosTextInput,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('text-input') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/text-input/pharos-text-input.test.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.test.ts
@@ -15,7 +15,7 @@ describe('pharos-text-input', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html`<pharos-text-input><span slot="label">I am a label</span></pharos-text-input>`
+      html`<test-pharos-text-input><span slot="label">I am a label</span></test-pharos-text-input>`
     );
   });
 
@@ -31,33 +31,37 @@ describe('pharos-text-input', () => {
 
   it('is accessible when disabled', async () => {
     component = await fixture(
-      html`<pharos-text-input disabled><span slot="label">I am a label</span></pharos-text-input>`
+      html`<test-pharos-text-input disabled
+        ><span slot="label">I am a label</span></test-pharos-text-input
+      >`
     );
     await expect(component).to.be.accessible();
   });
 
   it('is accessible when readonly', async () => {
     component = await fixture(
-      html`<pharos-text-input readonly><span slot="label">I am a label</span></pharos-text-input>`
+      html`<test-pharos-text-input readonly
+        ><span slot="label">I am a label</span></test-pharos-text-input
+      >`
     );
     await expect(component).to.be.accessible();
   });
 
   it('sets its default attributes', async () => {
     component = await fixture(html`
-      <pharos-text-input>
+      <test-pharos-text-input>
         <span slot="label">I am a label</span>
-      </pharos-text-input>
+      </test-pharos-text-input>
     `);
     expect(component).dom.to.equal(
-      `<pharos-text-input data-pharos-component="PharosTextInput" message="" name="" placeholder="" type="text" value="" variant="primary"><span slot="label">I am a label</span></pharos-text-input>`
+      `<test-pharos-text-input data-pharos-component="PharosTextInput" message="" name="" placeholder="" type="text" value="" variant="primary"><span slot="label">I am a label</span></test-pharos-text-input>`
     );
   });
 
   it('has an attribute to set the placeholder text of the input', async () => {
     component = await fixture(html`
-      <pharos-text-input placeholder="test"
-        ><span slot="label">I am a label</span></pharos-text-input
+      <test-pharos-text-input placeholder="test"
+        ><span slot="label">I am a label</span></test-pharos-text-input
       >
     `);
     expect(component.getAttribute('placeholder')).to.equal('test');
@@ -71,8 +75,8 @@ describe('pharos-text-input', () => {
 
   it('has an attribute to set autocomplete', async () => {
     component = await fixture(html`
-      <pharos-text-input autocomplete="on"
-        ><span slot="label">I am a label</span></pharos-text-input
+      <test-pharos-text-input autocomplete="on"
+        ><span slot="label">I am a label</span></test-pharos-text-input
       >
     `);
     expect(component['_input'].getAttribute('autocomplete')).to.equal('on');
@@ -80,7 +84,9 @@ describe('pharos-text-input', () => {
 
   it('has an attribute to set input value', async () => {
     component = await fixture(html`
-      <pharos-text-input value="test"><span slot="label">I am a label</span></pharos-text-input>
+      <test-pharos-text-input value="test"
+        ><span slot="label">I am a label</span></test-pharos-text-input
+      >
     `);
     expect(component.getAttribute('value')).to.equal('test');
     expect(component['_input'].value).to.equal('test');
@@ -88,7 +94,9 @@ describe('pharos-text-input', () => {
 
   it('has an attribute to set input type', async () => {
     component = await fixture(html`
-      <pharos-text-input type="number"><span slot="label">I am a label</span></pharos-text-input>
+      <test-pharos-text-input type="number"
+        ><span slot="label">I am a label</span></test-pharos-text-input
+      >
     `);
     expect(component.getAttribute('type')).to.equal('number');
     expect(component['_input'].type).to.equal('number');
@@ -107,8 +115,8 @@ describe('pharos-text-input', () => {
       eventSource = event.composedPath()[0] as Element;
     };
     component = await fixture(html`
-      <pharos-text-input @change=${onChange}
-        ><span slot="label">I am a label</span></pharos-text-input
+      <test-pharos-text-input @change=${onChange}
+        ><span slot="label">I am a label</span></test-pharos-text-input
       >
     `);
 
@@ -141,7 +149,9 @@ describe('pharos-text-input', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(
-      html`<pharos-text-input disabled><span slot="label">I am a label</span></pharos-text-input>`
+      html`<test-pharos-text-input disabled
+        ><span slot="label">I am a label</span></test-pharos-text-input
+      >`
     );
 
     component['_input'].focus();
@@ -153,7 +163,9 @@ describe('pharos-text-input', () => {
 
   it('throws an error for invalid type values', async () => {
     component = await fixture(html`
-      <pharos-text-input type="fake"><span slot="label">I am a label</span></pharos-text-input>
+      <test-pharos-text-input type="fake"
+        ><span slot="label">I am a label</span></test-pharos-text-input
+      >
     `).catch((e) => e);
     expect(
       'fake is not a valid text input type. Valid types are: email, hidden, number, password, search, tel, text, url'
@@ -163,7 +175,9 @@ describe('pharos-text-input', () => {
   it('renders an exclamation icon when the input is invalidated', async () => {
     component = await fixture(
       html`
-        <pharos-text-input invalidated><span slot="label">I am a label</span></pharos-text-input>
+        <test-pharos-text-input invalidated
+          ><span slot="label">I am a label</span></test-pharos-text-input
+        >
       `
     );
     expect(component).shadowDom.to.equal(`
@@ -195,7 +209,9 @@ describe('pharos-text-input', () => {
   it('renders a checkmark icon when the input is validated', async () => {
     component = await fixture(
       html`
-        <pharos-text-input validated><span slot="label">I am a label</span></pharos-text-input>
+        <test-pharos-text-input validated
+          ><span slot="label">I am a label</span></test-pharos-text-input
+        >
       `
     );
     expect(component).shadowDom.to.equal(`
@@ -226,7 +242,11 @@ describe('pharos-text-input', () => {
 
   it('renders a required asterisk and hidden text when input is required', async () => {
     component = await fixture(
-      html` <pharos-text-input required><span slot="label">I am a label</span></pharos-text-input> `
+      html`
+        <test-pharos-text-input required
+          ><span slot="label">I am a label</span></test-pharos-text-input
+        >
+      `
     );
     expect(component).shadowDom.to.equal(`
       <label for="input-element">
@@ -257,8 +277,8 @@ describe('pharos-text-input', () => {
   it('renders a provided message', async () => {
     component = await fixture(
       html`
-        <pharos-text-input message="I am invalid"
-          ><span slot="label">I am a label</span></pharos-text-input
+        <test-pharos-text-input message="I am invalid"
+          ><span slot="label">I am a label</span></test-pharos-text-input
         >
       `
     );
@@ -290,7 +310,9 @@ describe('pharos-text-input', () => {
   it('removes invalidated state when validated', async () => {
     component = await fixture(
       html`
-        <pharos-text-input invalidated><span slot="label">I am a label</span></pharos-text-input>
+        <test-pharos-text-input invalidated
+          ><span slot="label">I am a label</span></test-pharos-text-input
+        >
       `
     );
     component.validated = true;
@@ -303,7 +325,9 @@ describe('pharos-text-input', () => {
   it('removes validated state when invalidated', async () => {
     component = await fixture(
       html`
-        <pharos-text-input validated><span slot="label">I am a label</span></pharos-text-input>
+        <test-pharos-text-input validated
+          ><span slot="label">I am a label</span></test-pharos-text-input
+        >
       `
     );
     component.invalidated = true;
@@ -318,9 +342,9 @@ describe('pharos-text-input', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-text-input name="my-input" value="test">
+        <test-pharos-text-input name="my-input" value="test">
           <span slot="label">I am a label</span>
-        </pharos-text-input>
+        </test-pharos-text-input>
       `,
       { parentNode }
     );
@@ -336,9 +360,9 @@ describe('pharos-text-input', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-text-input name="my-input" value="test" disabled>
+        <test-pharos-text-input name="my-input" value="test" disabled>
           <span slot="label">I am a label</span>
-        </pharos-text-input>
+        </test-pharos-text-input>
       `,
       { parentNode }
     );
@@ -369,9 +393,9 @@ describe('pharos-text-input', () => {
 
     component = await fixture(
       html`
-        <pharos-text-input name="my-input" value="test">
+        <test-pharos-text-input name="my-input" value="test">
           <span slot="label">I am a label</span>
-        </pharos-text-input>
+        </test-pharos-text-input>
       `,
       { parentNode }
     );
@@ -397,9 +421,9 @@ describe('pharos-text-input', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-text-input name="my-input" value="test">
+        <test-pharos-text-input name="my-input" value="test">
           <span slot="label">I am a label</span>
-        </pharos-text-input>
+        </test-pharos-text-input>
       `,
       { parentNode }
     );
@@ -417,9 +441,9 @@ describe('pharos-text-input', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-text-input name="my-input" value="test">
+        <test-pharos-text-input name="my-input" value="test">
           <span slot="label">I am a label</span>
-        </pharos-text-input>
+        </test-pharos-text-input>
       `,
       { parentNode }
     );

--- a/packages/pharos/src/components/text-input/pharos-text-input.wc.stories.jsx
+++ b/packages/pharos/src/components/text-input/pharos-text-input.wc.stories.jsx
@@ -20,7 +20,7 @@ export const Base = {
   render: (args) =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 300px;">
-        <pharos-text-input
+        <storybook-pharos-text-input
           name="${args.name}"
           type="${ifDefined(args.type)}"
           ?hide-label="${args.hideLabel}"
@@ -34,7 +34,7 @@ export const Base = {
           .value=${args.value}
         >
           <span slot="label">${args.label}</span>
-        </pharos-text-input>
+        </storybook-pharos-text-input>
       </div>
     `,
   args: defaultArgs,
@@ -46,27 +46,29 @@ export const States = {
       <div
         style="display: grid; grid-gap: 1rem; grid-template-columns: repeat(2, 300px); 1rem 300px"
       >
-        <pharos-text-input name="default"><span slot="label">Empty input</span></pharos-text-input>
-        <pharos-text-input name="disabled" disabled
-          ><span slot="label">Disabled input</span></pharos-text-input
+        <storybook-pharos-text-input name="default"
+          ><span slot="label">Empty input</span></storybook-pharos-text-input
         >
-        <pharos-text-input name="readonly" readonly value="Example text"
-          ><span slot="label">Read only input</span></pharos-text-input
+        <storybook-pharos-text-input name="disabled" disabled
+          ><span slot="label">Disabled input</span></storybook-pharos-text-input
         >
-        <pharos-text-input name="placeholder" placeholder="example placeholder text"
-          ><span slot="label">Placeholder for input</span></pharos-text-input
+        <storybook-pharos-text-input name="readonly" readonly value="Example text"
+          ><span slot="label">Read only input</span></storybook-pharos-text-input
         >
-        <pharos-text-input name="provided" value="This value was provided"
-          ><span slot="label">Value provided</span></pharos-text-input
+        <storybook-pharos-text-input name="placeholder" placeholder="example placeholder text"
+          ><span slot="label">Placeholder for input</span></storybook-pharos-text-input
         >
-        <pharos-text-input name="hidden" hide-label value="Hidden label input"
-          ><span slot="label">Hidden label</span></pharos-text-input
+        <storybook-pharos-text-input name="provided" value="This value was provided"
+          ><span slot="label">Value provided</span></storybook-pharos-text-input
         >
-        <pharos-text-input name="validated" value="A validated value" validated
-          ><span slot="label">Validated input</span></pharos-text-input
+        <storybook-pharos-text-input name="hidden" hide-label value="Hidden label input"
+          ><span slot="label">Hidden label</span></storybook-pharos-text-input
         >
-        <pharos-text-input name="prominent" placeholder="so prominent" variant="prominent"
-          ><span slot="label">Prominent input</span></pharos-text-input
+        <storybook-pharos-text-input name="validated" value="A validated value" validated
+          ><span slot="label">Validated input</span></storybook-pharos-text-input
+        >
+        <storybook-pharos-text-input name="prominent" placeholder="so prominent" variant="prominent"
+          ><span slot="label">Prominent input</span></storybook-pharos-text-input
         >
       </div>
     `,
@@ -76,13 +78,13 @@ export const Events = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 300px;">
-        <pharos-text-input
+        <storybook-pharos-text-input
           placeholder="Enter some text"
           @change="${(e) => action('Change')(e.target.value)}"
           @input="${(e) => action('Input')(e.target.value)}"
         >
           <span slot="label">I fire events on input</span>
-        </pharos-text-input>
+        </storybook-pharos-text-input>
       </div>
     `,
   parameters: { options: { selectedPanel: 'addon-actions' } },
@@ -103,7 +105,7 @@ export const CustomErrorMessage = {
   render: (args) =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 300px;">
-        <pharos-text-input
+        <storybook-pharos-text-input
           placeholder="Enter some text"
           @change="${(e) => action('Change')(e.target.value)}"
           @input="${(e) => action('Input')(e.target.value)}"
@@ -121,7 +123,7 @@ export const CustomErrorMessage = {
               <li>No whitespace</li>
             </ul>
           </span>
-        </pharos-text-input>
+        </storybook-pharos-text-input>
       </div>
     `,
   args: {
@@ -136,7 +138,7 @@ export const FormData = {
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 300px;">
         <form name="my-form" action="https://httpbin.org/post" method="POST">
-          <pharos-text-input
+          <storybook-pharos-text-input
             style="margin-bottom: 0.5rem;"
             name="my-text-input"
             placeholder="Enter some text"
@@ -145,8 +147,8 @@ export const FormData = {
             required
           >
             <span slot="label">Test me out</span>
-          </pharos-text-input>
-          <pharos-button
+          </storybook-pharos-text-input>
+          <storybook-pharos-button
             type="submit"
             value="Submit"
             @click="${(e) => {
@@ -162,7 +164,7 @@ export const FormData = {
               xhr.send(formData);
             }}"
             >Submit
-          </pharos-button>
+          </storybook-pharos-button>
         </form>
       </div>
     `,

--- a/packages/pharos/src/components/textarea/PharosTextarea.react.stories.jsx
+++ b/packages/pharos/src/components/textarea/PharosTextarea.react.stories.jsx
@@ -4,10 +4,18 @@ import { PharosTextarea, PharosButton } from '../../react-components';
 import createFormData from '../../utils/createFormData';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Forms/Textarea',
   component: PharosTextarea,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('textarea') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/textarea/pharos-textarea.test.ts
+++ b/packages/pharos/src/components/textarea/pharos-textarea.test.ts
@@ -9,7 +9,7 @@ describe('pharos-textarea', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html`<pharos-textarea><span slot="label">I am a label</span></pharos-textarea>`
+      html`<test-pharos-textarea><span slot="label">I am a label</span></test-pharos-textarea>`
     );
   });
 
@@ -25,32 +25,38 @@ describe('pharos-textarea', () => {
 
   it('is accessible when disabled', async () => {
     component = await fixture(
-      html`<pharos-textarea disabled><span slot="label">I am a label</span></pharos-textarea>`
+      html`<test-pharos-textarea disabled
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >`
     );
     await expect(component).to.be.accessible();
   });
 
   it('is accessible when readonly', async () => {
     component = await fixture(
-      html`<pharos-textarea readonly><span slot="label">I am a label</span></pharos-textarea>`
+      html`<test-pharos-textarea readonly
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >`
     );
     await expect(component).to.be.accessible();
   });
 
   it('sets its default attributes', async () => {
     component = await fixture(html`
-      <pharos-textarea>
+      <test-pharos-textarea>
         <span slot="label">I am a label</span>
-      </pharos-textarea>
+      </test-pharos-textarea>
     `);
     expect(component).dom.to.equal(
-      `<pharos-textarea cols="20" data-pharos-component="PharosTextarea" dirname="" message="" name="" placeholder="" resize="both" rows="2" value="" wrap="soft"><span slot="label">I am a label</span></pharos-textarea>`
+      `<test-pharos-textarea cols="20" data-pharos-component="PharosTextarea" dirname="" message="" name="" placeholder="" resize="both" rows="2" value="" wrap="soft"><span slot="label">I am a label</span></test-pharos-textarea>`
     );
   });
 
   it('has an attribute to set the placeholder text of the input', async () => {
     component = await fixture(html`
-      <pharos-textarea placeholder="test"><span slot="label">I am a label</span></pharos-textarea>
+      <test-pharos-textarea placeholder="test"
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >
     `);
     expect(component.getAttribute('placeholder')).to.equal('test');
     expect(component['_textarea'].getAttribute('placeholder')).to.equal('test');
@@ -63,7 +69,9 @@ describe('pharos-textarea', () => {
 
   it('has an attribute to set input value', async () => {
     component = await fixture(html`
-      <pharos-textarea value="test"><span slot="label">I am a label</span></pharos-textarea>
+      <test-pharos-textarea value="test"
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >
     `);
     expect(component.getAttribute('value')).to.equal('test');
     expect(component['_textarea'].value).to.equal('test');
@@ -71,14 +79,18 @@ describe('pharos-textarea', () => {
 
   it('has an attribute to set resize options', async () => {
     component = await fixture(html`
-      <pharos-textarea resize="none"><span slot="label">I am a label</span></pharos-textarea>
+      <test-pharos-textarea resize="none"
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >
     `);
     expect(component.getAttribute('resize')).to.equal('none');
   });
 
   it('throws an error for an invalid resize value', async () => {
     component = await fixture(html`
-      <pharos-textarea resize="blah"><span slot="label">I am a label</span></pharos-textarea>
+      <test-pharos-textarea resize="blah"
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >
     `).catch((e) => e);
     expect('blah is not a valid resize value. Valid values are: none, vertical, horizontal, both')
       .to.be.thrown;
@@ -86,14 +98,18 @@ describe('pharos-textarea', () => {
 
   it('has an attribute to set wrap options', async () => {
     component = await fixture(html`
-      <pharos-textarea wrap="hard"><span slot="label">I am a label</span></pharos-textarea>
+      <test-pharos-textarea wrap="hard"
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >
     `);
     expect(component.getAttribute('wrap')).to.equal('hard');
   });
 
   it('throws an error for an invalid wrap value', async () => {
     component = await fixture(html`
-      <pharos-textarea wrap="blah"><span slot="label">I am a label</span></pharos-textarea>
+      <test-pharos-textarea wrap="blah"
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >
     `).catch((e) => e);
     expect('blah is not a valid wrap value. Valid values are: soft, hard').to.be.thrown;
   });
@@ -111,7 +127,9 @@ describe('pharos-textarea', () => {
       eventSource = event.composedPath()[0] as Element;
     };
     component = await fixture(html`
-      <pharos-textarea @change=${onChange}><span slot="label">I am a label</span></pharos-textarea>
+      <test-pharos-textarea @change=${onChange}
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >
     `);
 
     component['_textarea'].value = 'test';
@@ -143,7 +161,9 @@ describe('pharos-textarea', () => {
     document.addEventListener('focusin', onFocusIn);
 
     component = await fixture(
-      html`<pharos-textarea disabled><span slot="label">I am a label</span></pharos-textarea>`
+      html`<test-pharos-textarea disabled
+        ><span slot="label">I am a label</span></test-pharos-textarea
+      >`
     );
 
     component['_textarea'].focus();
@@ -155,7 +175,9 @@ describe('pharos-textarea', () => {
 
   it('renders a required asterisk and hidden text when input is required', async () => {
     component = await fixture(
-      html` <pharos-textarea required><span slot="label">I am a label</span></pharos-textarea> `
+      html`
+        <test-pharos-textarea required><span slot="label">I am a label</span></test-pharos-textarea>
+      `
     );
     expect(component).shadowDom.to.equal(`
       <label for="textarea-element">
@@ -190,8 +212,8 @@ describe('pharos-textarea', () => {
   it('renders a provided message', async () => {
     component = await fixture(
       html`
-        <pharos-textarea message="I am invalid"
-          ><span slot="label">I am a label</span></pharos-textarea
+        <test-pharos-textarea message="I am invalid"
+          ><span slot="label">I am a label</span></test-pharos-textarea
         >
       `
     );
@@ -231,7 +253,11 @@ describe('pharos-textarea', () => {
 
   it('removes invalidated state when validated', async () => {
     component = await fixture(
-      html` <pharos-textarea invalidated><span slot="label">I am a label</span></pharos-textarea> `
+      html`
+        <test-pharos-textarea invalidated
+          ><span slot="label">I am a label</span></test-pharos-textarea
+        >
+      `
     );
     component.validated = true;
     await component.updateComplete;
@@ -242,7 +268,11 @@ describe('pharos-textarea', () => {
 
   it('removes validated state when invalidated', async () => {
     component = await fixture(
-      html` <pharos-textarea validated><span slot="label">I am a label</span></pharos-textarea> `
+      html`
+        <test-pharos-textarea validated
+          ><span slot="label">I am a label</span></test-pharos-textarea
+        >
+      `
     );
     component.invalidated = true;
     await component.updateComplete;
@@ -256,9 +286,9 @@ describe('pharos-textarea', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-textarea name="my-textarea" value="test">
+        <test-pharos-textarea name="my-textarea" value="test">
           <span slot="label">I am a label</span>
-        </pharos-textarea>
+        </test-pharos-textarea>
       `,
       { parentNode }
     );
@@ -274,9 +304,9 @@ describe('pharos-textarea', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-textarea name="my-textarea" value="test" disabled>
+        <test-pharos-textarea name="my-textarea" value="test" disabled>
           <span slot="label">I am a label</span>
-        </pharos-textarea>
+        </test-pharos-textarea>
       `,
       { parentNode }
     );
@@ -305,9 +335,9 @@ describe('pharos-textarea', () => {
     parentNode.setAttribute('name', 'my-form');
     component = await fixture(
       html`
-        <pharos-textarea name="my-textarea" value="test">
+        <test-pharos-textarea name="my-textarea" value="test">
           <span slot="label">I am a label</span>
-        </pharos-textarea>
+        </test-pharos-textarea>
       `,
       { parentNode }
     );

--- a/packages/pharos/src/components/textarea/pharos-textarea.wc.stories.jsx
+++ b/packages/pharos/src/components/textarea/pharos-textarea.wc.stories.jsx
@@ -19,7 +19,7 @@ export const Base = {
   render: (args) =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 250px;">
-        <pharos-textarea
+        <storybook-pharos-textarea
           name="story-input"
           .cols="${args.columns}"
           ?disabled=${args.disabled}
@@ -35,7 +35,7 @@ export const Base = {
           .value=${args.value}
         >
           <span slot="label">${args.label}</span>
-        </pharos-textarea>
+        </storybook-pharos-textarea>
       </div>
     `,
   args: defaultArgs,
@@ -45,21 +45,23 @@ export const States = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: repeat(2, 250px);">
-        <pharos-textarea name="default"><span slot="label">Empty textarea</span></pharos-textarea>
-        <pharos-textarea name="disabled" disabled
-          ><span slot="label">Disabled textarea</span></pharos-textarea
+        <storybook-pharos-textarea name="default"
+          ><span slot="label">Empty textarea</span></storybook-pharos-textarea
         >
-        <pharos-textarea name="readonly" readonly value="Example text"
-          ><span slot="label">Read only textarea</span></pharos-textarea
+        <storybook-pharos-textarea name="disabled" disabled
+          ><span slot="label">Disabled textarea</span></storybook-pharos-textarea
         >
-        <pharos-textarea name="placeholder" placeholder="Placeholder text"
-          ><span slot="label">Placeholder for textarea</span></pharos-textarea
+        <storybook-pharos-textarea name="readonly" readonly value="Example text"
+          ><span slot="label">Read only textarea</span></storybook-pharos-textarea
         >
-        <pharos-textarea name="provided" value="This value is provided"
-          ><span slot="label">Value provided textarea</span></pharos-textarea
+        <storybook-pharos-textarea name="placeholder" placeholder="Placeholder text"
+          ><span slot="label">Placeholder for textarea</span></storybook-pharos-textarea
         >
-        <pharos-textarea name="resize" resize="none"
-          ><span slot="label">non-resizeable textarea</span></pharos-textarea
+        <storybook-pharos-textarea name="provided" value="This value is provided"
+          ><span slot="label">Value provided textarea</span></storybook-pharos-textarea
+        >
+        <storybook-pharos-textarea name="resize" resize="none"
+          ><span slot="label">non-resizeable textarea</span></storybook-pharos-textarea
         >
       </div>
     `,
@@ -69,13 +71,13 @@ export const Events = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 250px;">
-        <pharos-textarea
+        <storybook-pharos-textarea
           placeholder="Enter some text"
           @change="${(e) => action('Change')(e.target.value)}"
           @input="${(e) => action('Input')(e.target.value)}"
         >
           <span slot="label">I fire events on input</span>
-        </pharos-textarea>
+        </storybook-pharos-textarea>
       </div>
     `,
   parameters: { options: { selectedPanel: 'addon-actions' } },
@@ -98,7 +100,7 @@ export const CustomErrorMessage = {
   render: (args) =>
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 350px;">
-        <pharos-textarea
+        <storybook-pharos-textarea
           placeholder="Enter some text"
           @change="${(e) => action('Change')(e.target.value)}"
           @input="${(e) => action('Input')(e.target.value)}"
@@ -111,7 +113,7 @@ export const CustomErrorMessage = {
           <span slot="message">
             <p>Must be over 100 characters long</p>
           </span>
-        </pharos-textarea>
+        </storybook-pharos-textarea>
       </div>
     `,
   args: {
@@ -126,7 +128,7 @@ export const FormData = {
     html`
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 350px;">
         <form name="my-form" action="https://httpbin.org/post" method="POST">
-          <pharos-textarea
+          <storybook-pharos-textarea
             name="my-textarea"
             placeholder="Enter some text"
             style="margin-bottom: 0.5rem;"
@@ -135,8 +137,8 @@ export const FormData = {
             required
           >
             <span slot="label">I am invalid</span>
-          </pharos-textarea>
-          <pharos-button
+          </storybook-pharos-textarea>
+          <storybook-pharos-button
             type="submit"
             value="Submit"
             @click="${(e) => {
@@ -153,7 +155,7 @@ export const FormData = {
             }}"
           >
             Submit
-          </pharos-button>
+          </storybook-pharos-button>
         </form>
       </div>
     `,

--- a/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
+++ b/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
@@ -2,11 +2,19 @@ import { useEffect } from 'react';
 
 import { PharosToast, PharosToaster, PharosButton } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Toast',
   component: PharosToast,
   subcomponents: { PharosToaster },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('toast') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/toast/pharos-toast-button.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toast-button.test.ts
@@ -8,16 +8,19 @@ describe('pharos-toast-button', () => {
   let component: PharosToastButton;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-toast-button></pharos-toast-button> `);
+    component = await fixture(html` <test-pharos-toast-button></test-pharos-toast-button> `);
   });
 
   it('is accessible on a AA compliant background', async () => {
     const parentNode = document.createElement('div');
     parentNode.style.backgroundColor = PharosColorMarbleGray10;
 
-    component = await fixture(html`<pharos-toast-button>I am a button</pharos-toast-button>`, {
-      parentNode,
-    });
+    component = await fixture(
+      html`<test-pharos-toast-button>I am a button</test-pharos-toast-button>`,
+      {
+        parentNode,
+      }
+    );
     await expect(component).to.be.accessible();
   });
 });

--- a/packages/pharos/src/components/toast/pharos-toast.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.test.ts
@@ -8,10 +8,10 @@ describe('pharos-toast', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-toast open>
+      <test-pharos-toast open>
         The item has moved to your
-        <pharos-link href="#" on-background bold>Workspace</pharos-link>.
-      </pharos-toast>
+        <test-pharos-link href="#" on-background bold>Workspace</test-pharos-link>.
+      </test-pharos-toast>
     `);
   });
 
@@ -21,7 +21,7 @@ describe('pharos-toast', () => {
 
   it('throws an error for an invalid status value', async () => {
     component = await fixture(html`
-      <pharos-toast status="fake">I am a toast</pharos-toast>
+      <test-pharos-toast status="fake">I am a toast</test-pharos-toast>
     `).catch((e) => e);
     expect('fake is not a valid status. Valid statuses are: success, error').to.be.thrown;
   });
@@ -50,7 +50,9 @@ describe('pharos-toast', () => {
     component.status = 'error';
     await component.updateComplete;
 
-    const icon = component.renderRoot.querySelector('pharos-icon') as PharosIcon;
+    const icon = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosIcon"]'
+    ) as PharosIcon;
     expect(icon?.name).to.equal('exclamation-inverse');
   });
 
@@ -58,7 +60,9 @@ describe('pharos-toast', () => {
     component.status = 'info';
     await component.updateComplete;
 
-    const icon = component.renderRoot.querySelector('pharos-icon') as PharosIcon;
+    const icon = component.renderRoot.querySelector(
+      '[data-pharos-component="PharosIcon"]'
+    ) as PharosIcon;
     expect(icon?.name).to.equal('exclamation-inverse');
   });
 

--- a/packages/pharos/src/components/toast/pharos-toast.wc.stories.jsx
+++ b/packages/pharos/src/components/toast/pharos-toast.wc.stories.jsx
@@ -23,21 +23,21 @@ export const Base = {
     };
     effect();
     return html`
-      <pharos-button
+      <storybook-pharos-button
         id="success-toast-button"
         @click="${() => {
           const event = new CustomEvent('pharos-toast-open', {
             detail: {
               content:
-                'The item has moved to your <pharos-link href="#" on-background bold>Workspace</pharos-link>.',
+                'The item has moved to your <storybook-pharos-link href="#" on-background bold>Workspace</storybook-pharos-link>.',
             },
           });
           document.dispatchEvent(event);
         }}"
       >
         Have a toast!
-      </pharos-button>
-      <pharos-toaster></pharos-toaster>
+      </storybook-pharos-button>
+      <storybook-pharos-toaster></storybook-pharos-toaster>
     `;
   },
   parameters: { chromatic: { viewports: [320, 1200] } },
@@ -52,22 +52,22 @@ export const Error = {
     };
     effect();
     return html`
-      <pharos-button
+      <storybook-pharos-button
         id="error-toast-button"
         @click="${() => {
           const event = new CustomEvent('pharos-toast-open', {
             detail: {
               status: 'error',
               content:
-                'Sorry, we were unable to move the item. Please try again later. If the issue persists, <pharos-link href="#" on-background bold>contact JSTOR Support</pharos-link>.',
+                'Sorry, we were unable to move the item. Please try again later. If the issue persists, <storybook-pharos-link href="#" on-background bold>contact JSTOR Support</storybook-pharos-link>.',
             },
           });
           document.dispatchEvent(event);
         }}"
       >
         I have a bad feeling about this
-      </pharos-button>
-      <pharos-toaster></pharos-toaster>
+      </storybook-pharos-button>
+      <storybook-pharos-toaster></storybook-pharos-toaster>
     `;
   },
 };
@@ -83,21 +83,21 @@ export const LongContent = {
     };
     effect();
     return html`
-      <pharos-button
+      <storybook-pharos-button
         id="long-toast-button"
         @click="${() => {
           const event = new CustomEvent('pharos-toast-open', {
             detail: {
               content:
-                'This is a notification for longer content, which may even include a <pharos-link href="#" on-background bold>link</pharos-link>.',
+                'This is a notification for longer content, which may even include a <storybook-pharos-link href="#" on-background bold>link</storybook-pharos-link>.',
             },
           });
           document.dispatchEvent(event);
         }}"
       >
         Click to me see a long name
-      </pharos-button>
-      <pharos-toaster></pharos-toaster>
+      </storybook-pharos-button>
+      <storybook-pharos-toaster></storybook-pharos-toaster>
     `;
   },
   parameters: { chromatic: { viewports: [320, 1200] } },
@@ -112,7 +112,7 @@ export const Info = {
     };
     effect();
     return html`
-      <pharos-button
+      <storybook-pharos-button
         id="info-toast-button"
         @click="${() => {
           const event = new CustomEvent('pharos-toast-open', {
@@ -125,8 +125,8 @@ export const Info = {
         }}"
       >
         Click me to know more
-      </pharos-button>
-      <pharos-toaster></pharos-toaster>
+      </storybook-pharos-button>
+      <storybook-pharos-toaster></storybook-pharos-toaster>
     `;
   },
 };
@@ -140,7 +140,7 @@ export const UpdateableToast = {
     };
     effect();
     return html`
-      <pharos-button
+      <storybook-pharos-button
         id="info-toast-button"
         @click="${() => {
           const event = new CustomEvent('pharos-toast-open', {
@@ -167,8 +167,8 @@ export const UpdateableToast = {
         }}"
       >
         Save items to Workspace
-      </pharos-button>
-      <pharos-toaster></pharos-toaster>
+      </storybook-pharos-button>
+      <storybook-pharos-toaster></storybook-pharos-toaster>
     `;
   },
 };

--- a/packages/pharos/src/components/toast/pharos-toaster.test.ts
+++ b/packages/pharos/src/components/toast/pharos-toaster.test.ts
@@ -48,7 +48,7 @@ describe('pharos-toaster', () => {
   };
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-toaster></pharos-toaster> `);
+    component = await fixture(html` <test-pharos-toaster></test-pharos-toaster> `);
   });
 
   it('is accessible', async () => {
@@ -63,7 +63,7 @@ describe('pharos-toaster', () => {
     trigger.click();
     await component.updateComplete;
 
-    const toast = component.querySelector('pharos-toast');
+    const toast = component.querySelector('test-pharos-toast');
     expect(toast).to.not.be.null;
   });
 
@@ -78,7 +78,7 @@ describe('pharos-toaster', () => {
     await component.updateComplete;
     await nextFrame();
 
-    const toast = component.querySelectorAll('pharos-toast');
+    const toast = component.querySelectorAll('test-pharos-toast');
     expect(toast.length).to.equal(2);
   });
 
@@ -97,7 +97,7 @@ describe('pharos-toaster', () => {
     await component.updateComplete;
 
     const toast = (
-      component.querySelector('pharos-toast') as PharosToast
+      component.querySelector('test-pharos-toast') as PharosToast
     )?.renderRoot.querySelector('.toast');
     expect(activeElement === toast).to.be.true;
     document.removeEventListener('focusin', onFocusIn);
@@ -111,7 +111,7 @@ describe('pharos-toaster', () => {
     trigger.click();
     await component.updateComplete;
 
-    const toast = component.querySelector('pharos-toast');
+    const toast = component.querySelector('test-pharos-toast');
     expect(toast).to.not.be.null;
   });
 
@@ -123,7 +123,7 @@ describe('pharos-toaster', () => {
     trigger.click();
     await component.updateComplete;
 
-    const openToast = component.querySelector('pharos-toast');
+    const openToast = component.querySelector('test-pharos-toast');
     const details = {
       bubbles: true,
       composed: true,
@@ -132,7 +132,7 @@ describe('pharos-toaster', () => {
     component.dispatchEvent(new CustomEvent('pharos-toast-close', details));
     await component.updateComplete;
 
-    const toast = component.querySelector('pharos-toast');
+    const toast = component.querySelector('test-pharos-toast');
     expect(toast).to.be.null;
   });
 
@@ -150,9 +150,9 @@ describe('pharos-toaster', () => {
     await component.updateComplete;
 
     expect(component).dom.to.equal(`
-      <pharos-toaster data-pharos-component="PharosToaster">
-        <pharos-toast data-pharos-component="PharosToast" id="my-updateable-toast" indefinite="" open="" status="success">Toast has been updated</pharos-toast>
-      </pharos-toaster>
+      <test-pharos-toaster data-pharos-component="PharosToaster">
+        <test-pharos-toast data-pharos-component="PharosToast" id="my-updateable-toast" indefinite="" open="" status="success">Toast has been updated</test-pharos-toast>
+      </test-pharos-toaster>
     `);
   });
 });

--- a/packages/pharos/src/components/toggle-button-group/PharosToggleButtonGroup.react.stories.jsx
+++ b/packages/pharos/src/components/toggle-button-group/PharosToggleButtonGroup.react.stories.jsx
@@ -2,11 +2,19 @@ import { action } from '@storybook/addon-actions';
 
 import { PharosToggleButtonGroup, PharosToggleButton } from '../../react-components';
 import { configureDocsPage } from '@config/docsPageConfig';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Toggle Button Group',
   component: PharosToggleButtonGroup,
   subcomponents: { PharosToggleButton },
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('toggle-button-group') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.test.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.test.ts
@@ -11,27 +11,27 @@ describe('pharos-toggle-button-group', () => {
 
   beforeEach(async () => {
     component = await fixture(html`
-      <pharos-toggle-button-group>
-        <pharos-toggle-button id="button-1">Button 1</pharos-toggle-button>
-        <pharos-toggle-button id="button-2">Button 2</pharos-toggle-button>
-        <pharos-toggle-button id="button-3">Button 3</pharos-toggle-button>
-      </pharos-toggle-button-group>
+      <test-pharos-toggle-button-group>
+        <test-pharos-toggle-button id="button-1">Button 1</test-pharos-toggle-button>
+        <test-pharos-toggle-button id="button-2">Button 2</test-pharos-toggle-button>
+        <test-pharos-toggle-button id="button-3">Button 3</test-pharos-toggle-button>
+      </test-pharos-toggle-button-group>
     `);
 
     componentLastButtonSelected = await fixture(html`
-      <pharos-toggle-button-group>
-        <pharos-toggle-button id="button-4">Button 4</pharos-toggle-button>
-        <pharos-toggle-button id="button-5">Button 5</pharos-toggle-button>
-        <pharos-toggle-button id="button-6" selected>Button 6</pharos-toggle-button>
-      </pharos-toggle-button-group>
+      <test-pharos-toggle-button-group>
+        <test-pharos-toggle-button id="button-4">Button 4</test-pharos-toggle-button>
+        <test-pharos-toggle-button id="button-5">Button 5</test-pharos-toggle-button>
+        <test-pharos-toggle-button id="button-6" selected>Button 6</test-pharos-toggle-button>
+      </test-pharos-toggle-button-group>
     `);
 
     componentWithLabel = await fixture(html`
-      <pharos-toggle-button-group group-label="New options">
-        <pharos-toggle-button id="button-7">Button 7</pharos-toggle-button>
-        <pharos-toggle-button id="button-8">Button 8</pharos-toggle-button>
-        <pharos-toggle-button id="button-9" selected>Button 9</pharos-toggle-button>
-      </pharos-toggle-button-group>
+      <test-pharos-toggle-button-group group-label="New options">
+        <test-pharos-toggle-button id="button-7">Button 7</test-pharos-toggle-button>
+        <test-pharos-toggle-button id="button-8">Button 8</test-pharos-toggle-button>
+        <test-pharos-toggle-button id="button-9" selected>Button 9</test-pharos-toggle-button>
+      </test-pharos-toggle-button-group>
     `);
   });
 
@@ -69,7 +69,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('has 3 toggle buttons within the slot', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-toggle-button`)
+      component.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     expect(toggleButtons.length).to.be.eq(3);
@@ -77,7 +77,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('selects the first toggle button if no selection is defined', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-toggle-button`)
+      component.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     expect(toggleButtons[0].selected).to.be.true;
@@ -90,7 +90,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('selects the defined toggle button', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      componentLastButtonSelected.querySelectorAll(`pharos-toggle-button`)
+      componentLastButtonSelected.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     expect(toggleButtons[0].selected).to.be.false;
@@ -103,7 +103,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('changes the focus right with the right arrow key', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-toggle-button`)
+      component.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     toggleButtons[1].focus();
@@ -116,7 +116,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('changes the focus left with the left arrow key', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      componentLastButtonSelected.querySelectorAll(`pharos-toggle-button`)
+      componentLastButtonSelected.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     toggleButtons[1].focus();
@@ -129,7 +129,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('changes the selection with keyboard', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-toggle-button`)
+      component.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     toggleButtons[1].focus();
@@ -150,7 +150,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('wraps focus to the last toggle button when left arrow is hit on the first button', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-toggle-button`)
+      component.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     toggleButtons[1].focus();
@@ -167,7 +167,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('wraps focus to the first button when left arrow is hit on the last button', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      componentLastButtonSelected.querySelectorAll(`pharos-toggle-button`)
+      componentLastButtonSelected.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     toggleButtons[1].focus();
@@ -184,7 +184,7 @@ describe('pharos-toggle-button-group', () => {
 
   it('changes the selected button on click', async () => {
     const toggleButtons = Array.prototype.slice.call(
-      component.querySelectorAll(`pharos-toggle-button`)
+      component.querySelectorAll(`test-pharos-toggle-button`)
     ) as PharosToggleButton[];
 
     toggleButtons[1].click();

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.wc.stories.jsx
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.wc.stories.jsx
@@ -16,8 +16,8 @@ export default {
 export const Base = {
   render: () =>
     html`
-      <pharos-toggle-button-group>
-        <pharos-toggle-button
+      <storybook-pharos-toggle-button-group>
+        <storybook-pharos-toggle-button
           @click="${() => {
             document.querySelector('#list-view').style.display = 'block';
             document.querySelector('#gallery-view').style.display = 'none';
@@ -26,8 +26,8 @@ export const Base = {
           icon-left="view-list"
           id="view-list-button"
         >
-          List </pharos-toggle-button
-        ><pharos-toggle-button
+          List </storybook-pharos-toggle-button
+        ><storybook-pharos-toggle-button
           @click="${() => {
             document.querySelector('#list-view').style.display = 'none';
             document.querySelector('#gallery-view').style.display = 'block';
@@ -36,8 +36,8 @@ export const Base = {
           icon-left="view-gallery"
           id="view-gallery-button"
         >
-          Gallery </pharos-toggle-button
-        ><pharos-toggle-button
+          Gallery </storybook-pharos-toggle-button
+        ><storybook-pharos-toggle-button
           @click="${() => {
             document.querySelector('#list-view').style.display = 'none';
             document.querySelector('#gallery-view').style.display = 'none';
@@ -47,8 +47,8 @@ export const Base = {
           id="view-presentation-button"
         >
           Presentation
-        </pharos-toggle-button>
-      </pharos-toggle-button-group>
+        </storybook-pharos-toggle-button>
+      </storybook-pharos-toggle-button-group>
       <div id="list-view">List view</div>
       <div id="gallery-view" style="display: none">Gallery view</div>
       <div id="presentation-view" style="display: none">Presentation view</div>
@@ -58,15 +58,15 @@ export const Base = {
 export const Events = {
   render: () =>
     html`
-      <pharos-toggle-button-group
+      <storybook-pharos-toggle-button-group
         @pharos-toggle-button-selected="${(e) => action('Selected')(e.target.id)}"
       >
-        <pharos-toggle-button id="list-mode-button" icon-left="view-list">
-          List </pharos-toggle-button
-        ><pharos-toggle-button id="gallery-mode-button" icon-left="view-gallery">
+        <storybook-pharos-toggle-button id="list-mode-button" icon-left="view-list">
+          List </storybook-pharos-toggle-button
+        ><storybook-pharos-toggle-button id="gallery-mode-button" icon-left="view-gallery">
           Gallery
-        </pharos-toggle-button>
-      </pharos-toggle-button-group>
+        </storybook-pharos-toggle-button>
+      </storybook-pharos-toggle-button-group>
     `,
   parameters: { options: { selectedPanel: 'addon-actions' } },
 };
@@ -74,10 +74,19 @@ export const Events = {
 export const IconsOnly = {
   render: () =>
     html`
-      <pharos-toggle-button-group>
-        <pharos-toggle-button icon="view-list" id="view-list-button"></pharos-toggle-button
-        ><pharos-toggle-button icon="view-gallery" id="view-gallery-button"></pharos-toggle-button
-        ><pharos-toggle-button icon="image" id="view-presentation-button"></pharos-toggle-button>
-      </pharos-toggle-button-group>
+      <storybook-pharos-toggle-button-group>
+        <storybook-pharos-toggle-button
+          icon="view-list"
+          id="view-list-button"
+        ></storybook-pharos-toggle-button
+        ><storybook-pharos-toggle-button
+          icon="view-gallery"
+          id="view-gallery-button"
+        ></storybook-pharos-toggle-button
+        ><storybook-pharos-toggle-button
+          icon="image"
+          id="view-presentation-button"
+        ></storybook-pharos-toggle-button>
+      </storybook-pharos-toggle-button-group>
     `,
 };

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.test.ts
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button.test.ts
@@ -8,22 +8,25 @@ describe('pharos-toggle-button', () => {
   let component: PharosToggleButton;
 
   beforeEach(async () => {
-    component = await fixture(html` <pharos-toggle-button></pharos-toggle-button> `);
+    component = await fixture(html` <test-pharos-toggle-button></test-pharos-toggle-button> `);
   });
 
   it('is accessible on a AA compliant background', async () => {
     const parentNode = document.createElement('div');
     parentNode.style.backgroundColor = PharosColorWhite;
 
-    component = await fixture(html`<pharos-toggle-button>I am a button</pharos-toggle-button>`, {
-      parentNode,
-    });
+    component = await fixture(
+      html`<test-pharos-toggle-button>I am a button</test-pharos-toggle-button>`,
+      {
+        parentNode,
+      }
+    );
     await expect(component).to.be.accessible();
   });
 
   it('throws an error when an invalid property is set', async () => {
     component = await fixture(
-      html` <pharos-toggle-button href="www.truedelta.com"></pharos-toggle-button> `
+      html` <test-pharos-toggle-button href="www.truedelta.com"></test-pharos-toggle-button> `
     ).catch((e) => e);
     expect(
       'The toggle button component does not support these properties: href, hreflang, ping, rel, and target.'

--- a/packages/pharos/src/components/tooltip/PharosTooltip.react.stories.jsx
+++ b/packages/pharos/src/components/tooltip/PharosTooltip.react.stories.jsx
@@ -7,10 +7,18 @@ import {
 import { useEffect } from '@storybook/client-api';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { defaultArgs, argTypes } from './storyArgs';
+import { PharosContext } from '../../utils/PharosContext';
 
 export default {
   title: 'Components/Tooltip',
   component: PharosTooltip,
+  decorators: [
+    (Story) => (
+      <PharosContext.Provider value={{ prefix: 'storybook' }}>
+        <Story />
+      </PharosContext.Provider>
+    ),
+  ],
   parameters: {
     docs: { page: configureDocsPage('tooltip') },
     options: { selectedPanel: 'addon-controls' },

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.test.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.test.ts
@@ -21,11 +21,13 @@ describe('pharos-tooltip', () => {
 
   beforeEach(async () => {
     trigger = addTrigger();
-    component = await fixture(html` <pharos-tooltip id="my-tooltip">Hi there!</pharos-tooltip> `);
+    component = await fixture(
+      html` <test-pharos-tooltip id="my-tooltip">Hi there!</test-pharos-tooltip> `
+    );
 
     secondTrigger = addTrigger('my-second-trigger', 'my-second-tooltip');
     secondComponent = await fixture(html`
-      <pharos-tooltip id="my-second-tooltip">Hi there again!</pharos-tooltip>
+      <test-pharos-tooltip id="my-second-tooltip">Hi there again!</test-pharos-tooltip>
     `);
   });
 
@@ -46,7 +48,7 @@ describe('pharos-tooltip', () => {
 
   it('sets its default attributes', async () => {
     expect(component).dom.to.equal(
-      `<pharos-tooltip id="my-tooltip" placement="top" strategy="absolute" boundary="clippingAncestors" data-pharos-component="PharosTooltip">Hi there!</pharos-tooltip>`
+      `<test-pharos-tooltip id="my-tooltip" placement="top" strategy="absolute" boundary="clippingAncestors" data-pharos-component="PharosTooltip">Hi there!</test-pharos-tooltip>`
     );
   });
 
@@ -115,7 +117,7 @@ describe('pharos-tooltip', () => {
 
   it('throws an error for an invalid placement value', async () => {
     component = await fixture(html`
-      <pharos-tooltip placement="side">Hi there!</pharos-tooltip>
+      <test-pharos-tooltip placement="side">Hi there!</test-pharos-tooltip>
     `).catch((e) => e);
     expect(
       'side is not a valid placement. Valid placements are: top, top-start, top-end, bottom, bottom-start, bottom-end, right, right-start, right-end, left, left-start, left-end, auto, auto-start, auto-end'
@@ -170,8 +172,8 @@ describe('pharos-tooltip', () => {
 
   it('throws an error for invalid fallback values', async () => {
     component = await fixture(html`
-      <pharos-tooltip .fallbackPlacements="${['corner', 'right', 'fake'] as Placement[]}"
-        >Hi there!</pharos-tooltip
+      <test-pharos-tooltip .fallbackPlacements="${['corner', 'right', 'fake'] as Placement[]}"
+        >Hi there!</test-pharos-tooltip
       >
     `).catch((e) => e);
     expect(
@@ -181,7 +183,7 @@ describe('pharos-tooltip', () => {
 
   it('throws an error for invalid strategy values', async () => {
     component = await fixture(html`
-      <pharos-tooltip strategy="relative">Hi there!</pharos-tooltip>
+      <test-pharos-tooltip strategy="relative">Hi there!</test-pharos-tooltip>
     `).catch((e) => e);
     expect('relative is not a valid positioning strategy. Valid strategies are: absolute, fixed').to
       .be.thrown;
@@ -189,7 +191,9 @@ describe('pharos-tooltip', () => {
 
   it('applies text wrap class when tooltip content is longer than 30 characters', async () => {
     component = await fixture(html`
-      <pharos-tooltip>Hi there! I am a tooltip with more than 30 characters.</pharos-tooltip>
+      <test-pharos-tooltip
+        >Hi there! I am a tooltip with more than 30 characters.</test-pharos-tooltip
+      >
     `);
 
     expect(component['_bubble'].classList.contains('tooltip__bubble--text-wrap')).to.be.true;
@@ -209,7 +213,9 @@ describe('pharos-tooltip', () => {
 
   it('supports multiple triggers when open and another trigger is focused', async () => {
     const thirdTrigger = addTrigger('my-third-trigger', 'my-tooltip');
-    component = await fixture(html` <pharos-tooltip id="my-tooltip">Hi there!</pharos-tooltip> `);
+    component = await fixture(
+      html` <test-pharos-tooltip id="my-tooltip">Hi there!</test-pharos-tooltip> `
+    );
 
     trigger.dispatchEvent(new Event('mouseenter'));
     await component.updateComplete;
@@ -225,7 +231,9 @@ describe('pharos-tooltip', () => {
 
   it('supports multiple triggers when open and another trigger is hovered', async () => {
     const thirdTrigger = addTrigger('my-third-trigger', 'my-tooltip');
-    component = await fixture(html` <pharos-tooltip id="my-tooltip">Hi there!</pharos-tooltip> `);
+    component = await fixture(
+      html` <test-pharos-tooltip id="my-tooltip">Hi there!</test-pharos-tooltip> `
+    );
 
     trigger.dispatchEvent(new Event('focusin'));
     await aTimeout(100);
@@ -253,8 +261,8 @@ describe('pharos-tooltip', () => {
     const boundary = await fixture(html` <div id="custom-boundary" style="width: 100px"></div> `);
     document.body.appendChild(boundary);
     component = await fixture(html`
-      <pharos-tooltip id="my-second-tooltip"
-        >This one has content that is longer than 30 characters!</pharos-tooltip
+      <test-pharos-tooltip id="my-second-tooltip"
+        >This one has content that is longer than 30 characters!</test-pharos-tooltip
       >
     `);
     component.boundary = 'custom-boundary';

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.wc.stories.jsx
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.wc.stories.jsx
@@ -28,17 +28,17 @@ export const Base = {
     effect();
     return html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button id="my-button" data-tooltip-id="${args.id}"
-          >${args.targetText}</pharos-button
+        <storybook-pharos-button id="my-button" data-tooltip-id="${args.id}"
+          >${args.targetText}</storybook-pharos-button
         >
-        <pharos-tooltip
+        <storybook-pharos-tooltip
           id="${args.id}"
           ?full-width="${args.fullWidth}"
           ?open="${args.open}"
           .placement="${ifDefined(args.placement)}"
           .fallbackPlacements="${args.fallbackPlacements}"
           >${args.tooltipText}
-        </pharos-tooltip>
+        </storybook-pharos-tooltip>
       </div>
     `;
   },
@@ -60,12 +60,18 @@ export const DismissBehavior = {
       <div
         style="display: grid; grid-template-columns: repeat(3, auto); grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;"
       >
-        <pharos-button data-tooltip-id="my-hi-tooltip">Focus here</pharos-button>
-        <pharos-tooltip id="my-hi-tooltip">Hi there!</pharos-tooltip>
-        <pharos-button data-tooltip-id="my-again-tooltip">Then hover here</pharos-button>
-        <pharos-tooltip id="my-again-tooltip">Hi there again!</pharos-tooltip>
-        <pharos-button data-tooltip-id="my-yo-tooltip">Then focus me</pharos-button>
-        <pharos-tooltip id="my-yo-tooltip">Yo!</pharos-tooltip>
+        <storybook-pharos-button data-tooltip-id="my-hi-tooltip"
+          >Focus here</storybook-pharos-button
+        >
+        <storybook-pharos-tooltip id="my-hi-tooltip">Hi there!</storybook-pharos-tooltip>
+        <storybook-pharos-button data-tooltip-id="my-again-tooltip"
+          >Then hover here</storybook-pharos-button
+        >
+        <storybook-pharos-tooltip id="my-again-tooltip">Hi there again!</storybook-pharos-tooltip>
+        <storybook-pharos-button data-tooltip-id="my-yo-tooltip"
+          >Then focus me</storybook-pharos-button
+        >
+        <storybook-pharos-tooltip id="my-yo-tooltip">Yo!</storybook-pharos-tooltip>
       </div>
     `,
 };
@@ -99,10 +105,18 @@ export const MultipleTriggers = {
       <div
         style="display: grid; grid-template-columns: repeat(3, auto); grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;"
       >
-        <pharos-button data-tooltip-id="my-multi-tooltip">Focus here</pharos-button>
-        <pharos-button data-tooltip-id="my-multi-tooltip">Then hover here</pharos-button>
-        <pharos-button data-tooltip-id="my-multi-tooltip">Then focus me</pharos-button>
-        <pharos-tooltip id="my-multi-tooltip" full-width>Hi there!</pharos-tooltip>
+        <storybook-pharos-button data-tooltip-id="my-multi-tooltip"
+          >Focus here</storybook-pharos-button
+        >
+        <storybook-pharos-button data-tooltip-id="my-multi-tooltip"
+          >Then hover here</storybook-pharos-button
+        >
+        <storybook-pharos-button data-tooltip-id="my-multi-tooltip"
+          >Then focus me</storybook-pharos-button
+        >
+        <storybook-pharos-tooltip id="my-multi-tooltip" full-width
+          >Hi there!</storybook-pharos-tooltip
+        >
       </div>
     `,
 };
@@ -111,20 +125,23 @@ export const CustomBoundary = {
   render: () =>
     html`
       <div style="display: grid; grid-gap: 8rem; margin-top: 5rem; justify-content: space-evenly;">
-        <pharos-button id="my-button" data-dropdown-menu-id="my-menu" icon-right="chevron-down"
-          >Click Me</pharos-button
+        <storybook-pharos-button
+          id="my-button"
+          data-dropdown-menu-id="my-menu"
+          icon-right="chevron-down"
+          >Click Me</storybook-pharos-button
         >
-        <pharos-dropdown-menu id="my-menu">
-          <pharos-dropdown-menu-item>Menu item 1</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item>Menu item 2</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item data-tooltip-id="my-tooltip"
-            >Hover on Me</pharos-dropdown-menu-item
+        <storybook-pharos-dropdown-menu id="my-menu">
+          <storybook-pharos-dropdown-menu-item>Menu item 1</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item>Menu item 2</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item data-tooltip-id="my-tooltip"
+            >Hover on Me</storybook-pharos-dropdown-menu-item
           >
-          <pharos-tooltip id="my-tooltip" boundary="my-menu"
+          <storybook-pharos-tooltip id="my-tooltip" boundary="my-menu"
             >Even very long tooltips, such as this one, will stay within the boundaries of the
-            Tooltip.</pharos-tooltip
+            Tooltip.</storybook-pharos-tooltip
           >
-        </pharos-dropdown-menu>
+        </storybook-pharos-dropdown-menu>
       </div>
     `,
 };

--- a/packages/pharos/src/pages/home/home.scss
+++ b/packages/pharos/src/pages/home/home.scss
@@ -15,7 +15,7 @@
     grid-area: main;
   }
 
-  pharos-footer {
+  [data-pharos-component='PharosFooter'] {
     grid-area: footer;
   }
 }

--- a/packages/pharos/src/pages/home/wc/collection-card.ts
+++ b/packages/pharos/src/pages/home/wc/collection-card.ts
@@ -10,7 +10,7 @@ export const CollectionCard = (card: Card): TemplateResult => html`
       width="99.9%"
       class="home-page__image--collection"
     />
-    <pharos-heading level="2" preset="3">${card.title}</pharos-heading>
-    <pharos-link href="#">${card.link}</pharos-link>
+    <storybook-pharos-heading level="2" preset="3">${card.title}</storybook-pharos-heading>
+    <storybook-pharos-link href="#">${card.link}</storybook-pharos-link>
   </div>
 `;

--- a/packages/pharos/src/pages/home/wc/hero-search.ts
+++ b/packages/pharos/src/pages/home/wc/hero-search.ts
@@ -3,7 +3,7 @@ import type { TemplateResult } from 'lit';
 
 export const HeroSearch = (): TemplateResult => html`
   <div class="home-page__container--input">
-    <pharos-icon name="search" class="home-page__icon--search"></pharos-icon>
+    <storybook-pharos-icon name="search" class="home-page__icon--search"></storybook-pharos-icon>
     <input class="home-page__input" placeholder="Search JSTOR..." />
   </div>
 `;

--- a/packages/pharos/src/pages/home/wc/home.pages.stories.ts
+++ b/packages/pharos/src/pages/home/wc/home.pages.stories.ts
@@ -26,7 +26,10 @@ export const Home = {
     <div class="home-page__container">
       ${HeaderRevised()}
       <main>
-        <storybook-pharos-layout class="home-page__container--main-content" row-gap="${PharosSpacing7X}">
+        <storybook-pharos-layout
+          class="home-page__container--main-content"
+          row-gap="${PharosSpacing7X}"
+        >
           <div class="home-page__container--top" slot="top">
             <storybook-pharos-heading level="1" preset="7" no-margin class="home-page__heading"
               >Knowledge for everyone

--- a/packages/pharos/src/pages/home/wc/home.pages.stories.ts
+++ b/packages/pharos/src/pages/home/wc/home.pages.stories.ts
@@ -26,11 +26,11 @@ export const Home = {
     <div class="home-page__container">
       ${HeaderRevised()}
       <main>
-        <pharos-layout class="home-page__container--main-content" row-gap="${PharosSpacing7X}">
+        <storybook-pharos-layout class="home-page__container--main-content" row-gap="${PharosSpacing7X}">
           <div class="home-page__container--top" slot="top">
-            <pharos-heading level="1" preset="7" no-margin class="home-page__heading"
+            <storybook-pharos-heading level="1" preset="7" no-margin class="home-page__heading"
               >Knowledge for everyone
-            </pharos-heading>
+            </storybook-pharos-heading>
             ${HeroSearch()}
           </div>
           <div
@@ -38,29 +38,29 @@ export const Home = {
             slot="top"
             style="background-image: url('./images/home/hero.jpg')"
           ></div>
-          <pharos-link href="#" class="home-page__hero-link"
+          <storybook-pharos-link href="#" class="home-page__hero-link"
             >Tō kaidō gojo santsugi. Okazaki. Plate No 39. From the series: Fifty-three stations of
             the Tō kaidō Road, Kihei Sanoya, circa 1838.
-          </pharos-link>
+          </storybook-pharos-link>
           ${publicCollectionCards.map(
             (card) =>
               html` <div class="home-page__collection-card--open">${CollectionCard(card)}</div>`
           )}
           <div class="home-page__container--access">
-            <pharos-heading level="3" preset="5"
+            <storybook-pharos-heading level="3" preset="5"
               >JSTOR provides free access to hundreds of thousands of articles, images and books.
               Log in through your institution or learn about your other options, including free
               onsite reading.
-            </pharos-heading>
+            </storybook-pharos-heading>
             <ul class="home-page__list--access">
               <li>
-                <pharos-link href="#">Find my institution</pharos-link>
+                <storybook-pharos-link href="#">Find my institution</storybook-pharos-link>
               </li>
               <li>
-                <pharos-link href="#">Learn about JPASS</pharos-link>
+                <storybook-pharos-link href="#">Learn about JPASS</storybook-pharos-link>
               </li>
               <li>
-                <pharos-link href="#">Learn more about access</pharos-link>
+                <storybook-pharos-link href="#">Learn more about access</storybook-pharos-link>
               </li>
             </ul>
           </div>
@@ -70,7 +70,7 @@ export const Home = {
                 ${CollectionCard(card)}
               </div>`
           )}
-        </pharos-layout>
+        </storybook-pharos-layout>
       </main>
       ${Footer()}
     </div>

--- a/packages/pharos/src/pages/item-detail/item-detail.scss
+++ b/packages/pharos/src/pages/item-detail/item-detail.scss
@@ -15,7 +15,7 @@
     grid-area: main;
   }
 
-  pharos-footer {
+  [data-pharos-component='PharosFooter'] {
     grid-area: footer;
   }
 }
@@ -170,7 +170,7 @@
   display: flex;
   align-items: center;
 
-  &:hover pharos-icon {
+  &:hover [data-pharos-component='PharosIcon'] {
     fill: var(--pharos-color-hover-primary);
   }
 }

--- a/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel-item.ts
+++ b/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel-item.ts
@@ -3,11 +3,11 @@ import type { TemplateResult } from 'lit';
 import type { Collection } from '../../types';
 
 export const CollectionCarouselItem = (collection: Collection): TemplateResult => html`
-  <pharos-link href="#" subtle flex>
+  <storybook-pharos-link href="#" subtle flex>
     <div class="item-detail-page__grid--carousel-item item-detail-page__grid--open-collection">
       <img src="./images/item-detail/${collection.image}" alt="${collection.title}" />
-      <pharos-heading preset="1--bold" level="3" no-margin>${collection.title}</pharos-heading>
+      <storybook-pharos-heading preset="1--bold" level="3" no-margin>${collection.title}</storybook-pharos-heading>
     </div>
-  </pharos-link>
+  </storybook-pharos-link>
   <span class="item-detail-page__text--collection-items">${collection.items} items</span>
 `;

--- a/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel-item.ts
+++ b/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel-item.ts
@@ -6,7 +6,9 @@ export const CollectionCarouselItem = (collection: Collection): TemplateResult =
   <storybook-pharos-link href="#" subtle flex>
     <div class="item-detail-page__grid--carousel-item item-detail-page__grid--open-collection">
       <img src="./images/item-detail/${collection.image}" alt="${collection.title}" />
-      <storybook-pharos-heading preset="1--bold" level="3" no-margin>${collection.title}</storybook-pharos-heading>
+      <storybook-pharos-heading preset="1--bold" level="3" no-margin
+        >${collection.title}</storybook-pharos-heading
+      >
     </div>
   </storybook-pharos-link>
   <span class="item-detail-page__text--collection-items">${collection.items} items</span>

--- a/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel.ts
+++ b/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel.ts
@@ -6,7 +6,9 @@ import { collections } from '../../mocks';
 
 export const CollectionCarousel = (): TemplateResult => html`
   <div class="item-detail-page__container--top-bar">
-    <storybook-pharos-heading level="2" preset="3" no-margin>Explore our open collections</storybook-pharos-heading>
+    <storybook-pharos-heading level="2" preset="3" no-margin
+      >Explore our open collections</storybook-pharos-heading
+    >
     <div class="item-detail-page__container--carousel-buttons">
       <storybook-pharos-button
         label="backward"

--- a/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel.ts
+++ b/packages/pharos/src/pages/item-detail/wc/collection-carousel/collection-carousel.ts
@@ -6,20 +6,20 @@ import { collections } from '../../mocks';
 
 export const CollectionCarousel = (): TemplateResult => html`
   <div class="item-detail-page__container--top-bar">
-    <pharos-heading level="2" preset="3" no-margin>Explore our open collections</pharos-heading>
+    <storybook-pharos-heading level="2" preset="3" no-margin>Explore our open collections</storybook-pharos-heading>
     <div class="item-detail-page__container--carousel-buttons">
-      <pharos-button
+      <storybook-pharos-button
         label="backward"
         variant="subtle"
         icon="chevron-left-large"
         icon-condensed
-      ></pharos-button>
-      <pharos-button
+      ></storybook-pharos-button>
+      <storybook-pharos-button
         label="forward"
         variant="subtle"
         icon="chevron-right-large"
         icon-condensed
-      ></pharos-button>
+      ></storybook-pharos-button>
     </div>
   </div>
   <ul class="item-detail-page__list item-detail-page__grid--collections">

--- a/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel-item.ts
+++ b/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel-item.ts
@@ -6,7 +6,9 @@ export const ItemCarouselItem = (item: Item): TemplateResult => html`
   <storybook-pharos-link href="#" subtle flex>
     <div class="item-detail-page__grid--carousel-item">
       <img src="./images/item-detail/${item.image}" alt="${item.title}" />
-      <storybook-pharos-heading preset="1--bold" level="3" no-margin>${item.title}</storybook-pharos-heading>
+      <storybook-pharos-heading preset="1--bold" level="3" no-margin
+        >${item.title}</storybook-pharos-heading
+      >
     </div>
   </storybook-pharos-link>
   <span class="item-detail-page__text--item-metadata">${item.metadata}</span>

--- a/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel-item.ts
+++ b/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel-item.ts
@@ -3,11 +3,11 @@ import type { TemplateResult } from 'lit';
 import type { Item } from '../../types';
 
 export const ItemCarouselItem = (item: Item): TemplateResult => html`
-  <pharos-link href="#" subtle flex>
+  <storybook-pharos-link href="#" subtle flex>
     <div class="item-detail-page__grid--carousel-item">
       <img src="./images/item-detail/${item.image}" alt="${item.title}" />
-      <pharos-heading preset="1--bold" level="3" no-margin>${item.title}</pharos-heading>
+      <storybook-pharos-heading preset="1--bold" level="3" no-margin>${item.title}</storybook-pharos-heading>
     </div>
-  </pharos-link>
+  </storybook-pharos-link>
   <span class="item-detail-page__text--item-metadata">${item.metadata}</span>
 `;

--- a/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel.ts
+++ b/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel.ts
@@ -6,20 +6,20 @@ import { items } from '../../mocks';
 
 export const ItemCarousel = (): TemplateResult => html`
   <div class="item-detail-page__container--top-bar">
-    <pharos-heading level="2" preset="3" no-margin>In this collection</pharos-heading>
+    <storybook-pharos-heading level="2" preset="3" no-margin>In this collection</storybook-pharos-heading>
     <div class="item-detail-page__container--carousel-buttons">
-      <pharos-button
+      <storybook-pharos-button
         label="backward"
         variant="subtle"
         icon="chevron-left-large"
         icon-condensed
-      ></pharos-button>
-      <pharos-button
+      ></storybook-pharos-button>
+      <storybook-pharos-button
         label="forward"
         variant="subtle"
         icon="chevron-right-large"
         icon-condensed
-      ></pharos-button>
+      ></storybook-pharos-button>
     </div>
   </div>
   <ul class="item-detail-page__list item-detail-page__grid--items">

--- a/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel.ts
+++ b/packages/pharos/src/pages/item-detail/wc/item-carousel/item-carousel.ts
@@ -6,7 +6,9 @@ import { items } from '../../mocks';
 
 export const ItemCarousel = (): TemplateResult => html`
   <div class="item-detail-page__container--top-bar">
-    <storybook-pharos-heading level="2" preset="3" no-margin>In this collection</storybook-pharos-heading>
+    <storybook-pharos-heading level="2" preset="3" no-margin
+      >In this collection</storybook-pharos-heading
+    >
     <div class="item-detail-page__container--carousel-buttons">
       <storybook-pharos-button
         label="backward"

--- a/packages/pharos/src/pages/item-detail/wc/item-detail.pages.stories.ts
+++ b/packages/pharos/src/pages/item-detail/wc/item-detail.pages.stories.ts
@@ -25,37 +25,37 @@ export const ItemDetail = {
     <div class="item-detail-page__container">
       ${HeaderRevised(true)}
       <main>
-        <pharos-layout
+        <storybook-pharos-layout
           preset="2-col"
           rows="max-content 1fr"
           class="item-detail-page__container--main-content"
         >
           <div class="item-detail-page__container--top" slot="top">
-            <pharos-link href="#" class="item-detail-page__button--back" subtle flex>
-              <pharos-icon
+            <storybook-pharos-link href="#" class="item-detail-page__button--back" subtle flex>
+              <storybook-pharos-icon
                 name="arrow-left"
                 style="margin-right: var(--pharos-spacing-one-quarter-x)"
-              ></pharos-icon>
+              ></storybook-pharos-icon>
               Back to results
-            </pharos-link>
-            <pharos-button
+            </storybook-pharos-link>
+            <storybook-pharos-button
               variant="subtle"
               icon="arrow-left"
               href="#"
               label="Back to results"
               class="item-detail-page__button--mobile-back"
-            ></pharos-button>
+            ></storybook-pharos-button>
             <div class="item-detail-page__container--action-buttons">
-              <pharos-button variant="secondary" icon-left="cite">Cite</pharos-button>
-              <pharos-button variant="secondary" icon-left="share">Share</pharos-button>
-              <pharos-button variant="secondary" icon-left="save">Save</pharos-button>
-              <pharos-button variant="secondary" icon-left="download">Download</pharos-button>
+              <storybook-pharos-button variant="secondary" icon-left="cite">Cite</storybook-pharos-button>
+              <storybook-pharos-button variant="secondary" icon-left="share">Share</storybook-pharos-button>
+              <storybook-pharos-button variant="secondary" icon-left="save">Save</storybook-pharos-button>
+              <storybook-pharos-button variant="secondary" icon-left="download">Download</storybook-pharos-button>
             </div>
             <div class="item-detail-page__container--mobile-buttons">
-              <pharos-button variant="subtle" icon="cite" label="Cite"></pharos-button>
-              <pharos-button variant="subtle" icon="share" label="Share"></pharos-button>
-              <pharos-button variant="subtle" icon="save" label="Save"></pharos-button>
-              <pharos-button variant="subtle" icon="download" label="Download"></pharos-button>
+              <storybook-pharos-button variant="subtle" icon="cite" label="Cite"></storybook-pharos-button>
+              <storybook-pharos-button variant="subtle" icon="share" label="Share"></storybook-pharos-button>
+              <storybook-pharos-button variant="subtle" icon="save" label="Save"></storybook-pharos-button>
+              <storybook-pharos-button variant="subtle" icon="download" label="Download"></storybook-pharos-button>
             </div>
           </div>
           <div class="item-detail-page__container--viewer"></div>
@@ -63,7 +63,7 @@ export const ItemDetail = {
             ${ItemCarousel()} ${CollectionCarousel()}
           </div>
           ${Metadata()}
-        </pharos-layout>
+        </storybook-pharos-layout>
       </main>
       ${Footer()}
     </div>

--- a/packages/pharos/src/pages/item-detail/wc/item-detail.pages.stories.ts
+++ b/packages/pharos/src/pages/item-detail/wc/item-detail.pages.stories.ts
@@ -46,16 +46,40 @@ export const ItemDetail = {
               class="item-detail-page__button--mobile-back"
             ></storybook-pharos-button>
             <div class="item-detail-page__container--action-buttons">
-              <storybook-pharos-button variant="secondary" icon-left="cite">Cite</storybook-pharos-button>
-              <storybook-pharos-button variant="secondary" icon-left="share">Share</storybook-pharos-button>
-              <storybook-pharos-button variant="secondary" icon-left="save">Save</storybook-pharos-button>
-              <storybook-pharos-button variant="secondary" icon-left="download">Download</storybook-pharos-button>
+              <storybook-pharos-button variant="secondary" icon-left="cite"
+                >Cite</storybook-pharos-button
+              >
+              <storybook-pharos-button variant="secondary" icon-left="share"
+                >Share</storybook-pharos-button
+              >
+              <storybook-pharos-button variant="secondary" icon-left="save"
+                >Save</storybook-pharos-button
+              >
+              <storybook-pharos-button variant="secondary" icon-left="download"
+                >Download</storybook-pharos-button
+              >
             </div>
             <div class="item-detail-page__container--mobile-buttons">
-              <storybook-pharos-button variant="subtle" icon="cite" label="Cite"></storybook-pharos-button>
-              <storybook-pharos-button variant="subtle" icon="share" label="Share"></storybook-pharos-button>
-              <storybook-pharos-button variant="subtle" icon="save" label="Save"></storybook-pharos-button>
-              <storybook-pharos-button variant="subtle" icon="download" label="Download"></storybook-pharos-button>
+              <storybook-pharos-button
+                variant="subtle"
+                icon="cite"
+                label="Cite"
+              ></storybook-pharos-button>
+              <storybook-pharos-button
+                variant="subtle"
+                icon="share"
+                label="Share"
+              ></storybook-pharos-button>
+              <storybook-pharos-button
+                variant="subtle"
+                icon="save"
+                label="Save"
+              ></storybook-pharos-button>
+              <storybook-pharos-button
+                variant="subtle"
+                icon="download"
+                label="Download"
+              ></storybook-pharos-button>
             </div>
           </div>
           <div class="item-detail-page__container--viewer"></div>

--- a/packages/pharos/src/pages/item-detail/wc/metadata.ts
+++ b/packages/pharos/src/pages/item-detail/wc/metadata.ts
@@ -11,8 +11,8 @@ export const Metadata = (): TemplateResult => html`
       class="item-detail-page__image--collection"
     />
     <div class="item-detail-page__label--type">${item.type}</div>
-    <pharos-heading level="1" preset="3" class="item-detail-page__heading--metadata"
-      >${item.title}</pharos-heading
+    <storybook-pharos-heading level="1" preset="3" class="item-detail-page__heading--metadata"
+      >${item.title}</storybook-pharos-heading
     >
     <div class="item-detail-page__grid--metadata">
       ${metadata.map(

--- a/packages/pharos/src/pages/reports/react/ReportsTable.tsx
+++ b/packages/pharos/src/pages/reports/react/ReportsTable.tsx
@@ -69,7 +69,7 @@ export const ReportsTable: FC<HistoryTable | ScheduledTable> = ({ rows, columns 
                         detail: {
                           status: 'error',
                           content:
-                            'Sorry, we were unable to process your download. Please try again later. If the issue persists, <pharos-link href="#" on-background bold>contact JSTOR Support</pharos-link>.',
+                            'Sorry, we were unable to process your download. Please try again later. If the issue persists, <storybook-pharos-link href="#" on-background bold>contact JSTOR Support</storybook-pharos-link>.',
                         },
                       });
                       document.dispatchEvent(event);

--- a/packages/pharos/src/pages/reports/wc/create-report-modal.ts
+++ b/packages/pharos/src/pages/reports/wc/create-report-modal.ts
@@ -2,9 +2,9 @@ import { html } from 'lit';
 import type { TemplateResult } from 'lit';
 
 export const CreateReportModal = (): TemplateResult => html`
-  <pharos-modal id="create-report-modal" header="Create Report" size="large">
+  <storybook-pharos-modal id="create-report-modal" header="Create Report" size="large">
     <form class="reports-page__form--create-modal">
-      <pharos-select name="report" required>
+      <storybook-pharos-select name="report" required>
         <span slot="label">Select Report</span>
         <option value="">Select a Report</option>
         <optgroup label="Master Reports">
@@ -13,57 +13,57 @@ export const CreateReportModal = (): TemplateResult => html`
         <optgroup label="Standard Reports">
           <option value="ALL" selected>ALL - All Standard Reports</option>
         </optgroup>
-      </pharos-select>
+      </storybook-pharos-select>
       <fieldset class="reports-page__fieldset--type">
         <legend class="reports-page__legend">
           <span>Report Type</span>
         </legend>
-        <pharos-button name="is-scheduled" value="yes" disabled>Scheduled</pharos-button>
-        <pharos-button name="is-scheduled" value="no">One-time</pharos-button>
+        <storybook-pharos-button name="is-scheduled" value="yes" disabled>Scheduled</storybook-pharos-button>
+        <storybook-pharos-button name="is-scheduled" value="no">One-time</storybook-pharos-button>
       </fieldset>
       <fieldset class="reports-page__fieldset--date">
         <legend class="reports-page__legend">
           <span>Report Date Range</span>
         </legend>
         <div class="reports-page__grid--date-group">
-          <pharos-input-group name="start-date">
+          <storybook-pharos-input-group name="start-date">
             <span slot="label">Start Date</span>
-            <pharos-button
+            <storybook-pharos-button
               name="start-button"
               icon="calendar"
               variant="subtle"
               label="calendar"
-            ></pharos-button>
-          </pharos-input-group>
-          <pharos-input-group name="end-date">
+            ></storybook-pharos-button>
+          </storybook-pharos-input-group>
+          <storybook-pharos-input-group name="end-date">
             <span slot="label">End Date</span>
-            <pharos-button
+            <storybook-pharos-button
               name="end-button"
               icon="calendar"
               variant="subtle"
               label="calendar"
-            ></pharos-button>
-          </pharos-input-group>
+            ></storybook-pharos-button>
+          </storybook-pharos-input-group>
         </div>
       </fieldset>
-      <pharos-radio-group name="format">
+      <storybook-pharos-radio-group name="format">
         <span slot="legend">Report Format</span>
-        <pharos-radio-button value="xlsx" checked
-          ><span slot="label">XLSX</span></pharos-radio-button
+        <storybook-pharos-radio-button value="xlsx" checked
+          ><span slot="label">XLSX</span></storybook-pharos-radio-button
         >
-        <pharos-radio-button value="tsv"><span slot="label">TSV</span></pharos-radio-button>
-        <pharos-radio-button value="json"><span slot="label">JSON</span></pharos-radio-button>
-      </pharos-radio-group>
-      <pharos-text-input name="name" required>
+        <storybook-pharos-radio-button value="tsv"><span slot="label">TSV</span></storybook-pharos-radio-button>
+        <storybook-pharos-radio-button value="json"><span slot="label">JSON</span></storybook-pharos-radio-button>
+      </storybook-pharos-radio-group>
+      <storybook-pharos-text-input name="name" required>
         <span slot="label">Report Name</span>
-      </pharos-text-input>
-      <pharos-text-input name="email" value="human@ithaka.org" type="email" required>
+      </storybook-pharos-text-input>
+      <storybook-pharos-text-input name="email" value="human@ithaka.org" type="email" required>
         <span slot="label">Email Report To</span>
-      </pharos-text-input>
+      </storybook-pharos-text-input>
     </form>
-    <pharos-button slot="footer" type="button" variant="secondary" data-modal-close>
+    <storybook-pharos-button slot="footer" type="button" variant="secondary" data-modal-close>
       Cancel
-    </pharos-button>
-    <pharos-button slot="footer" type="button"> Continue </pharos-button>
-  </pharos-modal>
+    </storybook-pharos-button>
+    <storybook-pharos-button slot="footer" type="button"> Continue </storybook-pharos-button>
+  </storybook-pharos-modal>
 `;

--- a/packages/pharos/src/pages/reports/wc/create-report-modal.ts
+++ b/packages/pharos/src/pages/reports/wc/create-report-modal.ts
@@ -18,7 +18,9 @@ export const CreateReportModal = (): TemplateResult => html`
         <legend class="reports-page__legend">
           <span>Report Type</span>
         </legend>
-        <storybook-pharos-button name="is-scheduled" value="yes" disabled>Scheduled</storybook-pharos-button>
+        <storybook-pharos-button name="is-scheduled" value="yes" disabled
+          >Scheduled</storybook-pharos-button
+        >
         <storybook-pharos-button name="is-scheduled" value="no">One-time</storybook-pharos-button>
       </fieldset>
       <fieldset class="reports-page__fieldset--date">
@@ -51,8 +53,12 @@ export const CreateReportModal = (): TemplateResult => html`
         <storybook-pharos-radio-button value="xlsx" checked
           ><span slot="label">XLSX</span></storybook-pharos-radio-button
         >
-        <storybook-pharos-radio-button value="tsv"><span slot="label">TSV</span></storybook-pharos-radio-button>
-        <storybook-pharos-radio-button value="json"><span slot="label">JSON</span></storybook-pharos-radio-button>
+        <storybook-pharos-radio-button value="tsv"
+          ><span slot="label">TSV</span></storybook-pharos-radio-button
+        >
+        <storybook-pharos-radio-button value="json"
+          ><span slot="label">JSON</span></storybook-pharos-radio-button
+        >
       </storybook-pharos-radio-group>
       <storybook-pharos-text-input name="name" required>
         <span slot="label">Report Name</span>

--- a/packages/pharos/src/pages/reports/wc/reports-table.ts
+++ b/packages/pharos/src/pages/reports/wc/reports-table.ts
@@ -48,19 +48,19 @@ export const ReportsTable = (table: HistoryTable | ScheduledTable): TemplateResu
               })}
               ${isHistory
                 ? html`<td class="reports-page__table-cell--download">
-                    <pharos-button
+                    <storybook-pharos-button
                       variant="secondary"
                       @click="${() => {
                         const event = new CustomEvent('pharos-toast-open', {
                           detail: {
                             status: 'error',
                             content:
-                              'Sorry, we were unable to process your download. Please try again later. If the issue persists, <pharos-link href="#" on-background bold>contact JSTOR Support</pharos-link>.',
+                              'Sorry, we were unable to process your download. Please try again later. If the issue persists, <storybook-pharos-link href="#" on-background bold>contact JSTOR Support</storybook-pharos-link>.',
                           },
                         });
                         document.dispatchEvent(event);
                       }}"
-                      >Download</pharos-button
+                      >Download</storybook-pharos-button
                     >
                   </td>`
                 : null}

--- a/packages/pharos/src/pages/reports/wc/reports.pages.stories.ts
+++ b/packages/pharos/src/pages/reports/wc/reports.pages.stories.ts
@@ -24,13 +24,18 @@ export const Reports = {
     <div class="reports-page__container">
       ${Sidenav()}
       <main id="main-content">
-        <storybook-pharos-layout preset="1-col--sidenav" class="reports-page__container--main-content">
+        <storybook-pharos-layout
+          preset="1-col--sidenav"
+          class="reports-page__container--main-content"
+        >
           <div class="reports-page__container--top" slot="top">
             <div class="reports-page__container--nav-header">
               <storybook-pharos-sidenav-button></storybook-pharos-sidenav-button>
               <img src="./images/reports/jstor-horizontal.svg" alt="logo" width="96" height="24" />
               <span class="reports-page__separator">/</span>
-              <storybook-pharos-heading level="1" preset="4" no-margin>Admin</storybook-pharos-heading>
+              <storybook-pharos-heading level="1" preset="4" no-margin
+                >Admin</storybook-pharos-heading
+              >
             </div>
             <storybook-pharos-button
               variant="subtle"
@@ -40,24 +45,32 @@ export const Reports = {
             </storybook-pharos-button>
           </div>
           <div class="reports-page__container--disclaimer">
-            <storybook-pharos-heading level="2" preset="5--bold">COUNTER 5 Usage Reports</storybook-pharos-heading>
+            <storybook-pharos-heading level="2" preset="5--bold"
+              >COUNTER 5 Usage Reports</storybook-pharos-heading
+            >
             <p>
               Welcome to the COUNTER 5 reporting service for participating institutions. JSTOR
               offers COUNTER 5 compliant reports for usage beginning January 2019. COUNTER 4 reports
               are still available for usage from January 2017 - April 2019 from the
-              <storybook-pharos-link href="#">COUNTER 4 reporting service</storybook-pharos-link>. Please visit our
-              COUNTER 5
+              <storybook-pharos-link href="#">COUNTER 4 reporting service</storybook-pharos-link>.
+              Please visit our COUNTER 5
               <storybook-pharos-link href="#">support page</storybook-pharos-link>
               for more information on JSTOR usage reports.
             </p>
           </div>
           <div class="reports-page__container--table">
-            <storybook-pharos-button class="reports-page__button--create" data-modal-id="create-report-modal"
+            <storybook-pharos-button
+              class="reports-page__button--create"
+              data-modal-id="create-report-modal"
               >Create Report
             </storybook-pharos-button>
             <storybook-pharos-tabs>
-              <storybook-pharos-tab id="tab-1" data-panel-id="panel-1">Report History</storybook-pharos-tab>
-              <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Scheduled Reports</storybook-pharos-tab>
+              <storybook-pharos-tab id="tab-1" data-panel-id="panel-1"
+                >Report History</storybook-pharos-tab
+              >
+              <storybook-pharos-tab id="tab-2" data-panel-id="panel-2"
+                >Scheduled Reports</storybook-pharos-tab
+              >
               <storybook-pharos-tab-panel id="panel-1" slot="panel" style="overflow: visible">
                 ${ReportsTable(historyTable)}
               </storybook-pharos-tab-panel>

--- a/packages/pharos/src/pages/reports/wc/reports.pages.stories.ts
+++ b/packages/pharos/src/pages/reports/wc/reports.pages.stories.ts
@@ -24,52 +24,52 @@ export const Reports = {
     <div class="reports-page__container">
       ${Sidenav()}
       <main id="main-content">
-        <pharos-layout preset="1-col--sidenav" class="reports-page__container--main-content">
+        <storybook-pharos-layout preset="1-col--sidenav" class="reports-page__container--main-content">
           <div class="reports-page__container--top" slot="top">
             <div class="reports-page__container--nav-header">
-              <pharos-sidenav-button></pharos-sidenav-button>
+              <storybook-pharos-sidenav-button></storybook-pharos-sidenav-button>
               <img src="./images/reports/jstor-horizontal.svg" alt="logo" width="96" height="24" />
               <span class="reports-page__separator">/</span>
-              <pharos-heading level="1" preset="4" no-margin>Admin</pharos-heading>
+              <storybook-pharos-heading level="1" preset="4" no-margin>Admin</storybook-pharos-heading>
             </div>
-            <pharos-button
+            <storybook-pharos-button
               variant="subtle"
               icon-right="chevron-down"
               class="reports-page__button--user"
               >Gerry Larry Burla
-            </pharos-button>
+            </storybook-pharos-button>
           </div>
           <div class="reports-page__container--disclaimer">
-            <pharos-heading level="2" preset="5--bold">COUNTER 5 Usage Reports</pharos-heading>
+            <storybook-pharos-heading level="2" preset="5--bold">COUNTER 5 Usage Reports</storybook-pharos-heading>
             <p>
               Welcome to the COUNTER 5 reporting service for participating institutions. JSTOR
               offers COUNTER 5 compliant reports for usage beginning January 2019. COUNTER 4 reports
               are still available for usage from January 2017 - April 2019 from the
-              <pharos-link href="#">COUNTER 4 reporting service</pharos-link>. Please visit our
+              <storybook-pharos-link href="#">COUNTER 4 reporting service</storybook-pharos-link>. Please visit our
               COUNTER 5
-              <pharos-link href="#">support page</pharos-link>
+              <storybook-pharos-link href="#">support page</storybook-pharos-link>
               for more information on JSTOR usage reports.
             </p>
           </div>
           <div class="reports-page__container--table">
-            <pharos-button class="reports-page__button--create" data-modal-id="create-report-modal"
+            <storybook-pharos-button class="reports-page__button--create" data-modal-id="create-report-modal"
               >Create Report
-            </pharos-button>
-            <pharos-tabs>
-              <pharos-tab id="tab-1" data-panel-id="panel-1">Report History</pharos-tab>
-              <pharos-tab id="tab-2" data-panel-id="panel-2">Scheduled Reports</pharos-tab>
-              <pharos-tab-panel id="panel-1" slot="panel" style="overflow: visible">
+            </storybook-pharos-button>
+            <storybook-pharos-tabs>
+              <storybook-pharos-tab id="tab-1" data-panel-id="panel-1">Report History</storybook-pharos-tab>
+              <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Scheduled Reports</storybook-pharos-tab>
+              <storybook-pharos-tab-panel id="panel-1" slot="panel" style="overflow: visible">
                 ${ReportsTable(historyTable)}
-              </pharos-tab-panel>
-              <pharos-tab-panel id="panel-2" slot="panel">
+              </storybook-pharos-tab-panel>
+              <storybook-pharos-tab-panel id="panel-2" slot="panel">
                 ${ReportsTable(scheduledTable)}
-              </pharos-tab-panel>
-            </pharos-tabs>
+              </storybook-pharos-tab-panel>
+            </storybook-pharos-tabs>
           </div>
-        </pharos-layout>
+        </storybook-pharos-layout>
       </main>
     </div>
-    <pharos-toaster></pharos-toaster>
+    <storybook-pharos-toaster></storybook-pharos-toaster>
     ${CreateReportModal()}
   `,
 };

--- a/packages/pharos/src/pages/reports/wc/sidenav.ts
+++ b/packages/pharos/src/pages/reports/wc/sidenav.ts
@@ -2,22 +2,22 @@ import { html } from 'lit';
 import type { TemplateResult } from 'lit';
 
 export const Sidenav = (): TemplateResult => html`
-  <pharos-sidenav class="reports-page__sidenav" main-content-id="main-content">
-    <pharos-link slot="top" href="/" id="jstor-logo">
+  <storybook-pharos-sidenav class="reports-page__sidenav" main-content-id="main-content">
+    <storybook-pharos-link slot="top" href="/" id="jstor-logo">
       <img src="./images/jstor-logo-inverse.svg" alt="Pharos Home" width="72" height="100" />
-    </pharos-link>
-    <pharos-sidenav-section>
-      <pharos-sidenav-link href="#">Home</pharos-sidenav-link>
-      <pharos-sidenav-menu label="Reports" expanded>
-        <pharos-sidenav-link href="#" is-active>COUNTER 5</pharos-sidenav-link>
-        <pharos-sidenav-link href="#">Books at JSTOR</pharos-sidenav-link>
-        <pharos-sidenav-link href="#">COUNTER 4</pharos-sidenav-link>
-      </pharos-sidenav-menu>
-      <pharos-sidenav-link href="#">Holdings</pharos-sidenav-link>
-      <pharos-sidenav-link href="#">Access Methods</pharos-sidenav-link>
-      <pharos-sidenav-link href="#">Account</pharos-sidenav-link>
-      <pharos-sidenav-link href="#" target="_blank" external>Support</pharos-sidenav-link>
-      <pharos-sidenav-link href="#" target="_blank" external>For Librarians</pharos-sidenav-link>
-    </pharos-sidenav-section>
-  </pharos-sidenav>
+    </storybook-pharos-link>
+    <storybook-pharos-sidenav-section>
+      <storybook-pharos-sidenav-link href="#">Home</storybook-pharos-sidenav-link>
+      <storybook-pharos-sidenav-menu label="Reports" expanded>
+        <storybook-pharos-sidenav-link href="#" is-active>COUNTER 5</storybook-pharos-sidenav-link>
+        <storybook-pharos-sidenav-link href="#">Books at JSTOR</storybook-pharos-sidenav-link>
+        <storybook-pharos-sidenav-link href="#">COUNTER 4</storybook-pharos-sidenav-link>
+      </storybook-pharos-sidenav-menu>
+      <storybook-pharos-sidenav-link href="#">Holdings</storybook-pharos-sidenav-link>
+      <storybook-pharos-sidenav-link href="#">Access Methods</storybook-pharos-sidenav-link>
+      <storybook-pharos-sidenav-link href="#">Account</storybook-pharos-sidenav-link>
+      <storybook-pharos-sidenav-link href="#" target="_blank" external>Support</storybook-pharos-sidenav-link>
+      <storybook-pharos-sidenav-link href="#" target="_blank" external>For Librarians</storybook-pharos-sidenav-link>
+    </storybook-pharos-sidenav-section>
+  </storybook-pharos-sidenav>
 `;

--- a/packages/pharos/src/pages/reports/wc/sidenav.ts
+++ b/packages/pharos/src/pages/reports/wc/sidenav.ts
@@ -16,8 +16,12 @@ export const Sidenav = (): TemplateResult => html`
       <storybook-pharos-sidenav-link href="#">Holdings</storybook-pharos-sidenav-link>
       <storybook-pharos-sidenav-link href="#">Access Methods</storybook-pharos-sidenav-link>
       <storybook-pharos-sidenav-link href="#">Account</storybook-pharos-sidenav-link>
-      <storybook-pharos-sidenav-link href="#" target="_blank" external>Support</storybook-pharos-sidenav-link>
-      <storybook-pharos-sidenav-link href="#" target="_blank" external>For Librarians</storybook-pharos-sidenav-link>
+      <storybook-pharos-sidenav-link href="#" target="_blank" external
+        >Support</storybook-pharos-sidenav-link
+      >
+      <storybook-pharos-sidenav-link href="#" target="_blank" external
+        >For Librarians</storybook-pharos-sidenav-link
+      >
     </storybook-pharos-sidenav-section>
   </storybook-pharos-sidenav>
 `;

--- a/packages/pharos/src/pages/search/search.scss
+++ b/packages/pharos/src/pages/search/search.scss
@@ -9,7 +9,7 @@
     'footer footer footer';
   column-gap: 6rem;
 
-  pharos-header {
+  [data-pharos-component='PharosHeader'] {
     grid-area: header;
   }
 
@@ -21,7 +21,7 @@
     grid-row: sidebar;
   }
 
-  pharos-footer {
+  [data-pharos-component='PharosFooter'] {
     grid-column: footer;
   }
 }
@@ -35,8 +35,8 @@
   .search-page__facet {
     border-top: 1px solid var(--pharos-color-ui-30);
 
-    pharos-checkbox-group,
-    pharos-radio-group,
+    [data-pharos-component='PharosCheckboxGroup'],
+    [data-pharos-component='PharosRadioGroup'],
     fieldset {
       margin-top: var(--pharos-spacing-one-and-a-half-x);
     }
@@ -44,7 +44,7 @@
     &:last-child {
       border-bottom: 1px solid var(--pharos-color-ui-30);
 
-      pharos-radio-group {
+      [data-pharos-component='PharosRadioGroup'] {
         margin-bottom: var(--pharos-spacing-one-and-a-half-x);
       }
     }

--- a/packages/pharos/src/pages/search/wc/facets/date-range-facet.ts
+++ b/packages/pharos/src/pages/search/wc/facets/date-range-facet.ts
@@ -4,17 +4,17 @@ import type { TemplateResult } from 'lit';
 export const DateRangeFacet = (): TemplateResult => html`
   <fieldset class="search-page__fieldset--date">
     <legend>
-      <pharos-heading level="3" preset="legend">Date</pharos-heading>
+      <storybook-pharos-heading level="3" preset="legend">Date</storybook-pharos-heading>
     </legend>
     <small class="search-page__text--description">(YYYY, YYYY/MM or YYYY/MM/DD)</small>
     <div class="search-page__grid--date">
-      <pharos-text-input name="from">
+      <storybook-pharos-text-input name="from">
         <span slot="label">From</span>
-      </pharos-text-input>
-      <pharos-text-input name="to">
+      </storybook-pharos-text-input>
+      <storybook-pharos-text-input name="to">
         <span slot="label">To</span>
-      </pharos-text-input>
-      <pharos-button disabled>Apply</pharos-button>
+      </storybook-pharos-text-input>
+      <storybook-pharos-button disabled>Apply</storybook-pharos-button>
     </div>
   </fieldset>
 `;

--- a/packages/pharos/src/pages/search/wc/facets/facet-filters.ts
+++ b/packages/pharos/src/pages/search/wc/facets/facet-filters.ts
@@ -41,7 +41,7 @@ const accessTypeItems = [
 export const FacetFilters = (): TemplateResult => html`
   <aside>
     <div class="search-page__grid--facets">
-      <pharos-heading level="2" preset="1--bold">Filters</pharos-heading>
+      <storybook-pharos-heading level="2" preset="1--bold">Filters</storybook-pharos-heading>
       <form class="search-page__form">
         <div class="search-page__facet">
           ${MultiSelectFacet('academic-content', 'academic content', academicContentItems)}

--- a/packages/pharos/src/pages/search/wc/facets/multi-select-facet.ts
+++ b/packages/pharos/src/pages/search/wc/facets/multi-select-facet.ts
@@ -7,13 +7,13 @@ export const MultiSelectFacet = (
   legend: string,
   items: CheckboxGroupItem[]
 ): TemplateResult => html`
-  <pharos-checkbox-group name="${name}">
+  <storybook-pharos-checkbox-group name="${name}">
     <span slot="legend">${legend}</span>
     ${items.map(
       (item) =>
-        html`<pharos-checkbox value="${item.value}"
-          ><span slot="label">${item.label}</span></pharos-checkbox
+        html`<storybook-pharos-checkbox value="${item.value}"
+          ><span slot="label">${item.label}</span></storybook-pharos-checkbox
         >`
     )}
-  </pharos-checkbox-group>
+  </storybook-pharos-checkbox-group>
 `;

--- a/packages/pharos/src/pages/search/wc/facets/single-select-facet.ts
+++ b/packages/pharos/src/pages/search/wc/facets/single-select-facet.ts
@@ -7,13 +7,13 @@ export const SingleSelectFacet = (
   legend: string,
   items: RadioGroupItem[]
 ): TemplateResult => html`
-  <pharos-radio-group name="${name}">
+  <storybook-pharos-radio-group name="${name}">
     <span slot="legend">${legend}</span>
     ${items.map(
       (item) =>
-        html`<pharos-radio-button value="${item.value}"
-          ><span slot="label">${item.label}</span></pharos-radio-button
+        html`<storybook-pharos-radio-button value="${item.value}"
+          ><span slot="label">${item.label}</span></storybook-pharos-radio-button
         >`
     )}
-  </pharos-radio-group>
+  </storybook-pharos-radio-group>
 `;

--- a/packages/pharos/src/pages/search/wc/image-results/image-results-item.ts
+++ b/packages/pharos/src/pages/search/wc/image-results/image-results-item.ts
@@ -6,7 +6,9 @@ export const ImageResultsItem = (result: ImageResult): TemplateResult => html`
   <storybook-pharos-link href="#" subtle flex>
     <div class="search-page__grid--image">
       <img src="./images/search/${result.image}" alt="${result.title}" width="99%" />
-      <storybook-pharos-heading preset="1--bold" level="3" no-margin>${result.title}</storybook-pharos-heading>
+      <storybook-pharos-heading preset="1--bold" level="3" no-margin
+        >${result.title}</storybook-pharos-heading
+      >
     </div>
   </storybook-pharos-link>
 `;

--- a/packages/pharos/src/pages/search/wc/image-results/image-results-item.ts
+++ b/packages/pharos/src/pages/search/wc/image-results/image-results-item.ts
@@ -3,10 +3,10 @@ import type { TemplateResult } from 'lit';
 import type { ImageResult } from '../../types';
 
 export const ImageResultsItem = (result: ImageResult): TemplateResult => html`
-  <pharos-link href="#" subtle flex>
+  <storybook-pharos-link href="#" subtle flex>
     <div class="search-page__grid--image">
       <img src="./images/search/${result.image}" alt="${result.title}" width="99%" />
-      <pharos-heading preset="1--bold" level="3" no-margin>${result.title}</pharos-heading>
+      <storybook-pharos-heading preset="1--bold" level="3" no-margin>${result.title}</storybook-pharos-heading>
     </div>
-  </pharos-link>
+  </storybook-pharos-link>
 `;

--- a/packages/pharos/src/pages/search/wc/image-results/image-results.ts
+++ b/packages/pharos/src/pages/search/wc/image-results/image-results.ts
@@ -8,7 +8,10 @@ export const ImageResults = (): TemplateResult => html`
   <div class="search-page__container--image-results">
     <div class="search-page__container--results-top-bar">
       <storybook-pharos-heading level="3" preset="2">1,429 image results</storybook-pharos-heading>
-      <storybook-pharos-button variant="secondary" icon-right="arrow-right" style="margin-left: auto"
+      <storybook-pharos-button
+        variant="secondary"
+        icon-right="arrow-right"
+        style="margin-left: auto"
         >View all image results</storybook-pharos-button
       >
     </div>

--- a/packages/pharos/src/pages/search/wc/image-results/image-results.ts
+++ b/packages/pharos/src/pages/search/wc/image-results/image-results.ts
@@ -7,19 +7,19 @@ import { imageResults } from '../../mocks';
 export const ImageResults = (): TemplateResult => html`
   <div class="search-page__container--image-results">
     <div class="search-page__container--results-top-bar">
-      <pharos-heading level="3" preset="2">1,429 image results</pharos-heading>
-      <pharos-button variant="secondary" icon-right="arrow-right" style="margin-left: auto"
-        >View all image results</pharos-button
+      <storybook-pharos-heading level="3" preset="2">1,429 image results</storybook-pharos-heading>
+      <storybook-pharos-button variant="secondary" icon-right="arrow-right" style="margin-left: auto"
+        >View all image results</storybook-pharos-button
       >
     </div>
     <ul class="search-page__list--results search-page__grid--image-results">
       ${imageResults.map((result) => html`<li>${ImageResultsItem(result)}</li>`)}
       <li>
-        <pharos-link href="#" subtle flex>
+        <storybook-pharos-link href="#" subtle flex>
           <div class="search-page__grid--image search-page__container--all-images">
             View all images
           </div>
-        </pharos-link>
+        </storybook-pharos-link>
       </li>
     </ul>
   </div>

--- a/packages/pharos/src/pages/search/wc/search-results/search-results-item.ts
+++ b/packages/pharos/src/pages/search/wc/search-results/search-results-item.ts
@@ -21,13 +21,19 @@ export const SearchResultsItem = (result: SearchResult): TemplateResult => html`
     <div class="search-page__container--action-buttons">
       <ul class="search-page__list--action-buttons">
         <li class="search-page__list-item--action-buttons">
-          <storybook-pharos-button icon-left="download" full-width>Download PDF</storybook-pharos-button>
+          <storybook-pharos-button icon-left="download" full-width
+            >Download PDF</storybook-pharos-button
+          >
         </li>
         <li class="search-page__list-item--action-buttons">
-          <storybook-pharos-button icon-left="save" variant="secondary" full-width>Save</storybook-pharos-button>
+          <storybook-pharos-button icon-left="save" variant="secondary" full-width
+            >Save</storybook-pharos-button
+          >
         </li>
         <li class="search-page__list-item--action-buttons">
-          <storybook-pharos-button icon-left="cite" variant="secondary" full-width>Cite</storybook-pharos-button>
+          <storybook-pharos-button icon-left="cite" variant="secondary" full-width
+            >Cite</storybook-pharos-button
+          >
         </li>
       </ul>
     </div>

--- a/packages/pharos/src/pages/search/wc/search-results/search-results-item.ts
+++ b/packages/pharos/src/pages/search/wc/search-results/search-results-item.ts
@@ -5,29 +5,29 @@ import type { SearchResult } from '../../types';
 export const SearchResultsItem = (result: SearchResult): TemplateResult => html`
   <div class="search-page__grid--result">
     <div style="justify-self: center">
-      <pharos-checkbox name="doi" value="${result.doi}" hide-label
-        ><span slot="label">${result.title}</span></pharos-checkbox
+      <storybook-pharos-checkbox name="doi" value="${result.doi}" hide-label
+        ><span slot="label">${result.title}</span></storybook-pharos-checkbox
       >
     </div>
     <div>
       <span class="search-page__text--content-type">${result.type}</span>
-      <pharos-link href="/stable/${result.doi}" subtle style="display: flex">
-        <pharos-heading level="3" preset="3">${result.title}</pharos-heading>
-      </pharos-link>
-      <pharos-link href="#">${result.author}</pharos-link>
+      <storybook-pharos-link href="/stable/${result.doi}" subtle style="display: flex">
+        <storybook-pharos-heading level="3" preset="3">${result.title}</storybook-pharos-heading>
+      </storybook-pharos-link>
+      <storybook-pharos-link href="#">${result.author}</storybook-pharos-link>
       <p class="search-page__text--metadata">${result.metadata}</p>
       <p class="search-page__text--snippet">${result.snippet}</p>
     </div>
     <div class="search-page__container--action-buttons">
       <ul class="search-page__list--action-buttons">
         <li class="search-page__list-item--action-buttons">
-          <pharos-button icon-left="download" full-width>Download PDF</pharos-button>
+          <storybook-pharos-button icon-left="download" full-width>Download PDF</storybook-pharos-button>
         </li>
         <li class="search-page__list-item--action-buttons">
-          <pharos-button icon-left="save" variant="secondary" full-width>Save</pharos-button>
+          <storybook-pharos-button icon-left="save" variant="secondary" full-width>Save</storybook-pharos-button>
         </li>
         <li class="search-page__list-item--action-buttons">
-          <pharos-button icon-left="cite" variant="secondary" full-width>Cite</pharos-button>
+          <storybook-pharos-button icon-left="cite" variant="secondary" full-width>Cite</storybook-pharos-button>
         </li>
       </ul>
     </div>

--- a/packages/pharos/src/pages/search/wc/search-results/search-results.ts
+++ b/packages/pharos/src/pages/search/wc/search-results/search-results.ts
@@ -7,20 +7,20 @@ import { searchResults } from '../../mocks';
 export const SearchResults = (): TemplateResult => html`
   <div class="search-page__container--search-results">
     <div class="search-page__container--results-top-bar">
-      <pharos-heading level="3" preset="2">721,120 text results</pharos-heading>
-      <pharos-button
+      <storybook-pharos-heading level="3" preset="2">721,120 text results</storybook-pharos-heading>
+      <storybook-pharos-button
         variant="secondary"
         icon-right="chevron-down"
         data-dropdown-menu-id="sort-dropdown"
         style="margin-left: auto"
-        >Sort by: Relevance</pharos-button
+        >Sort by: Relevance</storybook-pharos-button
       >
     </div>
-    <pharos-dropdown-menu id="sort-dropdown" show-selected full-width>
-      <pharos-dropdown-menu-item selected>Relevance</pharos-dropdown-menu-item>
-      <pharos-dropdown-menu-item>Newest</pharos-dropdown-menu-item>
-      <pharos-dropdown-menu-item>Oldest</pharos-dropdown-menu-item>
-    </pharos-dropdown-menu>
+    <storybook-pharos-dropdown-menu id="sort-dropdown" show-selected full-width>
+      <storybook-pharos-dropdown-menu-item selected>Relevance</storybook-pharos-dropdown-menu-item>
+      <storybook-pharos-dropdown-menu-item>Newest</storybook-pharos-dropdown-menu-item>
+      <storybook-pharos-dropdown-menu-item>Oldest</storybook-pharos-dropdown-menu-item>
+    </storybook-pharos-dropdown-menu>
     <ol class="search-page__list--results">
       ${searchResults.map(
         (result) =>
@@ -28,12 +28,12 @@ export const SearchResults = (): TemplateResult => html`
       )}
     </ol>
     <div class="search-page__container--results-pagination">
-      <pharos-pagination
+      <storybook-pharos-pagination
         total-results="132"
         page-size="4"
         current-page="1"
         style="margin-left: auto"
-      ></pharos-pagination>
+      ></storybook-pharos-pagination>
     </div>
   </div>
 `;

--- a/packages/pharos/src/pages/search/wc/search.pages.stories.ts
+++ b/packages/pharos/src/pages/search/wc/search.pages.stories.ts
@@ -22,8 +22,8 @@ export const Search = {
       ${Header()}
       <main class="search-page__container--main-content">
         <div class="search-page__container--results-content">
-          <pharos-heading level="2" preset="5--bold">722,549 search results</pharos-heading>
-          <pharos-link href="/help" style="margin-left: auto">Search help</pharos-link>
+          <storybook-pharos-heading level="2" preset="5--bold">722,549 search results</storybook-pharos-heading>
+          <storybook-pharos-link href="/help" style="margin-left: auto">Search help</storybook-pharos-link>
         </div>
         ${ImageResults()} ${SearchResults()}
       </main>

--- a/packages/pharos/src/pages/search/wc/search.pages.stories.ts
+++ b/packages/pharos/src/pages/search/wc/search.pages.stories.ts
@@ -22,8 +22,12 @@ export const Search = {
       ${Header()}
       <main class="search-page__container--main-content">
         <div class="search-page__container--results-content">
-          <storybook-pharos-heading level="2" preset="5--bold">722,549 search results</storybook-pharos-heading>
-          <storybook-pharos-link href="/help" style="margin-left: auto">Search help</storybook-pharos-link>
+          <storybook-pharos-heading level="2" preset="5--bold"
+            >722,549 search results</storybook-pharos-heading
+          >
+          <storybook-pharos-link href="/help" style="margin-left: auto"
+            >Search help</storybook-pharos-link
+          >
         </div>
         ${ImageResults()} ${SearchResults()}
       </main>

--- a/packages/pharos/src/pages/shared/styles/header-revised.scss
+++ b/packages/pharos/src/pages/shared/styles/header-revised.scss
@@ -10,7 +10,7 @@
     grid-template-columns: var(--pharos-spacing-1-x) 1fr var(--pharos-spacing-1-x);
   }
 
-  .header-revised__nav pharos-dropdown-menu-nav,
+  .header-revised__nav [data-pharos-component='PharosDropdownMenuNav'],
   .header-revised__button--pds,
   .header-revised__grid--account {
     display: none;

--- a/packages/pharos/src/pages/shared/wc/footer.ts
+++ b/packages/pharos/src/pages/shared/wc/footer.ts
@@ -6,282 +6,282 @@ import initTranslateWidget from '../../search/initTranslateWidget';
 export const Footer = (): TemplateResult => {
   initTranslateWidget();
   return html`
-    <pharos-footer>
+    <storybook-pharos-footer>
       <ul slot="links-group">
         <li>
-          <pharos-link id="subject-link" on-background subtle href="/subjects" target="_blank"
-            >By Subject</pharos-link
+          <storybook-pharos-link id="subject-link" on-background subtle href="/subjects" target="_blank"
+            >By Subject</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="title-link"
             on-background
             subtle
             href="/action/showJournals?browseType=title"
             target="_blank"
-            >By Title</pharos-link
+            >By Title</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="collections-link"
             on-background
             subtle
             href="/site/collection-list"
             target="_blank"
-            >By Collections</pharos-link
+            >By Collections</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link id="publisher-link" on-background subtle href="/publishers" target="_blank"
-            >By Publisher</pharos-link
+          <storybook-pharos-link id="publisher-link" on-background subtle href="/publishers" target="_blank"
+            >By Publisher</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="adv-search-link"
             on-background
             subtle
             href="/action/showAdvancedSearch"
             target="_blank"
-            >Advanced Search</pharos-link
+            >Advanced Search</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link id="dfr-link" on-background subtle href="/dfr" target="_blank"
-            >Data for Research</pharos-link
+          <storybook-pharos-link id="dfr-link" on-background subtle href="/dfr" target="_blank"
+            >Data for Research</storybook-pharos-link
           >
         </li>
       </ul>
       <ul slot="links-group">
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="access-link"
             on-background
             subtle
             href="https://support.jstor.org/hc/en-us/articles/360000313328-Need-Help-Logging-in-To-JSTOR"
             target="_blank"
-            >Get Access</pharos-link
+            >Get Access</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="support-link"
             on-background
             subtle
             href="https://support.jstor.org"
             target="_blank"
-            >Support</pharos-link
+            >Support</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="libguides-link"
             on-background
             subtle
             href="https://guides.jstor.org"
             target="_blank"
-            >LibGuides</pharos-link
+            >LibGuides</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="research-link"
             on-background
             subtle
             href="https://guides.jstor.org/researchbasics"
             target="_blank"
-            >Research Basics</pharos-link
+            >Research Basics</storybook-pharos-link
           >
         </li>
       </ul>
       <ul slot="links-group">
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="about-link"
             on-background
             subtle
             href="https://about.jstor.org"
             target="_blank"
-            >About JSTOR</pharos-link
+            >About JSTOR</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="mission-link"
             on-background
             subtle
             href="https://about.jstor.org/mission-history/"
             target="_blank"
-            >Mission and History</pharos-link
+            >Mission and History</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="in-jstor-link"
             on-background
             subtle
             href="https://about.jstor.org/whats-in-jstor/"
             target="_blank"
-            >What's in JSTOR</pharos-link
+            >What's in JSTOR</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="get-jstor-link"
             on-background
             subtle
             href="https://about.jstor.org/get-jstor/"
             target="_blank"
-            >Get JSTOR</pharos-link
+            >Get JSTOR</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="news-link"
             on-background
             subtle
             href="https://about.jstor.org/news/"
             target="_blank"
-            >News</pharos-link
+            >News</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="webinars-link"
             on-background
             subtle
             href="https://about.jstor.org/webinars/"
             target="_blank"
-            >Webinars</pharos-link
+            >Webinars</storybook-pharos-link
           >
         </li>
       </ul>
       <ul slot="links-group">
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="labs-link"
             on-background
             subtle
             href="https://labs.jstor.org/"
             target="_blank"
-            >JSTOR Labs</pharos-link
+            >JSTOR Labs</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="daily-link"
             on-background
             subtle
             href="https://daily.jstor.org/"
             target="_blank"
-            >JSTOR Daily</pharos-link
+            >JSTOR Daily</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="careers-link"
             on-background
             subtle
             href="https://www.ithaka.org/careers/"
             target="_blank"
-            >Careers</pharos-link
+            >Careers</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link id="contact-link" on-background subtle href="/contact-us/" target="_blank"
-            >Contact Us</pharos-link
+          <storybook-pharos-link id="contact-link" on-background subtle href="/contact-us/" target="_blank"
+            >Contact Us</storybook-pharos-link
           >
         </li>
       </ul>
       <ul slot="button-links">
         <li>
-          <pharos-button
+          <storybook-pharos-button
             id="for-librarians-link"
             variant="secondary"
             on-background
             href="https://about.jstor.org/librarians/"
             target="_blank"
-            >For Librarians</pharos-button
+            >For Librarians</storybook-pharos-button
           >
         </li>
         <li>
-          <pharos-button
+          <storybook-pharos-button
             id="for-publishers-link"
             variant="secondary"
             on-background
             href="https://about.jstor.org/publishers/"
             target="_blank"
-            >For Publishers</pharos-button
+            >For Publishers</storybook-pharos-button
           >
         </li>
       </ul>
       <ul slot="social-links">
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="twitter-link"
             href="https://twitter.com/JSTOR"
             target="_blank"
             label="twitter - This link opens in a new window"
           >
-            <pharos-icon name="twitter"></pharos-icon>
-          </pharos-link>
+            <storybook-pharos-icon name="twitter"></storybook-pharos-icon>
+          </storybook-pharos-link>
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="facebook-link"
             href="https://www.facebook.com/JSTOR.org"
             target="_blank"
             label="facebook - This link opens in a new window"
           >
-            <pharos-icon name="facebook"></pharos-icon>
-          </pharos-link>
+            <storybook-pharos-icon name="facebook"></storybook-pharos-icon>
+          </storybook-pharos-link>
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="instagram-link"
             href="https://www.instagram.com/jstor_org"
             target="_blank"
             label="instagram - This link opens in a new window"
           >
-            <pharos-icon name="instagram"></pharos-icon>
-          </pharos-link>
+            <storybook-pharos-icon name="instagram"></storybook-pharos-icon>
+          </storybook-pharos-link>
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="youtube-link"
             href="https://www.youtube.com/channel/UCQM-7sUBV6Z-PVas0S4k0lw"
             target="_blank"
             label="youtube - This link opens in a new window"
           >
-            <pharos-icon name="youtube"></pharos-icon>
-          </pharos-link>
+            <storybook-pharos-icon name="youtube"></storybook-pharos-icon>
+          </storybook-pharos-link>
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="linkedin-link"
             href="https://www.linkedin.com/company/ithaka"
             target="_blank"
             label="linkedin - This link opens in a new window"
           >
-            <pharos-icon name="linkedin"></pharos-icon>
-          </pharos-link>
+            <storybook-pharos-icon name="linkedin"></storybook-pharos-icon>
+          </storybook-pharos-link>
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="tumblr-link"
             href="https://jstor.tumblr.com"
             target="_blank"
             label="tumblr - This link opens in a new window"
           >
-            <pharos-icon name="tumblr"></pharos-icon>
-          </pharos-link>
+            <storybook-pharos-icon name="tumblr"></storybook-pharos-icon>
+          </storybook-pharos-link>
         </li>
       </ul>
       <span id="misson-text" slot="mission-statement"
         >JSTOR is part of
-        <pharos-link on-background href="https://www.ithaka.org">ITHAKA</pharos-link>, a
+        <storybook-pharos-link on-background href="https://www.ithaka.org">ITHAKA</storybook-pharos-link>, a
         not-for-profit organization helping the academic community use digital technologies to
         preserve the scholarly record and to advance research and teaching in sustainable
         ways.</span
@@ -293,47 +293,47 @@ export const Footer = (): TemplateResult => {
       >
       <ul slot="legal-links">
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="terms-link"
             on-background
             subtle
             href="https://about.jstor.org/terms"
             target="_blank"
-            >Terms & Conditions of Use</pharos-link
+            >Terms & Conditions of Use</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="privacy-link"
             on-background
             subtle
             href="https://www.ithaka.org/privacypolicy"
             target="_blank"
-            >Privacy Policy</pharos-link
+            >Privacy Policy</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="cookie-link"
             on-background
             subtle
             href="https://www.ithaka.org/cookies"
             target="_blank"
-            >Cookie Policy</pharos-link
+            >Cookie Policy</storybook-pharos-link
           >
         </li>
         <li>
-          <pharos-link
+          <storybook-pharos-link
             id="accessibility-link"
             on-background
             subtle
             href="https://about.jstor.org/accessibility"
             target="_blank"
-            >Accessibility</pharos-link
+            >Accessibility</storybook-pharos-link
           >
         </li>
       </ul>
       <div slot="google-widget" id="google_translate_element" aria-hidden="true"></div>
-    </pharos-footer>
+    </storybook-pharos-footer>
   `;
 };

--- a/packages/pharos/src/pages/shared/wc/footer.ts
+++ b/packages/pharos/src/pages/shared/wc/footer.ts
@@ -9,7 +9,12 @@ export const Footer = (): TemplateResult => {
     <storybook-pharos-footer>
       <ul slot="links-group">
         <li>
-          <storybook-pharos-link id="subject-link" on-background subtle href="/subjects" target="_blank"
+          <storybook-pharos-link
+            id="subject-link"
+            on-background
+            subtle
+            href="/subjects"
+            target="_blank"
             >By Subject</storybook-pharos-link
           >
         </li>
@@ -34,7 +39,12 @@ export const Footer = (): TemplateResult => {
           >
         </li>
         <li>
-          <storybook-pharos-link id="publisher-link" on-background subtle href="/publishers" target="_blank"
+          <storybook-pharos-link
+            id="publisher-link"
+            on-background
+            subtle
+            href="/publishers"
+            target="_blank"
             >By Publisher</storybook-pharos-link
           >
         </li>
@@ -190,7 +200,12 @@ export const Footer = (): TemplateResult => {
           >
         </li>
         <li>
-          <storybook-pharos-link id="contact-link" on-background subtle href="/contact-us/" target="_blank"
+          <storybook-pharos-link
+            id="contact-link"
+            on-background
+            subtle
+            href="/contact-us/"
+            target="_blank"
             >Contact Us</storybook-pharos-link
           >
         </li>
@@ -281,8 +296,9 @@ export const Footer = (): TemplateResult => {
       </ul>
       <span id="misson-text" slot="mission-statement"
         >JSTOR is part of
-        <storybook-pharos-link on-background href="https://www.ithaka.org">ITHAKA</storybook-pharos-link>, a
-        not-for-profit organization helping the academic community use digital technologies to
+        <storybook-pharos-link on-background href="https://www.ithaka.org"
+          >ITHAKA</storybook-pharos-link
+        >, a not-for-profit organization helping the academic community use digital technologies to
         preserve the scholarly record and to advance research and teaching in sustainable
         ways.</span
       >

--- a/packages/pharos/src/pages/shared/wc/header-revised.ts
+++ b/packages/pharos/src/pages/shared/wc/header-revised.ts
@@ -76,14 +76,18 @@ export const HeaderRevised = (showSearch = false): TemplateResult => html`
             >Browse</storybook-pharos-dropdown-menu-nav-link
           >
           <storybook-pharos-dropdown-menu id="browse-menu">
-            <storybook-pharos-dropdown-menu-item link="/subjects">by Subject</storybook-pharos-dropdown-menu-item>
+            <storybook-pharos-dropdown-menu-item link="/subjects"
+              >by Subject</storybook-pharos-dropdown-menu-item
+            >
             <storybook-pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
               >by Title</storybook-pharos-dropdown-menu-item
             >
             <storybook-pharos-dropdown-menu-item link="/site/collection-list"
               >by Collections</storybook-pharos-dropdown-menu-item
             >
-            <storybook-pharos-dropdown-menu-item link="/publishers">by Publisher</storybook-pharos-dropdown-menu-item>
+            <storybook-pharos-dropdown-menu-item link="/publishers"
+              >by Publisher</storybook-pharos-dropdown-menu-item
+            >
           </storybook-pharos-dropdown-menu>
           <storybook-pharos-dropdown-menu-nav-link
             href="/account/workspace"
@@ -97,11 +101,15 @@ export const HeaderRevised = (showSearch = false): TemplateResult => html`
             <storybook-pharos-dropdown-menu-item link="/account/workspace"
               >Workspace</storybook-pharos-dropdown-menu-item
             >
-            <storybook-pharos-dropdown-menu-item link="/analyze">Text Analyzer</storybook-pharos-dropdown-menu-item>
+            <storybook-pharos-dropdown-menu-item link="/analyze"
+              >Text Analyzer</storybook-pharos-dropdown-menu-item
+            >
             <storybook-pharos-dropdown-menu-item link="/understand"
               >The JSTOR Understanding Series</storybook-pharos-dropdown-menu-item
             >
-            <storybook-pharos-dropdown-menu-item link="/dfr">Data for Research</storybook-pharos-dropdown-menu-item>
+            <storybook-pharos-dropdown-menu-item link="/dfr"
+              >Data for Research</storybook-pharos-dropdown-menu-item
+            >
           </storybook-pharos-dropdown-menu>
         </storybook-pharos-dropdown-menu-nav>
       </div>
@@ -115,14 +123,20 @@ export const HeaderRevised = (showSearch = false): TemplateResult => html`
         >
         <div class="header-revised__grid--account">
           <div class="header-revised__grid--account-links">
-            <storybook-pharos-link href="//about.jstor.org" target="_blank" bold>About</storybook-pharos-link>
-            <storybook-pharos-link href="//support.jstor.org" target="_blank" bold>Support</storybook-pharos-link>
+            <storybook-pharos-link href="//about.jstor.org" target="_blank" bold
+              >About</storybook-pharos-link
+            >
+            <storybook-pharos-link href="//support.jstor.org" target="_blank" bold
+              >Support</storybook-pharos-link
+            >
           </div>
           <div class="header-revised__grid--account-buttons">
             <storybook-pharos-button variant="secondary" href="//support.jstor.org" target="_blank"
               >Register</storybook-pharos-button
             >
-            <storybook-pharos-button href="//support.jstor.org" target="_blank">Log in</storybook-pharos-button>
+            <storybook-pharos-button href="//support.jstor.org" target="_blank"
+              >Log in</storybook-pharos-button
+            >
           </div>
         </div>
         <svg

--- a/packages/pharos/src/pages/shared/wc/header-revised.ts
+++ b/packages/pharos/src/pages/shared/wc/header-revised.ts
@@ -12,7 +12,7 @@ export const HeaderRevised = (showSearch = false): TemplateResult => html`
     })}"
   >
     <div class="header-revised__container--content">
-      <pharos-link href="/" id="jstor-logo" class="header-revised__logo" flex>
+      <storybook-pharos-link href="/" id="jstor-logo" class="header-revised__logo" flex>
         <img
           src="./images/jstor-logo.svg"
           alt="JSTOR Home"
@@ -34,9 +34,9 @@ export const HeaderRevised = (showSearch = false): TemplateResult => html`
           height="60"
           class="header-revised__image--logo-small"
         />
-      </pharos-link>
+      </storybook-pharos-link>
       <div class="header-revised__nav">
-        <pharos-input-group
+        <storybook-pharos-input-group
           name="my-input-group"
           hide-label
           class="${classMap({
@@ -45,84 +45,84 @@ export const HeaderRevised = (showSearch = false): TemplateResult => html`
           })}"
         >
           <span slot="label">Search</span>
-          <pharos-button
+          <storybook-pharos-button
             name="search-button"
             icon="search"
             variant="subtle"
             label="search"
-          ></pharos-button>
-        </pharos-input-group>
-        <pharos-dropdown-menu-nav label="main navigation">
-          <pharos-dropdown-menu-nav-link
+          ></storybook-pharos-button>
+        </storybook-pharos-input-group>
+        <storybook-pharos-dropdown-menu-nav label="main navigation">
+          <storybook-pharos-dropdown-menu-nav-link
             href="/action/showAdvancedSearch"
             id="adv-search-menu-link"
             data-dropdown-menu-id="search-menu"
             data-dropdown-menu-hover
-            >Search</pharos-dropdown-menu-nav-link
+            >Search</storybook-pharos-dropdown-menu-nav-link
           >
-          <pharos-dropdown-menu id="search-menu">
-            <pharos-dropdown-menu-item link="/action/showAdvancedSearch"
-              >Advanced Search</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu id="search-menu">
+            <storybook-pharos-dropdown-menu-item link="/action/showAdvancedSearch"
+              >Advanced Search</storybook-pharos-dropdown-menu-item
             >
-            <pharos-dropdown-menu-item link="/action/doImageSearch"
-              >Image Search</pharos-dropdown-menu-item
+            <storybook-pharos-dropdown-menu-item link="/action/doImageSearch"
+              >Image Search</storybook-pharos-dropdown-menu-item
             >
-          </pharos-dropdown-menu>
-          <pharos-dropdown-menu-nav-link
+          </storybook-pharos-dropdown-menu>
+          <storybook-pharos-dropdown-menu-nav-link
             href="/subjects"
             id="browse-link"
             data-dropdown-menu-id="browse-menu"
             data-dropdown-menu-hover
-            >Browse</pharos-dropdown-menu-nav-link
+            >Browse</storybook-pharos-dropdown-menu-nav-link
           >
-          <pharos-dropdown-menu id="browse-menu">
-            <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
-            <pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
-              >by Title</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu id="browse-menu">
+            <storybook-pharos-dropdown-menu-item link="/subjects">by Subject</storybook-pharos-dropdown-menu-item>
+            <storybook-pharos-dropdown-menu-item link="/action/showJournals?browseType=title"
+              >by Title</storybook-pharos-dropdown-menu-item
             >
-            <pharos-dropdown-menu-item link="/site/collection-list"
-              >by Collections</pharos-dropdown-menu-item
+            <storybook-pharos-dropdown-menu-item link="/site/collection-list"
+              >by Collections</storybook-pharos-dropdown-menu-item
             >
-            <pharos-dropdown-menu-item link="/publishers">by Publisher</pharos-dropdown-menu-item>
-          </pharos-dropdown-menu>
-          <pharos-dropdown-menu-nav-link
+            <storybook-pharos-dropdown-menu-item link="/publishers">by Publisher</storybook-pharos-dropdown-menu-item>
+          </storybook-pharos-dropdown-menu>
+          <storybook-pharos-dropdown-menu-nav-link
             href="/account/workspace"
             id="tools-link"
             data-dropdown-menu-id="tools-menu"
             data-dropdown-menu-hover
             class="hide-for-small"
-            >Tools</pharos-dropdown-menu-nav-link
+            >Tools</storybook-pharos-dropdown-menu-nav-link
           >
-          <pharos-dropdown-menu id="tools-menu">
-            <pharos-dropdown-menu-item link="/account/workspace"
-              >Workspace</pharos-dropdown-menu-item
+          <storybook-pharos-dropdown-menu id="tools-menu">
+            <storybook-pharos-dropdown-menu-item link="/account/workspace"
+              >Workspace</storybook-pharos-dropdown-menu-item
             >
-            <pharos-dropdown-menu-item link="/analyze">Text Analyzer</pharos-dropdown-menu-item>
-            <pharos-dropdown-menu-item link="/understand"
-              >The JSTOR Understanding Series</pharos-dropdown-menu-item
+            <storybook-pharos-dropdown-menu-item link="/analyze">Text Analyzer</storybook-pharos-dropdown-menu-item>
+            <storybook-pharos-dropdown-menu-item link="/understand"
+              >The JSTOR Understanding Series</storybook-pharos-dropdown-menu-item
             >
-            <pharos-dropdown-menu-item link="/dfr">Data for Research</pharos-dropdown-menu-item>
-          </pharos-dropdown-menu>
-        </pharos-dropdown-menu-nav>
+            <storybook-pharos-dropdown-menu-item link="/dfr">Data for Research</storybook-pharos-dropdown-menu-item>
+          </storybook-pharos-dropdown-menu>
+        </storybook-pharos-dropdown-menu-nav>
       </div>
       <div class="header-revised__container--account">
-        <pharos-button
+        <storybook-pharos-button
           variant="subtle"
           icon-left="checkmark-inverse"
           icon-right="chevron-down"
           class="header-revised__button--pds"
-          >Access provided by JSTOR</pharos-button
+          >Access provided by JSTOR</storybook-pharos-button
         >
         <div class="header-revised__grid--account">
           <div class="header-revised__grid--account-links">
-            <pharos-link href="//about.jstor.org" target="_blank" bold>About</pharos-link>
-            <pharos-link href="//support.jstor.org" target="_blank" bold>Support</pharos-link>
+            <storybook-pharos-link href="//about.jstor.org" target="_blank" bold>About</storybook-pharos-link>
+            <storybook-pharos-link href="//support.jstor.org" target="_blank" bold>Support</storybook-pharos-link>
           </div>
           <div class="header-revised__grid--account-buttons">
-            <pharos-button variant="secondary" href="//support.jstor.org" target="_blank"
-              >Register</pharos-button
+            <storybook-pharos-button variant="secondary" href="//support.jstor.org" target="_blank"
+              >Register</storybook-pharos-button
             >
-            <pharos-button href="//support.jstor.org" target="_blank">Log in</pharos-button>
+            <storybook-pharos-button href="//support.jstor.org" target="_blank">Log in</storybook-pharos-button>
           </div>
         </div>
         <svg

--- a/packages/pharos/src/pages/shared/wc/header.ts
+++ b/packages/pharos/src/pages/shared/wc/header.ts
@@ -14,8 +14,12 @@ const accountNav = (section: string) => html`
       ></storybook-pharos-dropdown-menu-nav-link
     >
     <storybook-pharos-dropdown-menu id="profile-menu-${section}">
-      <storybook-pharos-dropdown-menu-item link="/account/profile">Profile</storybook-pharos-dropdown-menu-item>
-      <storybook-pharos-dropdown-menu-item link="/account/workspace">Workspace</storybook-pharos-dropdown-menu-item>
+      <storybook-pharos-dropdown-menu-item link="/account/profile"
+        >Profile</storybook-pharos-dropdown-menu-item
+      >
+      <storybook-pharos-dropdown-menu-item link="/account/workspace"
+        >Workspace</storybook-pharos-dropdown-menu-item
+      >
       <storybook-pharos-dropdown-menu-item link="/account/read-online"
         >Free Article Views</storybook-pharos-dropdown-menu-item
       >
@@ -25,7 +29,9 @@ const accountNav = (section: string) => html`
       <storybook-pharos-dropdown-menu-item link="/account/purchases"
         >Puchase History</storybook-pharos-dropdown-menu-item
       >
-      <storybook-pharos-dropdown-menu-item link="/action/doLogout">Logout</storybook-pharos-dropdown-menu-item>
+      <storybook-pharos-dropdown-menu-item link="/action/doLogout"
+        >Logout</storybook-pharos-dropdown-menu-item
+      >
     </storybook-pharos-dropdown-menu>
   </storybook-pharos-dropdown-menu-nav>
 `;
@@ -41,13 +47,17 @@ export const Header = (): TemplateResult => html`
       >
         <span>Access provided by&nbsp;</span>
         <span style="font-weight: bold">JSTOR</span>
-        <storybook-pharos-icon name="chevron-down" style="margin-left: 1rem"></storybook-pharos-icon>
+        <storybook-pharos-icon
+          name="chevron-down"
+          style="margin-left: 1rem"
+        ></storybook-pharos-icon>
       </div>
       <storybook-pharos-dropdown-menu id="pds-menu" placement="bottom">
         <div style="padding: 1rem">
           <p>
             Please contact
-            <storybook-pharos-link href="//jstor.org">JSTOR</storybook-pharos-link> for additional help and information.
+            <storybook-pharos-link href="//jstor.org">JSTOR</storybook-pharos-link> for additional
+            help and information.
           </p>
         </div>
       </storybook-pharos-dropdown-menu>
@@ -75,7 +85,10 @@ export const Header = (): TemplateResult => html`
     <div slot="end-top">${accountNav('end')}</div>
     <div slot="end-bottom" style="display: flex;">
       <storybook-pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
-        <storybook-pharos-dropdown-menu-nav-link href="/action/showAdvancedSearch" id="adv-search-menu-link">
+        <storybook-pharos-dropdown-menu-nav-link
+          href="/action/showAdvancedSearch"
+          id="adv-search-menu-link"
+        >
           Advanced Search
         </storybook-pharos-dropdown-menu-nav-link>
         <storybook-pharos-dropdown-menu-nav-link
@@ -87,14 +100,18 @@ export const Header = (): TemplateResult => html`
           Browse
         </storybook-pharos-dropdown-menu-nav-link>
         <storybook-pharos-dropdown-menu id="browse-menu">
-          <storybook-pharos-dropdown-menu-item link="/subjects">by Subject</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/subjects"
+            >by Subject</storybook-pharos-dropdown-menu-item
+          >
           <storybook-pharos-dropdown-menu-item link="/action/showJournals?browseType=title">
             by Title
           </storybook-pharos-dropdown-menu-item>
           <storybook-pharos-dropdown-menu-item link="/site/collection-list">
             by Collections
           </storybook-pharos-dropdown-menu-item>
-          <storybook-pharos-dropdown-menu-item link="/publishers">by Publisher</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/publishers"
+            >by Publisher</storybook-pharos-dropdown-menu-item
+          >
         </storybook-pharos-dropdown-menu>
         <storybook-pharos-dropdown-menu-nav-link
           href="/account/workspace"
@@ -108,11 +125,15 @@ export const Header = (): TemplateResult => html`
           <storybook-pharos-dropdown-menu-item link="/account/workspace">
             Workspace
           </storybook-pharos-dropdown-menu-item>
-          <storybook-pharos-dropdown-menu-item link="/analyze">Text Analyzer</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/analyze"
+            >Text Analyzer</storybook-pharos-dropdown-menu-item
+          >
           <storybook-pharos-dropdown-menu-item link="/understand">
             The JSTOR Understanding Series
           </storybook-pharos-dropdown-menu-item>
-          <storybook-pharos-dropdown-menu-item link="/dfr">Data for Research</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/dfr"
+            >Data for Research</storybook-pharos-dropdown-menu-item
+          >
         </storybook-pharos-dropdown-menu>
       </storybook-pharos-dropdown-menu-nav>
     </div>

--- a/packages/pharos/src/pages/shared/wc/header.ts
+++ b/packages/pharos/src/pages/shared/wc/header.ts
@@ -2,8 +2,8 @@ import { html } from 'lit';
 import type { TemplateResult } from 'lit';
 
 const accountNav = (section: string) => html`
-  <pharos-dropdown-menu-nav label="profile">
-    <pharos-dropdown-menu-nav-link
+  <storybook-pharos-dropdown-menu-nav label="profile">
+    <storybook-pharos-dropdown-menu-nav-link
       href="/account/profile"
       id="profile-link-${section}"
       data-dropdown-menu-id="profile-menu-${section}"
@@ -11,27 +11,27 @@ const accountNav = (section: string) => html`
       ><span class="hide-for-small">human@ithaka.org</span
       ><span class="show-for-small" style="display: none"
         >Account</span
-      ></pharos-dropdown-menu-nav-link
+      ></storybook-pharos-dropdown-menu-nav-link
     >
-    <pharos-dropdown-menu id="profile-menu-${section}">
-      <pharos-dropdown-menu-item link="/account/profile">Profile</pharos-dropdown-menu-item>
-      <pharos-dropdown-menu-item link="/account/workspace">Workspace</pharos-dropdown-menu-item>
-      <pharos-dropdown-menu-item link="/account/read-online"
-        >Free Article Views</pharos-dropdown-menu-item
+    <storybook-pharos-dropdown-menu id="profile-menu-${section}">
+      <storybook-pharos-dropdown-menu-item link="/account/profile">Profile</storybook-pharos-dropdown-menu-item>
+      <storybook-pharos-dropdown-menu-item link="/account/workspace">Workspace</storybook-pharos-dropdown-menu-item>
+      <storybook-pharos-dropdown-menu-item link="/account/read-online"
+        >Free Article Views</storybook-pharos-dropdown-menu-item
       >
-      <pharos-dropdown-menu-item link="/account/subscriptions"
-        >JPASS Downloads</pharos-dropdown-menu-item
+      <storybook-pharos-dropdown-menu-item link="/account/subscriptions"
+        >JPASS Downloads</storybook-pharos-dropdown-menu-item
       >
-      <pharos-dropdown-menu-item link="/account/purchases"
-        >Puchase History</pharos-dropdown-menu-item
+      <storybook-pharos-dropdown-menu-item link="/account/purchases"
+        >Puchase History</storybook-pharos-dropdown-menu-item
       >
-      <pharos-dropdown-menu-item link="/action/doLogout">Logout</pharos-dropdown-menu-item>
-    </pharos-dropdown-menu>
-  </pharos-dropdown-menu-nav>
+      <storybook-pharos-dropdown-menu-item link="/action/doLogout">Logout</storybook-pharos-dropdown-menu-item>
+    </storybook-pharos-dropdown-menu>
+  </storybook-pharos-dropdown-menu-nav>
 `;
 
 export const Header = (): TemplateResult => html`
-  <pharos-header>
+  <storybook-pharos-header>
     <div id="pds" slot="top" class="hide-for-small">
       <div
         tabindex="0"
@@ -41,80 +41,80 @@ export const Header = (): TemplateResult => html`
       >
         <span>Access provided by&nbsp;</span>
         <span style="font-weight: bold">JSTOR</span>
-        <pharos-icon name="chevron-down" style="margin-left: 1rem"></pharos-icon>
+        <storybook-pharos-icon name="chevron-down" style="margin-left: 1rem"></storybook-pharos-icon>
       </div>
-      <pharos-dropdown-menu id="pds-menu" placement="bottom">
+      <storybook-pharos-dropdown-menu id="pds-menu" placement="bottom">
         <div style="padding: 1rem">
           <p>
             Please contact
-            <pharos-link href="//jstor.org">JSTOR</pharos-link> for additional help and information.
+            <storybook-pharos-link href="//jstor.org">JSTOR</storybook-pharos-link> for additional help and information.
           </p>
         </div>
-      </pharos-dropdown-menu>
+      </storybook-pharos-dropdown-menu>
     </div>
     <span slot="top" class="show-for-small" style="display: none; font-weight: bold">JSTOR</span>
-    <pharos-link slot="start" href="/" id="jstor-logo">
+    <storybook-pharos-link slot="start" href="/" id="jstor-logo">
       <img src="./images/jstor-logo.svg" alt="JSTOR Home" width="65" height="90" />
-    </pharos-link>
+    </storybook-pharos-link>
     <div slot="center">
-      <pharos-input-group
+      <storybook-pharos-input-group
         name="my-input-group"
         hide-label
         placeholder="Search JSTOR"
         class="header-example__input-group"
       >
         <span slot="label">Search JSTOR</span>
-        <pharos-button
+        <storybook-pharos-button
           name="search-button"
           icon="search"
           variant="subtle"
           label="search"
-        ></pharos-button>
-      </pharos-input-group>
+        ></storybook-pharos-button>
+      </storybook-pharos-input-group>
     </div>
     <div slot="end-top">${accountNav('end')}</div>
     <div slot="end-bottom" style="display: flex;">
-      <pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
-        <pharos-dropdown-menu-nav-link href="/action/showAdvancedSearch" id="adv-search-menu-link">
+      <storybook-pharos-dropdown-menu-nav label="main navigation" style="display: inline-block">
+        <storybook-pharos-dropdown-menu-nav-link href="/action/showAdvancedSearch" id="adv-search-menu-link">
           Advanced Search
-        </pharos-dropdown-menu-nav-link>
-        <pharos-dropdown-menu-nav-link
+        </storybook-pharos-dropdown-menu-nav-link>
+        <storybook-pharos-dropdown-menu-nav-link
           href="/subjects"
           id="browse-link"
           data-dropdown-menu-id="browse-menu"
           data-dropdown-menu-hover
         >
           Browse
-        </pharos-dropdown-menu-nav-link>
-        <pharos-dropdown-menu id="browse-menu">
-          <pharos-dropdown-menu-item link="/subjects">by Subject</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item link="/action/showJournals?browseType=title">
+        </storybook-pharos-dropdown-menu-nav-link>
+        <storybook-pharos-dropdown-menu id="browse-menu">
+          <storybook-pharos-dropdown-menu-item link="/subjects">by Subject</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/action/showJournals?browseType=title">
             by Title
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item link="/site/collection-list">
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/site/collection-list">
             by Collections
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item link="/publishers">by Publisher</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-        <pharos-dropdown-menu-nav-link
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/publishers">by Publisher</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+        <storybook-pharos-dropdown-menu-nav-link
           href="/account/workspace"
           id="tools-link"
           data-dropdown-menu-id="tools-menu"
           data-dropdown-menu-hover
         >
           Tools
-        </pharos-dropdown-menu-nav-link>
-        <pharos-dropdown-menu id="tools-menu">
-          <pharos-dropdown-menu-item link="/account/workspace">
+        </storybook-pharos-dropdown-menu-nav-link>
+        <storybook-pharos-dropdown-menu id="tools-menu">
+          <storybook-pharos-dropdown-menu-item link="/account/workspace">
             Workspace
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item link="/analyze">Text Analyzer</pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item link="/understand">
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/analyze">Text Analyzer</storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/understand">
             The JSTOR Understanding Series
-          </pharos-dropdown-menu-item>
-          <pharos-dropdown-menu-item link="/dfr">Data for Research</pharos-dropdown-menu-item>
-        </pharos-dropdown-menu>
-      </pharos-dropdown-menu-nav>
+          </storybook-pharos-dropdown-menu-item>
+          <storybook-pharos-dropdown-menu-item link="/dfr">Data for Research</storybook-pharos-dropdown-menu-item>
+        </storybook-pharos-dropdown-menu>
+      </storybook-pharos-dropdown-menu-nav>
     </div>
-  </pharos-header>
+  </storybook-pharos-header>
 `;

--- a/packages/pharos/src/styles/tokens.wc.stories.jsx
+++ b/packages/pharos/src/styles/tokens.wc.stories.jsx
@@ -551,7 +551,7 @@ const TypeTokens = () => html`
                       style="font-size:${tokens.type.scale[key].comment};"
                       >GT America</span
                     >`
-                  : html`<pharos-icon name="dash-small"></pharos-icon>`}
+                  : html`<storybook-pharos-icon name="dash-small"></storybook-pharos-icon>`}
               </td>
               <td>
                 ${tokens.type.scale[key].value > 5
@@ -560,7 +560,7 @@ const TypeTokens = () => html`
                       style="font-size:${tokens.type.scale[key].comment};"
                       >Ivar Headline</span
                     >`
-                  : html`<pharos-icon name="dash-small"></pharos-icon>`}
+                  : html`<storybook-pharos-icon name="dash-small"></storybook-pharos-icon>`}
               </td>
             </tr>
           `


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Resolves #477 

**How does this change work?**

- Create new `initComponents` for Storybook with a `storybook` scope
- Change `initComponents` for tests to use `test` scope
- Update `*.wc.stories.jsx` to use scoped component names
- Update `*.react.stories.jsx` to use `<PharosContext.Provider>` decorator
- Update `*.test.ts` to use scoped components

**Additional context**

I could not get `<PharosContext.Provider>` to work as a global decorator; it did not appear to pass the `createContext` down to the component rendered inside the story. If anyone can get this to work, that would be cleaner and preferred.
