### PR TITLE
Tabs: Make selected tab outline fully visible

### DIFF
--- a/.changeset/small-ways-live.md
+++ b/.changeset/small-ways-live.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Make selected tab outline fully visible

--- a/packages/pharos/src/components/tabs/pharos-tabs.scss
+++ b/packages/pharos/src/components/tabs/pharos-tabs.scss
@@ -32,7 +32,7 @@
   overflow-x: scroll;
   scroll-behavior: smooth;
   margin-bottom: var(--pharos-spacing-one-half-x);
-  padding-bottom: var(--pharos-spacing-one-quarter-x) var(--pharos-spacing-one-quarter-x)
+  padding: var(--pharos-spacing-one-quarter-x) var(--pharos-spacing-one-quarter-x)
     var(--pharos-spacing-1-x);
 }
 

--- a/packages/pharos/src/components/tabs/pharos-tabs.scss
+++ b/packages/pharos/src/components/tabs/pharos-tabs.scss
@@ -32,7 +32,8 @@
   overflow-x: scroll;
   scroll-behavior: smooth;
   margin-bottom: var(--pharos-spacing-one-half-x);
-  padding-bottom: var(--pharos-spacing-1-x);
+  padding-bottom: var(--pharos-spacing-one-quarter-x) var(--pharos-spacing-one-quarter-x)
+    var(--pharos-spacing-1-x);
 }
 
 .tab__panels {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Fixes #473 

**How does this change work?**

Add padding around the tab list to ensure the outline has space to render.