### PR TITLE
Storybook: remove TypeScript watch from commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "storybook:wc": "yarn storybook:wc:start",
     "storybook:wc:start": "storybook dev -c .storybook/wc -p 9000",
     "prestorybook:wc:dev": "yarn storybook:setup",
-    "storybook:wc:dev": "concurrently \"yarn:storybook:wc:start\" \"yarn:watch:tsc\" \"yarn:watch:styles\" --raw --kill-others",
+    "storybook:wc:dev": "concurrently \"yarn:storybook:wc:start\" \"yarn:watch:styles\" --raw --kill-others",
     "storybook:wc:build": "storybook build -c .storybook/wc -o .storybook-static/wc",
 
     "prestorybook:react": "yarn storybook:setup",
     "storybook:react": "yarn storybook:react:start",
     "storybook:react:start": "storybook dev -c .storybook/react -p 9001",
     "prestorybook:react:dev": "yarn storybook:setup",
-    "storybook:react:dev": "concurrently \"yarn:storybook:react:start\" \"yarn:watch:tsc\" \"yarn:watch:styles\" --raw --kill-others",
+    "storybook:react:dev": "concurrently \"yarn:storybook:react:start\" \"yarn:watch:styles\" --raw --kill-others",
     "storybook:react:build": "storybook build -c .storybook/react -o .storybook-static/react",
 
     "storybook:main:dev": "storybook dev -c .storybook/main -p 9002",


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

I added this in #579 hoping it would automatically watch TypeScript files when running Storybook locally, but unfortunately this seems to interfere with certain things like the loading of icons.

**How does this change work?**

You can achieve this yourself by running e.g. `yarn storybook:wc:dev` and `yarn watch:tsc` in separate processes.