### PR TITLE
Sheet: allow expansion with attribute

### DIFF
--- a/.changeset/sixty-fishes-cheat.md
+++ b/.changeset/sixty-fishes-cheat.md
@@ -1,5 +1,5 @@
 ---
-'@ithaka/pharos': patch
+'@ithaka/pharos': minor
 ---
 
 allow expansion with attribute in sheet

--- a/.changeset/sixty-fishes-cheat.md
+++ b/.changeset/sixty-fishes-cheat.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+allow expansion with attribute in sheet

--- a/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
+++ b/packages/pharos/src/components/sheet/PharosSheet.react.stories.jsx
@@ -32,6 +32,14 @@ export const WithClose = {
   ),
 };
 
+export const Expanded = {
+  render: () => (
+    <PharosSheet id="my-sheet" label="Pharos sheet" expanded>
+      <div>Lorem ipsum dolor sit amet</div>
+    </PharosSheet>
+  ),
+};
+
 export const LongContent = {
   render: () => (
     <PharosSheet id="my-sheet" label="Pharos sheet">

--- a/packages/pharos/src/components/sheet/pharos-sheet.scss
+++ b/packages/pharos/src/components/sheet/pharos-sheet.scss
@@ -127,9 +127,3 @@
     margin-right: 1.25rem;
   }
 }
-
-:host([expanded]) {
-  .sheet__content {
-    height: 95%;
-  }
-}

--- a/packages/pharos/src/components/sheet/pharos-sheet.ts
+++ b/packages/pharos/src/components/sheet/pharos-sheet.ts
@@ -49,7 +49,7 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
    * Indicates if the sheet is expanded.
    * @attr expanded
    */
-  @property({ type: Boolean, reflect: true })
+  @property({ type: Boolean, reflect: true, attribute: 'expanded' })
   public expanded = false;
 
   /**
@@ -111,7 +111,9 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
     if (changedProperties.has('open')) {
       if (this.open) {
         const sheetContent = this.shadowRoot?.querySelector(`.sheet__content`) as HTMLDivElement;
-        sheetContent.style.height = this.MIN_EXPAND_PERCENTAGE;
+        sheetContent.style.height = this.expanded
+          ? this.MAX_EXPAND_PERCENTAGE
+          : this.MIN_EXPAND_PERCENTAGE;
         this._focusContents();
       } else {
         this._returnTriggerFocus();
@@ -119,6 +121,12 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
 
       if (changedProperties.get('open') !== undefined) {
         this._emitVisibilityChange();
+      }
+    }
+    if (changedProperties.has('expanded')) {
+      if (this.expanded) {
+        const sheetContent = this.shadowRoot?.querySelector(`.sheet__content`) as HTMLDivElement;
+        sheetContent.style.height = this.MAX_EXPAND_PERCENTAGE;
       }
     }
   }
@@ -182,7 +190,9 @@ export class PharosSheet extends ScopedRegistryMixin(PharosElement) {
       ) {
         this.open = true;
         const sheetContent = this.shadowRoot?.querySelector(`.sheet__content`) as HTMLDivElement;
-        sheetContent.style.height = this.MIN_EXPAND_PERCENTAGE;
+        sheetContent.style.height = this.expanded
+          ? this.MAX_EXPAND_PERCENTAGE
+          : this.MIN_EXPAND_PERCENTAGE;
       }
     }
   }

--- a/packages/pharos/src/components/sheet/pharos-sheet.wc.stories.jsx
+++ b/packages/pharos/src/components/sheet/pharos-sheet.wc.stories.jsx
@@ -41,6 +41,20 @@ export const WithClose = {
     `,
 };
 
+export const Expanded = {
+  render: () =>
+    html`
+      <div>
+        <storybook-pharos-button id="my-button" data-sheet-id="my-sheet" icon-right="chevron-down">
+          Click Me
+        </storybook-pharos-button>
+        <storybook-pharos-sheet id="my-sheet" label="Pharos sheet" expanded>
+          <div>Lorem ipsum dolor sit amet</div>
+        </storybook-pharos-sheet>
+      </div>
+    `,
+};
+
 export const LongContent = {
   render: () =>
     html`


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
We want to allow adding "expended" attribute to expand the sheet from consumer. This feature was broken because the css got overwritten by the height we set with typescript.

**How does this change work?**
Get rid of unused css and use pure typescript to control the height.

