### PR TITLE
Button: Only render aria-pressed when explicitly defined

### DIFF
--- a/.changeset/grumpy-emus-impress.md
+++ b/.changeset/grumpy-emus-impress.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Only render aria-pressed when explicitly defined

--- a/packages/pharos/scripts/build-react.js
+++ b/packages/pharos/scripts/build-react.js
@@ -75,7 +75,8 @@ const createDefaultProps = (reactName) => {
         (attribute) => attribute.default === property.default && attribute.resolveInitializer
       );
       const defaultValue = hasInitializer
-        ? modules.find((item) => item.kind === 'variable' && item.name === property.default).default
+        ? modules.find((item) => item.kind === 'variable' && item.name === property.default)
+            ?.default
         : property.default;
       return `${property.name}: ${defaultValue},\n`;
     });

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -17,7 +17,8 @@ export type ButtonType = 'button' | 'submit' | 'reset';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'overlay';
 
-export type PressedState = 'false' | 'true' | 'mixed' | 'undefined';
+// undefined means no state has been expressed at all and won't render; 'undefined' is an explicit state
+export type PressedState = 'false' | 'true' | 'mixed' | 'undefined' | undefined;
 
 const TYPES = ['button', 'submit', 'reset'] as ButtonType[];
 
@@ -143,7 +144,7 @@ export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement))
    * @attr value
    */
   @property({ type: String, reflect: true })
-  public pressed: PressedState = 'undefined';
+  public pressed: PressedState = undefined;
 
   @query('#button-element')
   private _button!: HTMLButtonElement | HTMLAnchorElement;

--- a/packages/pharos/src/components/button/storyArgs.ts
+++ b/packages/pharos/src/components/button/storyArgs.ts
@@ -14,7 +14,7 @@ export const argTypes = {
     control: { type: 'select' },
   },
   pressed: {
-    options: ['false', 'true', 'mixed', 'undefined'],
+    options: ['false', 'true', 'mixed', 'undefined', undefined],
     control: { type: 'inline-radio' },
   },
   type: {
@@ -37,7 +37,7 @@ export const defaultArgs = {
   iconCondensed: false,
   large: false,
   onBackground: false,
-  pressed: 'undefined',
+  pressed: undefined,
   type: 'button',
   variant: 'primary',
 };


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Fixes #511 

**How does this change work?**

Use `undefined` instead of `'undefined'` as the default value. This causes `ifDefined` not to render the `aria-pressed` attribute unless given an explicit value.