### PR TITLE
Sheet: Add overflow for long content and remove footer

### DIFF
--- a/.changeset/fresh-parrots-judge.md
+++ b/.changeset/fresh-parrots-judge.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Add overflow to sheet

--- a/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
+++ b/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
@@ -1,7 +1,6 @@
 import { PharosSheet } from '../../react-components/sheet/pharos-sheet';
 import { configureDocsPage } from '@config/docsPageConfig';
 import { PharosContext } from '../../utils/PharosContext';
-import { PharosButton } from '../../react-components';
 
 export default {
   title: 'Components/Sheet',

--- a/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
+++ b/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
@@ -25,18 +25,17 @@ export const Base = {
   args: {},
 };
 
-export const WithFooter = {
+export const WithClose = {
   render: () => (
-    <PharosSheet id="my-sheet" label="Pharos sheet" footer-divider="true">
+    <PharosSheet id="my-sheet" label="Pharos sheet" with-close>
       <div>Lorem ipsum dolor sit amet</div>
-      <PharosButton slot="footer">Do something</PharosButton>
     </PharosSheet>
   ),
 };
 
 export const LongContent = {
   render: () => (
-    <PharosSheet id="my-sheet" label="Pharos sheet" footer-divider="true">
+    <PharosSheet id="my-sheet" label="Pharos sheet">
       <div>Lorem ipsum dolor sit amet</div>
       <div>Lorem ipsum dolor sit amet</div>
       <div>Lorem ipsum dolor sit amet</div>
@@ -54,7 +53,6 @@ export const LongContent = {
       <div>Lorem ipsum dolor sit amet</div>
       <div>Lorem ipsum dolor sit amet</div>
       <div>Lorem ipsum dolor sit amet</div>
-      <PharosButton slot="footer">Do something</PharosButton>
     </PharosSheet>
   ),
 };

--- a/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
+++ b/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
@@ -33,3 +33,28 @@ export const WithFooter = {
     </PharosSheet>
   ),
 };
+
+export const LongContent = {
+  render: () => (
+    <PharosSheet id="my-sheet" label="Pharos sheet" footer-divider="true">
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <div>Lorem ipsum dolor sit amet</div>
+      <PharosButton slot="footer">Do something</PharosButton>
+    </PharosSheet>
+  ),
+};

--- a/packages/pharos/src/components/sheet/pharos-sheet.scss
+++ b/packages/pharos/src/components/sheet/pharos-sheet.scss
@@ -74,19 +74,7 @@
   outline: 0;
   transition: height var(--pharos-transition-base);
   box-shadow: 0 1px 2px 0 rgb(18 18 18 / 0.3), 0 -4px 8px 3px rgb(18 18 18 / 0.15);
-
-  .sheet__wrapper {
-    padding: 0 var(--pharos-spacing-one-and-a-half-x);
-    display: flex;
-    flex-direction: column;
-    height: calc(100% - 67px);
-  }
-
-  @include mixins.until(small) {
-    .sheet__wrapper {
-      padding: 0 20px;
-    }
-  }
+  contain: layout;
 
   .sheet__handle {
     background: var(--pharos-color-marble-gray-80);
@@ -110,40 +98,19 @@
 .sheet__header {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
-  margin-top: var(--pharos-spacing-one-and-a-half-x);
-}
-
-.sheet__footer {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
   justify-content: flex-end;
-  padding: var(--pharos-spacing-1-x) var(--pharos-spacing-one-and-a-half-x);
-
-  @at-root #{&}--empty {
-    padding: 0 0 var(--pharos-spacing-2-x);
-  }
+  margin-top: var(--pharos-spacing-one-and-a-half-x);
+  margin-right: var(--pharos-spacing-one-and-a-half-x);
 }
 
 @include mixins.until(small) {
-  .sheet__footer {
-    padding: var(--pharos-spacing-1-x) 1.25rem;
+  .sheet__header {
+    margin-right: 1.25rem;
   }
-}
-
-slot[name='footer']::slotted(*) {
-  margin-left: var(--pharos-spacing-1-x);
 }
 
 :host([expanded]) {
   .sheet__content {
     height: 100%;
-  }
-}
-
-:host([footer-divider]) {
-  .sheet__footer {
-    border-top: 1px solid var(--pharos-color-marble-gray-base);
   }
 }

--- a/packages/pharos/src/components/sheet/pharos-sheet.scss
+++ b/packages/pharos/src/components/sheet/pharos-sheet.scss
@@ -77,6 +77,9 @@
 
   .sheet__wrapper {
     padding: 0 var(--pharos-spacing-one-and-a-half-x);
+    display: flex;
+    flex-direction: column;
+    height: calc(100% - 67px);
   }
 
   @include mixins.until(small) {
@@ -89,6 +92,7 @@
     background: var(--pharos-color-marble-gray-80);
     width: var(--pharos-spacing-three-and-a-half-x);
     height: 4px;
+    min-height: 4px;
     border-radius: 2px;
     margin: var(--pharos-spacing-one-half-x) auto 0 auto;
     box-sizing: border-box;
@@ -100,6 +104,7 @@
   position: relative;
   flex: 1 1 auto;
   margin-top: 0.375rem;
+  overflow-y: auto;
 }
 
 .sheet__header {

--- a/packages/pharos/src/components/sheet/pharos-sheet.test.ts
+++ b/packages/pharos/src/components/sheet/pharos-sheet.test.ts
@@ -10,7 +10,9 @@ describe('pharos-sheet', () => {
 
   beforeEach(async () => {
     component = await fixture(
-      html` <test-pharos-sheet id="my-sheet" label="Test sheet"> My Sheet </test-pharos-sheet> `
+      html`
+        <test-pharos-sheet id="my-sheet" label="Test sheet" has-close> My Sheet </test-pharos-sheet>
+      `
     );
   });
 

--- a/packages/pharos/src/components/sheet/pharos-sheet.ts
+++ b/packages/pharos/src/components/sheet/pharos-sheet.ts
@@ -61,7 +61,7 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
    * Indicates if the sheet contains close button.
    * @attr hasClose
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, attribute: 'has-close' })
   public hasClose = false;
 
   /**

--- a/packages/pharos/src/components/sheet/pharos-sheet.ts
+++ b/packages/pharos/src/components/sheet/pharos-sheet.ts
@@ -62,7 +62,7 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
    * @attr hasClose
    */
   @property({ type: Boolean, reflect: true })
-  public hasClose = true;
+  public hasClose = false;
 
   /**
    * Text content for the sheet header

--- a/packages/pharos/src/components/sheet/pharos-sheet.ts
+++ b/packages/pharos/src/components/sheet/pharos-sheet.ts
@@ -21,7 +21,6 @@ const FOCUS_ELEMENT = `[data-sheet-focus]`;
  *
  * @slot description - Content that describes the primary message or purpose of the sheet.
  * @slot - Contains the content of the sheet body.
- * @slot footer - Contains the content of the sheet footer.
  *
  * @fires pharos-sheet-open - Fires when the sheet is about to open - cancelable
  * @fires pharos-sheet-opened - Fires when the sheet has opened
@@ -71,20 +70,11 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
   @property({ type: String, reflect: true })
   public header = 'Sheet header';
 
-  /**
-   * Indicates if the sheet footer should contain a divider.
-   * @attr footer-divider
-   */
-  @property({ type: Boolean, reflect: true, attribute: 'footer-divider' })
-  public footerDivider = false;
-
   private _currentTrigger: Element | null = null;
 
   private _triggers!: NodeListOf<HTMLElement>;
 
   @state()
-  private _isFooterEmpty = true;
-
   private _startHeight = 0;
   private _startY = 0;
   private _isDragging = false;
@@ -303,20 +293,17 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
     return descriptionSlot.length ? 'description' : undefined;
   }
 
-  private _handleFooterSlotchange(e: Event) {
-    this._isFooterEmpty =
-      (e.target as HTMLSlotElement).assignedNodes({ flatten: true }).length === 0;
-  }
-
   private _renderCloseButton(): TemplateResult | typeof nothing {
     return this.hasClose
-      ? html` <pharos-button
-          id="close-button"
-          type="button"
-          variant="subtle"
-          icon="close"
-          label="Close sheet"
-        ></pharos-button>`
+      ? html` <div class="sheet__header">
+          <pharos-button
+            id="close-button"
+            type="button"
+            variant="subtle"
+            icon="close"
+            label="Close sheet"
+          ></pharos-button>
+        </div>`
       : nothing;
   }
 
@@ -340,21 +327,10 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
         >
           <focus-trap>
             <div class="sheet__content">
-              <div class="sheet__wrapper">
-                ${this._renderSheetHandle()}
-                <div class="sheet__header">
-                  <pharos-heading id="sheet-header" level="2" preset="2" no-margin>
-                    ${this.header}
-                  </pharos-heading>
-                  ${this._renderCloseButton()}
-                </div>
-                <div class="sheet__body">
-                  ${this.descriptionContent}
-                  <slot></slot>
-                </div>
-              </div>
-              <div class="sheet__footer${this._isFooterEmpty ? '--empty' : ''}">
-                <slot @slotchange=${this._handleFooterSlotchange} name="footer"></slot>
+              ${this._renderSheetHandle()} ${this._renderCloseButton()}
+              <div class="sheet__body">
+                ${this.descriptionContent}
+                <slot></slot>
               </div>
             </div>
           </focus-trap>

--- a/packages/pharos/src/components/sheet/pharos-sheet.ts
+++ b/packages/pharos/src/components/sheet/pharos-sheet.ts
@@ -236,13 +236,15 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
   }
 
   private _handleDragEnd(): void {
-    this._isDragging = false;
-    const sheetContent = this.shadowRoot?.querySelector(`.sheet__content`) as HTMLDivElement;
-    const sheetHeight = sheetContent.clientHeight;
-    if (sheetHeight > this._startHeight) {
-      sheetContent.style.height = '100%';
-    } else {
-      sheetContent.style.height = '50%';
+    if (this._isDragging) {
+      this._isDragging = false;
+      const sheetContent = this.shadowRoot?.querySelector(`.sheet__content`) as HTMLDivElement;
+      const sheetHeight = sheetContent.clientHeight;
+      if (sheetHeight > this._startHeight) {
+        sheetContent.style.height = '100%';
+      } else {
+        sheetContent.style.height = '50%';
+      }
     }
   }
 

--- a/packages/pharos/src/components/sheet/pharos-sheet.wc.stories.jsx
+++ b/packages/pharos/src/components/sheet/pharos-sheet.wc.stories.jsx
@@ -27,16 +27,15 @@ export const Base = {
     `,
 };
 
-export const WithFooter = {
+export const WithClose = {
   render: () =>
     html`
       <div>
         <storybook-pharos-button id="my-button" data-sheet-id="my-sheet" icon-right="chevron-down">
           Click Me
         </storybook-pharos-button>
-        <storybook-pharos-sheet id="my-sheet" label="Pharos sheet" footer-divider="true">
-          <div style="padding-bottom: 2rem">Lorem ipsum dolor sit amet</div>
-          <storybook-pharos-button slot="footer">Do something</storybook-pharos-button>
+        <storybook-pharos-sheet id="my-sheet" label="Pharos sheet" has-close>
+          <div>Lorem ipsum dolor sit amet</div>
         </storybook-pharos-sheet>
       </div>
     `,
@@ -49,7 +48,7 @@ export const LongContent = {
         <storybook-pharos-button id="my-button" data-sheet-id="my-sheet" icon-right="chevron-down">
           Click Me
         </storybook-pharos-button>
-        <storybook-pharos-sheet id="my-sheet" label="Pharos sheet" footer-divider="true">
+        <storybook-pharos-sheet id="my-sheet" label="Pharos sheet">
           <div>Lorem ipsum dolor sit amet</div>
           <div>Lorem ipsum dolor sit amet</div>
           <div>Lorem ipsum dolor sit amet</div>
@@ -67,7 +66,6 @@ export const LongContent = {
           <div>Lorem ipsum dolor sit amet</div>
           <div>Lorem ipsum dolor sit amet</div>
           <div>Lorem ipsum dolor sit amet</div>
-          <storybook-pharos-button slot="footer">Do something</storybook-pharos-button>
         </storybook-pharos-sheet>
       </div>
     `,

--- a/packages/pharos/src/components/sheet/pharos-sheet.wc.stories.jsx
+++ b/packages/pharos/src/components/sheet/pharos-sheet.wc.stories.jsx
@@ -41,3 +41,34 @@ export const WithFooter = {
       </div>
     `,
 };
+
+export const LongContent = {
+  render: () =>
+    html`
+      <div>
+        <storybook-pharos-button id="my-button" data-sheet-id="my-sheet" icon-right="chevron-down">
+          Click Me
+        </storybook-pharos-button>
+        <storybook-pharos-sheet id="my-sheet" label="Pharos sheet" footer-divider="true">
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <div>Lorem ipsum dolor sit amet</div>
+          <storybook-pharos-button slot="footer">Do something</storybook-pharos-button>
+        </storybook-pharos-sheet>
+      </div>
+    `,
+};


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Fix the sheet to allow it scroll with long content.

Before:
<img width="661" alt="image" src="https://github.com/ithaka/pharos/assets/38861633/2af5399c-b66b-4150-abbe-676ed9debcb7">

After:
<img width="661" alt="image" src="https://github.com/ithaka/pharos/assets/38861633/c1af879d-9341-4fa0-9c98-82ebc7bd2f01">


**How does this change work?**
Add overflow and other css constraints.
Also remove the header and footer from sheet to match what we did for popover. 
