### PR TITLE
fix(tests): update wait for sidenav animation to be less flaky

### DIFF
--- a/packages/pharos/src/components/sidenav/pharos-sidenav.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav.test.ts
@@ -1,4 +1,4 @@
-import { fixture, expect, nextFrame } from '@open-wc/testing';
+import { aTimeout, fixture, expect } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { setViewport } from '@web/test-runner-commands';
 
@@ -136,7 +136,7 @@ describe('pharos-sidenav', () => {
 
     await setViewport({ width: 1056, height: 768 });
     await component.updateComplete;
-    await nextFrame();
+    await aTimeout(1);
     expect(component.slide).to.be.false;
   });
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Upon reviewing several of the flaky runs of unit tests, the `resets its slide status when going back to a viewport above 1055px` was the frequent culprit. I suspect this is because the animation doesn't finish after the next frame much of the time, so using `aTimeout` to wait instead might be more robust. We use `aTimeout` regularly throughout the tests. We can increase the timeout value if we continue to see flakiness out of it.

**How does this change work?**

Replace `await nextFrame()` with `await aTimeout(1)` in the flaky test.