### PR TITLE
Use :focus-visible for most interactive elements

### DIFF
--- a/.changeset/stupid-files-jump.md
+++ b/.changeset/stupid-files-jump.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Use `:focus-visible` for non-form interactive elements

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -6,7 +6,6 @@ import {
   PharosColorMarbleGray20,
   PharosFontFamilyBody,
   PharosColorInteractivePrimary,
-  PharosColorInteractiveSecondary,
   PharosColorTextBase,
   PharosColorTextWhite,
 } from '../packages/pharos/lib/styles/variables.js';
@@ -16,7 +15,7 @@ export default create({
   base: 'light',
 
   colorPrimary: PharosColorInteractivePrimary,
-  colorSecondary: PharosColorInteractiveSecondary,
+  colorSecondary: PharosColorInteractivePrimary,
 
   // UI
   appBg: PharosColorWhite,

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.scss
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.scss
@@ -31,9 +31,16 @@
   text-align: left;
   margin: 0;
 
-  &:focus {
+  &:focus-visible {
     outline: 2px solid var(--pharos-color-focus);
     outline-offset: -1px;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      outline: 2px solid var(--pharos-color-focus);
+      outline-offset: 2px;
+    }
   }
 }
 

--- a/packages/pharos/src/components/tabs/pharos-tab-panel.scss
+++ b/packages/pharos/src/components/tabs/pharos-tab-panel.scss
@@ -5,9 +5,16 @@
   overflow-y: hidden;
 }
 
-:host(:focus) {
+:host(:focus-visible) {
   outline: 2px solid var(--pharos-color-focus);
   outline-offset: 2px;
+}
+
+@supports not selector(:focus-visible) {
+  :host(:focus) {
+    outline: 2px solid var(--pharos-color-focus);
+    outline-offset: 2px;
+  }
 }
 
 :host([selected]) {

--- a/packages/pharos/src/components/tabs/pharos-tab.scss
+++ b/packages/pharos/src/components/tabs/pharos-tab.scss
@@ -30,9 +30,16 @@
   }
 }
 
-:host(:focus) {
+:host(:focus-visible) {
   outline: 2px solid var(--pharos-color-focus);
   outline-offset: 2px;
+}
+
+@supports not selector(:focus-visible) {
+  :host(:focus) {
+    outline: 2px solid var(--pharos-color-focus);
+    outline-offset: 2px;
+  }
 }
 
 :host(:hover) {

--- a/packages/pharos/src/utils/scss/_mixins.scss
+++ b/packages/pharos/src/utils/scss/_mixins.scss
@@ -239,9 +239,16 @@
 /// @access public
 /// @group interaction
 @mixin interactive-focus {
-  &:focus {
+  &:focus-visible {
     outline: 2px solid var(--pharos-color-focus);
     outline-offset: 2px;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      outline: 2px solid var(--pharos-color-focus);
+      outline-offset: 2px;
+    }
   }
 }
 


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No (strictly speaking no API change, but perhaps warrants putting into v13?)

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Resolves #175 

**How does this change work?**

This change uses `:focus-visible` instead of `:focus` for most interactive elements. Notably, it leaves form controls alone, because the focus styling for those feels quite natural as compared to others.

Where buttons, tabs, and links used to have intrusive boxes placed around them on focus for all users, they will now only display those focus outlines when navigating with keyboards or other input devices. Direct mouse pointer input does not create the outline.

The expectation is that this **increases** accessibility for the set of users using mouse pointers, creating less visual noise and motion, while **maintaining** accessibility for all other users. MDN does call out that [there may be cognition
considerations](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#cognition) for the disparity between navigation modes, which I'm not sure how we might best understand more.

This change also provides a fallback for those browsers that don't yet support `:focus-visible` (Safari < 15 at all, and Safari < 15.4 by default) which is to maintain the current behavior of focus outlines all the time.