### PR TITLE
Update sidenav-links marked as external to open in a new tab

### DIFF
--- a/.changeset/large-tomatoes-pull.md
+++ b/.changeset/large-tomatoes-pull.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Update external sidenav links to open in a new tab

--- a/packages/pharos/src/components/sidenav/PharosSidenav.react.stories.jsx
+++ b/packages/pharos/src/components/sidenav/PharosSidenav.react.stories.jsx
@@ -66,10 +66,10 @@ export const Base = {
             <PharosSidenavLink href="#">Menu item 2</PharosSidenavLink>
           </PharosSidenavMenu>
           <PharosSidenavLink href="#">Menu item</PharosSidenavLink>
-          <PharosSidenavLink href="#" target="_blank" external>
+          <PharosSidenavLink href="#" external>
             External link
           </PharosSidenavLink>
-          <PharosSidenavLink href="#" target="_blank" external>
+          <PharosSidenavLink href="#" external>
             External link
           </PharosSidenavLink>
         </PharosSidenavSection>

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-link.test.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-link.test.ts
@@ -25,4 +25,17 @@ describe('pharos-sidenav-link', () => {
     );
     expect(icon).not.to.be.null;
   });
+  it('opens links in a new tab when the link is external', async () => {
+    component.external = true;
+    await component.updateComplete;
+    const link = component.renderRoot.querySelector('a[target="_blank"][rel="noopener"]');
+    expect(link).not.to.be.null;
+  });
+  it('prioritizes a manually set target when link is set to external', async () => {
+    component.external = true;
+    component.target = '_top';
+    await component.updateComplete;
+    const link = component.renderRoot.querySelector('a[target="_top"]');
+    expect(link).not.to.be.null;
+  });
 });

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
@@ -56,6 +56,10 @@ export class PharosSidenavLink extends ScopedRegistryMixin(PharosLink) {
   }
 
   protected override render(): TemplateResult {
+    if (!this.target && this.external) {
+      this.target = '_blank';
+      this.rel = 'noopener';
+    }
     return html`${super.render()}`;
   }
 }

--- a/packages/pharos/src/components/sidenav/pharos-sidenav.wc.stories.jsx
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav.wc.stories.jsx
@@ -48,10 +48,10 @@ export const Base = {
             <storybook-pharos-sidenav-link href="#">Menu item 2</storybook-pharos-sidenav-link>
           </storybook-pharos-sidenav-menu>
           <storybook-pharos-sidenav-link href="#">Menu item</storybook-pharos-sidenav-link>
-          <storybook-pharos-sidenav-link href="#" target="_blank" external
+          <storybook-pharos-sidenav-link href="#" external target="_top"
             >External link</storybook-pharos-sidenav-link
           >
-          <storybook-pharos-sidenav-link href="#" target="_blank" external
+          <storybook-pharos-sidenav-link href="#" external
             >External link</storybook-pharos-sidenav-link
           >
         </storybook-pharos-sidenav-section>


### PR DESCRIPTION
External sidenav links now will open in a new tab matching [the documentation](https://pharos.jstor.org/components/sidenav), as well as having rel="noopener" added to the link.

**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Closes #538 

**How does this change work?**
If a `PharosSidenavLink` is created with the external option, the link will be rendered with target="_blank" and rel="noopener". If for some reason someone manually specified a target with external it will still respect the target that was set.

**Additional context**
- I opted against adding rel="nofollow" as mentioned in the issue because I think there are cases when that wouldn't be the desired value.
- I also updated storybook to show that target="_blank" no longer needs to be manually added.
