### PR TITLE
Icon: Update stories to correctly pass description to components

### DIFF
--- a/.changeset/rotten-worms-tell.md
+++ b/.changeset/rotten-worms-tell.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix PharosIcon stories to handle description arguments properly

--- a/packages/pharos/src/components/icon/PharosIcon.react.stories.jsx
+++ b/packages/pharos/src/components/icon/PharosIcon.react.stories.jsx
@@ -22,7 +22,13 @@ export default {
 };
 
 export const Base = {
-  render: (args) => <PharosIcon name={args.name} className="icon-example__icon"></PharosIcon>,
+  render: (args) => (
+    <PharosIcon
+      name={args.name}
+      description={args.description}
+      className="icon-example__icon"
+    ></PharosIcon>
+  ),
   args: defaultArgs,
 };
 

--- a/packages/pharos/src/components/icon/pharos-icon.wc.stories.jsx
+++ b/packages/pharos/src/components/icon/pharos-icon.wc.stories.jsx
@@ -17,7 +17,11 @@ export default {
 export const Base = {
   render: (args) =>
     html`
-      <storybook-pharos-icon name=${args.name} class="icon-example__icon"></storybook-pharos-icon>
+      <storybook-pharos-icon
+        name=${args.name}
+        description=${args.description}
+        class="icon-example__icon"
+      ></storybook-pharos-icon>
     `,
   args: defaultArgs,
 };


### PR DESCRIPTION
The PharosIcon stories currently have a description argument but it was not actually being passed to the story components, so it is not rendered into the stories. This fixes that.

**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
While working on #467 a group of pharos maintainers discovered that the current icon Storybook stories were broken, and decided to fix them before continuing.

**How does this change work?**
Correctly passes the description arguments to the story components
