### PR TITLE
Storybook: Update links broken by scoping

### DIFF
--- a/.storybook/GuidelineLink.tsx
+++ b/.storybook/GuidelineLink.tsx
@@ -1,13 +1,16 @@
 import type { FC } from 'react';
 
 import { PharosLink } from '../packages/pharos/src/react-components/link/pharos-link';
+import { PharosContext } from '../packages/pharos/src/utils/PharosContext';
 
 interface GuidelineLinkProps {
   path: string;
 }
 
 export const GuidelineLink: FC<GuidelineLinkProps> = ({ path }) => (
-  <PharosLink href={`https://pharos.jstor.org/components/${path}`} target="_blank">
-    See guidelines in Pharos
-  </PharosLink>
+  <PharosContext.Provider value={{ prefix: 'storybook' }}>
+    <PharosLink href={`https://pharos.jstor.org/components/${path}`} target="_blank">
+      See guidelines in Pharos
+    </PharosLink>
+  </PharosContext.Provider>
 );

--- a/packages/pharos/src/components/alert/PharosAlert.react.stories.jsx
+++ b/packages/pharos/src/components/alert/PharosAlert.react.stories.jsx
@@ -66,7 +66,7 @@ export const Error = {
     <PharosAlert status={status} closable={closable}>
       <p className="alert-example__content">{text}</p>
       <p className="alert-example__content">
-        For more information, <pharos-link href="#">read the documentation</pharos-link>.
+        For more information, <PharosLink href="#">read the documentation</PharosLink>.
       </p>
     </PharosAlert>
   ),

--- a/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
+++ b/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
@@ -30,7 +30,7 @@ export const Base = {
           const event = new CustomEvent('pharos-toast-open', {
             detail: {
               content:
-                'The item has moved to your <pharos-link href="#" on-background bold>Workspace</pharos-link>.',
+                'The item has moved to your <PharosLink href="#" on-background bold>Workspace</PharosLink>.',
             },
           });
           document.dispatchEvent(event);
@@ -53,7 +53,7 @@ export const Error = {
             detail: {
               status: 'error',
               content:
-                'Sorry, we were unable to move the item. Please try again later. If the issue persists, <pharos-link href="#" on-background bold>contact JSTOR Support</pharos-link>.',
+                'Sorry, we were unable to move the item. Please try again later. If the issue persists, <PharosLink href="#" on-background bold>contact JSTOR Support</PharosLink>.',
             },
           });
           document.dispatchEvent(event);
@@ -84,7 +84,7 @@ export const LongContent = {
             const event = new CustomEvent('pharos-toast-open', {
               detail: {
                 content:
-                  'This is a notification for longer content, which may even include a <pharos-link href="#" on-background bold>link</pharos-link>.',
+                  'This is a notification for longer content, which may even include a <PharosLink href="#" on-background bold>link</PharosLink>.',
               },
             });
             document.dispatchEvent(event);

--- a/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
+++ b/packages/pharos/src/components/toast/PharosToast.react.stories.jsx
@@ -30,7 +30,7 @@ export const Base = {
           const event = new CustomEvent('pharos-toast-open', {
             detail: {
               content:
-                'The item has moved to your <PharosLink href="#" on-background bold>Workspace</PharosLink>.',
+                'The item has moved to your <storybook-pharos-link href="#" on-background bold>Workspace</storybook-pharos-link>.',
             },
           });
           document.dispatchEvent(event);
@@ -53,7 +53,7 @@ export const Error = {
             detail: {
               status: 'error',
               content:
-                'Sorry, we were unable to move the item. Please try again later. If the issue persists, <PharosLink href="#" on-background bold>contact JSTOR Support</PharosLink>.',
+                'Sorry, we were unable to move the item. Please try again later. If the issue persists, <storybook-pharos-link href="#" on-background bold>contact JSTOR Support</storybook-pharos-link>.',
             },
           });
           document.dispatchEvent(event);
@@ -84,7 +84,7 @@ export const LongContent = {
             const event = new CustomEvent('pharos-toast-open', {
               detail: {
                 content:
-                  'This is a notification for longer content, which may even include a <PharosLink href="#" on-background bold>link</PharosLink>.',
+                  'This is a notification for longer content, which may even include a <storybook-pharos-link href="#" on-background bold>link</storybook-pharos-link>.',
               },
             });
             document.dispatchEvent(event);


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Some links got broken when we moved to scoping all Storybook and test elements, and some potentially never worked because they were web component usages in React stories. The worst breakage was that all the "See guidelines in Pharos" links in Storybook's Docs tab were broken.

**How does this change work?**

- Scope the GuidelineLink component
- Update React stories to use React Pharos Links