### PR TITLE
Dropdown Menu: add fallback color for on background variant

### DIFF
--- a/.changeset/quick-cherries-grab.md
+++ b/.changeset/quick-cherries-grab.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+add fallback color for on background variant

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.scss
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.scss
@@ -107,7 +107,7 @@
 :host([on-background]) .dropdown-menu-item__button:hover {
   @include mixins.button-color(
     $color: var(--pharos-button-color-on-background-secondary-text-base),
-    $background-color: var(--pharos-color-marble-gray-30),
+    $background-color: var(--pharos-color-marble-gray-30, #4d4d4c),
     $border-color: var(--pharos-color-marble-gray-20)
   );
 }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [X] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Adds a fallback color to correct race conditions with different versions of pharos on the page and adhere to [ADR 0008](https://github.com/ithaka/pharos/blob/develop/docs/architecture/decisions/0008-evolve-tokens-in-backward-compatible-manner.md)

**How does this change work?**
Add fallback color if the color variable is not found

**Additional context**
