### PR TITLE
fix(site): add missing href to example Link

### DIFF
--- a/.changeset/warm-cobras-knock.md
+++ b/.changeset/warm-cobras-knock.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+Add missing href to example Link

--- a/packages/pharos-site/static/guidelines/link.docs.mdx
+++ b/packages/pharos-site/static/guidelines/link.docs.mdx
@@ -11,7 +11,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
 ## Examples
 
 ```jsx live
-<PharosLink>I am a link</PharosLink>
+<PharosLink href="#">I am a link</PharosLink>
 ```
 
 <PageSection topMargin title="Usage">


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

#button
Links without an `href` attribute render as a button, and the canonical example Link in the docs did not have an `href`, so rendering as a button may serve to confuse newcomers.

**How does this change work?**

Add `href="#"` in line with other examples on the page.

**Additional context**

Fixes #507 
Closes #508