### PR TITLE
fix(chromatic): reintroduce build-storybook script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch:styles": "yarn workspace @ithaka/pharos build:styles:watch",
     "build:core": "yarn workspace @ithaka/pharos build",
 
-    "storybook:build": "yarn storybook:setup && yarn storybook:react:build && yarn storybook:wc:build && yarn storybook:main:build",
+    "storybook:build": "yarn storybook:setup && concurrently \"yarn storybook:wc:build\" \"yarn storybook:react:build\" \"yarn storybook:main:build\" --prefix=\"{command}\" --prefix-length=30",
     "storybook:setup": "yarn build:core",
 
     "prestorybook:wc": "yarn storybook:setup",
@@ -39,6 +39,8 @@
 
     "storybook:main:dev": "storybook dev -c .storybook/main -p 9002",
     "storybook:main:build": "storybook build -c .storybook/main -o .storybook-static/main",
+
+    "build-storybook": "yarn storybook:build",
 
     "presite:build": "yarn build:core",
     "site:build": "yarn workspace @ithaka/pharos-site build",


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

The `build-storybook` script was removed in #597 because it seemed unused, but it turns out to have been used by Chromatic for generating build diffs.

**How does this change work?**

Add it back in, referencing the newer, consistently-named `storybook:build` script.

**Additional context**

I also sped it up by running all the builds concurrently.