### PR TITLE
Coach Mark: Fix react component positioning

### DIFF
--- a/.changeset/silver-pugs-share.md
+++ b/.changeset/silver-pugs-share.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix positioning of coach mark react component

--- a/packages/pharos/src/components/coach-mark/pharos-coach-mark.ts
+++ b/packages/pharos/src/components/coach-mark/pharos-coach-mark.ts
@@ -88,7 +88,8 @@ export class PharosCoachMark extends ScopedRegistryMixin(PharosElement) {
 
   override connectedCallback() {
     super.connectedCallback();
-    this.setOffset();
+
+    autoUpdate(document.documentElement, this, () => this.requestUpdate());
   }
 
   private setOffset() {
@@ -96,22 +97,21 @@ export class PharosCoachMark extends ScopedRegistryMixin(PharosElement) {
     const targetElement: Element | null = document.querySelector(`[data-coach-mark="${id}"]`);
     if (!targetElement) return;
 
-    this._cleanup = autoUpdate(targetElement, this, () =>
-      computePosition(targetElement, this, {
-        placement: this.alignment === 'center' ? this.side : `${this.side}-${this.alignment}`,
-        middleware: [flip(), offset(20)],
-      }).then(({ x, y, placement }) => {
-        Object.assign(this.style, {
-          left: `${x}px`,
-          top: `${y}px`,
-        });
-        this._computedSide = placement.toString().split('-')[0]; // Removes -start or -end from final placement
-        this.requestUpdate();
-      })
-    );
+    computePosition(targetElement, this, {
+      placement: this.alignment === 'center' ? this.side : `${this.side}-${this.alignment}`,
+      middleware: [flip(), offset(20)],
+    }).then(({ x, y, placement }) => {
+      Object.assign(this.style, {
+        left: `${x}px`,
+        top: `${y}px`,
+      });
+      this._computedSide = placement.toString().split('-')[0]; // Removes -start or -end from final placement
+    });
   }
 
   protected override render(): TemplateResult {
+    this.setOffset();
+
     return html`
       <div
         class="coach-mark ${this.delay && this.delay !== 'none' ? `delay-${this.delay}` : ''}"


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Coach mark react component is not correctly positioned in storybook and pharos docs

**How does this change work?**
computePosition method must be called after the coach mark element is added to the document in order to reference the id attribute. computePosition is called prior to rendering for the react component, resulting in a null id value (at time of calling) and a null `targetElement` reference. This may be related to how the web component is wrapped by the react component.

To fix this, autoUpdate() was extracted from setOffset(). autoUpdate() was adjusted to trigger a rerender and setOffset() was moved into render()

Before|After
-|-
![Screenshot 2023-10-18 at 4 49 33 PM](https://github.com/ithaka/pharos/assets/52258386/f6b28c51-319f-416a-aa91-796d1898ec45)|![Screenshot 2023-10-18 at 4 49 39 PM](https://github.com/ithaka/pharos/assets/52258386/a61c28a6-0378-40e4-9d96-498855d937f6)

