### PR TITLE
Popover: Border radius styling enforcement

### DIFF
--- a/packages/pharos/src/components/popover/pharos-popover.scss
+++ b/packages/pharos/src/components/popover/pharos-popover.scss
@@ -22,6 +22,7 @@
   transform: translate3d(0, 0, 0);
   transition: visibility 0s var(--pharos-transition-duration-short),
     opacity var(--pharos-transition-duration-short) linear;
+  overflow: hidden;
 }
 
 :host([open]) .popover {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Fixes a problem where contents of the popover would cover the border radius 

**How does this change work?**
Add overflow hidden prevents child elements from expanding outside of the popover

**Additional context**
Screenshot of child element covering the configured radius 
<img width="1728" alt="image" src="https://github.com/ithaka/pharos/assets/13315416/40636b5f-0912-41d9-841c-fd65f73e43c8">

