### PR TITLE
Remove `paint` value from contain properties

### DIFF
--- a/.changeset/five-moles-add.md
+++ b/.changeset/five-moles-add.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': major
+---
+
+Remove `paint` value of contain property globally

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.scss
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.scss
@@ -14,7 +14,7 @@
 
   background-color: var(--pharos-color-ui-10);
   position: relative;
-  contain: paint;
+  contain: layout;
   margin: 0;
   list-style-type: none;
   padding-left: 0;

--- a/packages/pharos/src/components/footer/pharos-footer.scss
+++ b/packages/pharos/src/components/footer/pharos-footer.scss
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  contain: content;
+  contain: layout style;
 }
 
 #footer-element {

--- a/packages/pharos/src/components/input-group/pharos-input-group.scss
+++ b/packages/pharos/src/components/input-group/pharos-input-group.scss
@@ -1,7 +1,7 @@
 :host {
   display: block;
   width: 100%;
-  contain: paint;
+  contain: layout;
 }
 
 .input-group {

--- a/packages/pharos/src/components/modal/pharos-modal.scss
+++ b/packages/pharos/src/components/modal/pharos-modal.scss
@@ -6,7 +6,7 @@
   z-index: 9000;
   pointer-events: none;
   inset: 0;
-  contain: strict;
+  contain: layout size style;
 }
 
 .modal__overlay {

--- a/packages/pharos/src/components/select/pharos-select.scss
+++ b/packages/pharos/src/components/select/pharos-select.scss
@@ -3,7 +3,7 @@
 :host {
   display: block;
   width: 100%;
-  contain: paint;
+  contain: layout;
 }
 
 #select-element {

--- a/packages/pharos/src/components/sheet/pharos-sheet.scss
+++ b/packages/pharos/src/components/sheet/pharos-sheet.scss
@@ -6,7 +6,7 @@
   z-index: 9000;
   pointer-events: none;
   inset: 0;
-  contain: strict;
+  contain: layout size style;
 }
 
 .sheet__overlay {

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-menu.scss
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-menu.scss
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  contain: content;
+  contain: layout style;
 }
 
 #button-element {

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-section.scss
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-section.scss
@@ -1,6 +1,6 @@
 :host {
   display: block;
-  contain: content;
+  contain: layout style;
 }
 
 .section__container {

--- a/packages/pharos/src/components/tabs/pharos-tab.scss
+++ b/packages/pharos/src/components/tabs/pharos-tab.scss
@@ -9,7 +9,7 @@
   border: none;
   background: none;
   border-bottom: 1px solid var(--pharos-color-ui-40);
-  contain: content;
+  contain: layout style;
   display: grid;
   grid-template-columns: max-content;
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [x] Yes (visual/layout, not API)
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Fixes #585 (differently than suggested, removing only the `paint` value but not the `contain` property altogether).

**How does this change work?**

* Change `contain: paint` to `contain: layout` (this needs some scrutiny as this isn't always a safe operation, but where applied here is meant to be so)
* Change `contain: content` to `contain: layout style`
* Change `contain: strict` to `contain: layout size style`