### PR TITLE
Update all internal icon usages to use new a11y-hidden and a11y-title syntax

### DIFF
--- a/.changeset/stupid-olives-compare.md
+++ b/.changeset/stupid-olives-compare.md
@@ -1,0 +1,6 @@
+---
+'@ithaka/pharos': patch
+'@ithaka/pharos-site': patch
+---
+
+Update all icons to use a11y-hidden and a11y-title syntax over description

--- a/packages/pharos-site/src/components/SearchBox.tsx
+++ b/packages/pharos-site/src/components/SearchBox.tsx
@@ -14,7 +14,7 @@ const SearchBox: FC = () => {
       <div className={searchBox__container}>
         <input className={searchBox__input} placeholder="Search" />
         <div className={searchBox__icon}>
-          <PharosIcon name="search" />
+          <PharosIcon name="search" a11yHidden="true" />
         </div>
       </div>
     );

--- a/packages/pharos-site/src/components/statics/BestPractices.tsx
+++ b/packages/pharos-site/src/components/statics/BestPractices.tsx
@@ -34,7 +34,7 @@ const BestPractices: FC<BestPracticesProps> = ({ Do, Dont }) => {
               <div className={container__practices}>
                 <PharosIcon
                   name="checkmark"
-                  description="Check mark"
+                  a11yTitle="Check mark"
                   className={icon__do}
                 ></PharosIcon>
                 <div>
@@ -50,7 +50,7 @@ const BestPractices: FC<BestPracticesProps> = ({ Do, Dont }) => {
             <>
               <hr className={line__dont} />
               <div className={container__practices}>
-                <PharosIcon name="close" description="X" className={icon__dont}></PharosIcon>
+                <PharosIcon name="close" a11yTitle="X" className={icon__dont}></PharosIcon>
                 <div>
                   <div className={text__dont}>Don&apos;ts</div>
                   <div className={text__guideline}> {Dont} </div>

--- a/packages/pharos-site/src/components/statics/DosAndDonts.tsx
+++ b/packages/pharos-site/src/components/statics/DosAndDonts.tsx
@@ -31,7 +31,7 @@ const DosAndDonts: FC<DosAndDontsProps> = ({ children, Dont }) => {
               <>
                 <PharosIcon
                   name="close"
-                  description="X"
+                  a11yTitle="X"
                   style={{ fill: 'var(--pharos-color-feedback-error)' }}
                 ></PharosIcon>
                 <PharosHeading level="4" preset="4--bold" noMargin>
@@ -42,7 +42,7 @@ const DosAndDonts: FC<DosAndDontsProps> = ({ children, Dont }) => {
               <>
                 <PharosIcon
                   name="checkmark"
-                  description="Checkmark"
+                  a11yTitle="Checkmark"
                   style={{ fill: 'var(--pharos-color-feedback-success)' }}
                 ></PharosIcon>
                 <PharosHeading level="4" preset="4--bold" noMargin>

--- a/packages/pharos-site/src/components/statics/iconography/IconsDisplay.tsx
+++ b/packages/pharos-site/src/components/statics/iconography/IconsDisplay.tsx
@@ -33,7 +33,7 @@ const Icons: FC<IconDisplayProps> = ({ title, iconsToShow, rows }) => {
         return (
           <div className={iconContainer} key={i}>
             <div className={icon}>
-              <PharosIcon name={name} />
+              <PharosIcon name={name} a11yTitle={name} />
             </div>
             <div className={display__text}>{displayName}</div>
           </div>

--- a/packages/pharos-site/src/pages/brand-expressions/color.mdx
+++ b/packages/pharos-site/src/pages/brand-expressions/color.mdx
@@ -374,11 +374,12 @@ import PageSection from '../../components/statics/PageSection';
     <PharosIcon
       name="link-external"
       style={{ marginRight: 'var(--pharos-spacing-1-x)' }}
+      a11yHidden="true"
     ></PharosIcon>
     <PharosLink href="https://webaim.org/resources/contrastchecker/" target="_blank">
       WebAIM Color Contrast Checker
     </PharosLink>
-    <PharosIcon name="link-external"></PharosIcon>
+    <PharosIcon name="link-external" a11yHidden="true"></PharosIcon>
   </div>
 </PageSection>
 

--- a/packages/pharos-site/src/pages/design-tokens/type-scale.mdx
+++ b/packages/pharos-site/src/pages/design-tokens/type-scale.mdx
@@ -34,7 +34,7 @@ import PageSection from '../../components/statics/PageSection';
                 GT America
               </span>
             ) : (
-              <PharosIcon name="dash-small"></PharosIcon>
+              <PharosIcon name="dash-small" a11yHidden="true"></PharosIcon>
             )}
           </td>
           <td>
@@ -50,7 +50,7 @@ import PageSection from '../../components/statics/PageSection';
                 Ivar Headline
               </span>
             ) : (
-              <PharosIcon name="dash-small"></PharosIcon>
+              <PharosIcon name="dash-small" a11yHidden="true"></PharosIcon>
             )}
           </td>
         </tr>

--- a/packages/pharos-site/src/pages/index.tsx
+++ b/packages/pharos-site/src/pages/index.tsx
@@ -56,7 +56,7 @@ const IndexPage: FC = () => {
             onClick={handleLinkClick}
           >
             Check out the component status page
-            <PharosIcon name="arrow-right" className={icon__arrow}></PharosIcon>
+            <PharosIcon name="arrow-right" className={icon__arrow} a11yHidden="true"></PharosIcon>
           </PharosLink>
         </PharosLayout>
 
@@ -128,7 +128,7 @@ const IndexPage: FC = () => {
 
         <div className={card}>
           <div className={icon}>
-            <PharosIcon name="new"></PharosIcon>
+            <PharosIcon name="new" a11yHidden="true"></PharosIcon>
           </div>
           <PharosHeading level="2" preset="4">
             What&apos;s new: Pharos {pkg.version}
@@ -169,7 +169,7 @@ const IndexPage: FC = () => {
         </div>
         <div className={card}>
           <div className={icon}>
-            <PharosIcon name="question-inverse"></PharosIcon>
+            <PharosIcon name="question-inverse" a11yHidden="true"></PharosIcon>
           </div>
           <PharosHeading level="2" preset="4">
             Support
@@ -197,7 +197,7 @@ const IndexPage: FC = () => {
 
         <div className={card}>
           <div className={icon}>
-            <PharosIcon name="add"></PharosIcon>
+            <PharosIcon name="add" a11yHidden="true"></PharosIcon>
           </div>
           <PharosHeading level="2" preset="4">
             Contribute to Pharos
@@ -230,7 +230,7 @@ const IndexPage: FC = () => {
         </div>
         <div className={card}>
           <div className={icon}>
-            <PharosIcon name="workspace"></PharosIcon>
+            <PharosIcon name="workspace" a11yHidden="true"></PharosIcon>
           </div>
           <div className={container__heading}>
             <PharosHeading level="2" preset="4" noMargin>

--- a/packages/pharos-site/static/guidelines/button.docs.mdx
+++ b/packages/pharos-site/static/guidelines/button.docs.mdx
@@ -120,7 +120,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
-          a11yHidden="true"
+          a11yTitle="good example"
         ></PharosIcon>Save
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -131,7 +131,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
-          a11yHidden="true"
+          a11yTitle="bad example"
         ></PharosIcon>Workspace
       </li>
     </ul>
@@ -144,7 +144,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
-          a11yHidden="true"
+          a11yTitle="good example"
         ></PharosIcon>Find my institution
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -155,7 +155,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
-          a11yHidden="true"
+          a11yTitle="bad example"
         ></PharosIcon>Institution finder
       </li>
     </ul>
@@ -175,7 +175,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
-          a11yHidden="true"
+          a11yTitle="good example"
         ></PharosIcon>Cite
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -186,7 +186,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
-          a11yHidden="true"
+          a11yTitle="bad example"
         ></PharosIcon>Click here to copy the citation
       </li>
     </ul>
@@ -199,7 +199,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
-          a11yHidden="true"
+          a11yTitle="good example"
         ></PharosIcon>Download
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -210,7 +210,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
-          a11yHidden="true"
+          a11yTitle="bad example"
         ></PharosIcon>Download the PDF
       </li>
     </ul>

--- a/packages/pharos-site/static/guidelines/button.docs.mdx
+++ b/packages/pharos-site/static/guidelines/button.docs.mdx
@@ -120,6 +120,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Save
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -130,6 +131,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Workspace
       </li>
     </ul>
@@ -142,6 +144,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Find my institution
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -152,6 +155,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Institution finder
       </li>
     </ul>
@@ -171,6 +175,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Cite
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -181,6 +186,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Click here to copy the citation
       </li>
     </ul>
@@ -193,6 +199,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x)',
             fill: 'var(--pharos-color-green-base)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Download
       </li>
       <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -203,6 +210,7 @@ import ellipsesExample from '@images/components/button/buttons_ellipses-example.
             marginRight: 'var(--pharos-spacing-one-half-x',
             fill: 'var(--pharos-color-living-coral-53)',
           }}
+          a11yHidden="true"
         ></PharosIcon>Download the PDF
       </li>
     </ul>

--- a/packages/pharos-site/static/guidelines/footer.docs.mdx
+++ b/packages/pharos-site/static/guidelines/footer.docs.mdx
@@ -242,7 +242,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
         target="_blank"
         label="twitter - This link opens in a new window"
       >
-        <PharosIcon name="twitter"></PharosIcon>
+        <PharosIcon name="twitter" a11yHidden="true"></PharosIcon>
       </PharosLink>
     </li>
     <li>
@@ -252,7 +252,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
         target="_blank"
         label="facebook - This link opens in a new window"
       >
-        <PharosIcon name="facebook"></PharosIcon>
+        <PharosIcon name="facebook" a11yHidden="true"></PharosIcon>
       </PharosLink>
     </li>
     <li>
@@ -262,7 +262,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
         target="_blank"
         label="instagram - This link opens in a new window"
       >
-        <PharosIcon name="instagram"></PharosIcon>
+        <PharosIcon name="instagram" a11yHidden="true"></PharosIcon>
       </PharosLink>
     </li>
     <li>
@@ -272,7 +272,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
         target="_blank"
         label="youtube - This link opens in a new window"
       >
-        <PharosIcon name="youtube"></PharosIcon>
+        <PharosIcon name="youtube" a11yHidden="true"></PharosIcon>
       </PharosLink>
     </li>
     <li>
@@ -282,7 +282,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
         target="_blank"
         label="linkedin - This link opens in a new window"
       >
-        <PharosIcon name="linkedin"></PharosIcon>
+        <PharosIcon name="linkedin" a11yHidden="true"></PharosIcon>
       </PharosLink>
     </li>
     <li>
@@ -292,7 +292,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
         target="_blank"
         label="tumblr - This link opens in a new window"
       >
-        <PharosIcon name="tumblr"></PharosIcon>
+        <PharosIcon name="tumblr" a11yHidden="true"></PharosIcon>
       </PharosLink>
     </li>
   </ul>

--- a/packages/pharos-site/static/guidelines/icon.docs.mdx
+++ b/packages/pharos-site/static/guidelines/icon.docs.mdx
@@ -12,9 +12,9 @@ import BestPractices from '@components/statics/BestPractices.tsx';
 
 ```jsx live
 <>
-  <PharosIcon name="workspace" />
-  <PharosIcon name="download" />
-  <PharosIcon name="email" />
+  <PharosIcon name="workspace" a11yTitle="workspace" />
+  <PharosIcon name="download" a11yTitle="download" />
+  <PharosIcon name="email" a11yTitle="email" />
 </>
 ```
 

--- a/packages/pharos-site/static/guidelines/toast.docs.mdx
+++ b/packages/pharos-site/static/guidelines/toast.docs.mdx
@@ -93,7 +93,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
               marginRight: 'var(--pharos-spacing-one-half-x)',
               fill: 'var(--pharos-color-green-base)',
             }}
-          a11yTitle="good example"
+            a11yTitle="good example"
           ></PharosIcon>"The item was saved to Martin Luther King Research."
         </li>
         <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -104,7 +104,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
               marginRight: 'var(--pharos-spacing-one-half-x',
               fill: 'var(--pharos-color-living-coral-53)',
             }}
-          a11yTitle="bad example"
+            a11yTitle="bad example"
           ></PharosIcon>"Item saved to Martin Luther King Research."
         </li>
       </ul>

--- a/packages/pharos-site/static/guidelines/toast.docs.mdx
+++ b/packages/pharos-site/static/guidelines/toast.docs.mdx
@@ -93,6 +93,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
               marginRight: 'var(--pharos-spacing-one-half-x)',
               fill: 'var(--pharos-color-green-base)',
             }}
+            a11yHidden="true"
           ></PharosIcon>"The item was saved to Martin Luther King Research."
         </li>
         <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -103,6 +104,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
               marginRight: 'var(--pharos-spacing-one-half-x',
               fill: 'var(--pharos-color-living-coral-53)',
             }}
+            a11yHidden="true"
           ></PharosIcon>"Item saved to Martin Luther King Research."
         </li>
       </ul>

--- a/packages/pharos-site/static/guidelines/toast.docs.mdx
+++ b/packages/pharos-site/static/guidelines/toast.docs.mdx
@@ -93,7 +93,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
               marginRight: 'var(--pharos-spacing-one-half-x)',
               fill: 'var(--pharos-color-green-base)',
             }}
-            a11yHidden="true"
+          a11yTitle="good example"
           ></PharosIcon>"The item was saved to Martin Luther King Research."
         </li>
         <li style={{ display: 'flex', color: 'var(--pharos-color-living-coral-53)' }}>
@@ -104,7 +104,7 @@ import BestPractices from '@components/statics/BestPractices.tsx';
               marginRight: 'var(--pharos-spacing-one-half-x',
               fill: 'var(--pharos-color-living-coral-53)',
             }}
-            a11yHidden="true"
+          a11yTitle="bad example"
           ></PharosIcon>"Item saved to Martin Luther King Research."
         </li>
       </ul>

--- a/packages/pharos-site/static/guidelines/tooltip.docs.mdx
+++ b/packages/pharos-site/static/guidelines/tooltip.docs.mdx
@@ -34,73 +34,109 @@ import BestPractices from '@components/statics/BestPractices.tsx';
     <Canvas>
       <div className="tooltip-example__container">
         <button data-tooltip-id="my-top-start-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see top-start tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-top-start-tooltip" open placement="top-start">
           top-start
         </PharosTooltip>
         <button data-tooltip-id="my-top-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see top tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-top-tooltip" open placement="top">
           top
         </PharosTooltip>
         <button data-tooltip-id="my-top-end-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see top-end tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-top-end-tooltip" open placement="top-end">
           top-end
         </PharosTooltip>
         <button data-tooltip-id="my-left-start-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see left-start tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-left-start-tooltip" open placement="left-start">
           left-start
         </PharosTooltip>
         <button data-tooltip-id="my-left-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see left tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-left-tooltip" open placement="left">
           left
         </PharosTooltip>
         <button data-tooltip-id="my-left-end-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see left-end tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-left-end-tooltip" open placement="left-end">
           left-end
         </PharosTooltip>
         <button data-tooltip-id="my-right-start-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see right-start tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-right-start-tooltip" open placement="right-start">
           right-start
         </PharosTooltip>
         <button data-tooltip-id="my-right-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see right tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-right-tooltip" open placement="right">
           right
         </PharosTooltip>
         <button data-tooltip-id="my-right-end-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see right-end tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-right-end-tooltip" open placement="right-end">
           right-end
         </PharosTooltip>
         <button data-tooltip-id="my-bottom-start-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see bottom-start tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-bottom-start-tooltip" open placement="bottom-start">
           bottom-start
         </PharosTooltip>
         <button data-tooltip-id="my-bottom-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see bottom tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-bottom-tooltip" open placement="bottom">
           bottom
         </PharosTooltip>
         <button data-tooltip-id="my-bottom-end-tooltip" className="tooltip-example__target">
-          <PharosIcon name="info-inverse"></PharosIcon>
+          <PharosIcon
+            name="info-inverse"
+            a11yTitle="Hover over to see bottom-end tooltip example"
+          ></PharosIcon>
         </button>
         <PharosTooltip id="my-bottom-end-tooltip" open placement="bottom-end">
           bottom-end

--- a/packages/pharos/src/components/alert/pharos-alert.test.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.test.ts
@@ -38,6 +38,7 @@ describe('pharos-alert', () => {
         <pharos-icon
           class="alert__icon"
           data-pharos-component="PharosIcon"
+          a11y-hidden="true"
           description=""
           name="info-inverse"
         >

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -132,7 +132,7 @@ export class PharosAlert extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
         })}"
         tabindex="0"
       >
-        <pharos-icon class="alert__icon" name="${this._getIcon()}"></pharos-icon>
+        <pharos-icon class="alert__icon" name="${this._getIcon()}" a11y-hidden="true"></pharos-icon>
         <div class="alert__body">
           <slot @slotchange=${this._handleSlotChange}></slot>
         </div>

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -271,7 +271,7 @@ export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement))
       icon = this.icon;
     }
 
-    return icon ? html` <pharos-icon name="${icon}"></pharos-icon> ` : nothing;
+    return icon ? html` <pharos-icon name="${icon}" ally-hidden="true"></pharos-icon> ` : nothing;
   }
 
   protected get buttonContent(): TemplateResult {

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -271,7 +271,7 @@ export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement))
       icon = this.icon;
     }
 
-    return icon ? html` <pharos-icon name="${icon}" ally-hidden="true"></pharos-icon> ` : nothing;
+    return icon ? html` <pharos-icon name="${icon}" a11y-hidden="true"></pharos-icon> ` : nothing;
   }
 
   protected get buttonContent(): TemplateResult {

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -227,6 +227,7 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
                           <pharos-icon
                             class="combobox__option__icon"
                             name="checkmark"
+                            a11y-hidden="true"
                           ></pharos-icon>
                         `
                       : nothing}
@@ -295,7 +296,7 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
           <pharos-icon
             class="combobox__icon"
             name="chevron-down"
-            description="Dropdown"
+            a11y-title="Dropdown"
           ></pharos-icon>
         </button>
       `;

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-link.ts
@@ -41,7 +41,11 @@ export class PharosDropdownMenuNavLink extends ScopedRegistryMixin(PharosLink) {
 
   protected override get appendContent(): TemplateResult | typeof nothing {
     if (this.hasAttribute('data-dropdown-menu-id')) {
-      return html`<pharos-icon name="chevron-down" class="link__icon"></pharos-icon>`;
+      return html`<pharos-icon
+        name="chevron-down"
+        class="link__icon"
+        a11y-hidden="true"
+      ></pharos-icon>`;
     }
     return nothing;
   }

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
@@ -126,7 +126,11 @@ export class PharosDropdownMenuItem extends ScopedRegistryMixin(FocusMixin(Pharo
   private _renderIcon(): TemplateResult | typeof nothing {
     if (this.icon) {
       return html`
-        <pharos-icon class="dropdown-menu-item__icon" name="${this.icon}"></pharos-icon>
+        <pharos-icon
+          class="dropdown-menu-item__icon"
+          name="${this.icon}"
+          a11y-hidden="{true}"
+        ></pharos-icon>
       `;
     }
     return nothing;
@@ -140,6 +144,7 @@ export class PharosDropdownMenuItem extends ScopedRegistryMixin(FocusMixin(Pharo
             [`dropdown-menu-item__icon--selected`]: true,
           })}"
           name="checkmark"
+          a11y-hidden="true"
         ></pharos-icon>
       `;
     }

--- a/packages/pharos/src/components/footer/pharos-footer.test.ts
+++ b/packages/pharos/src/components/footer/pharos-footer.test.ts
@@ -180,7 +180,7 @@ describe('pharos-footer', () => {
               target="_blank"
               label="twitter - This link opens in a new window"
             >
-              <test-pharos-icon name="twitter"></test-pharos-icon>
+              <test-pharos-icon name="twitter" a11y-hidden="true"></test-pharos-icon>
             </test-pharos-link>
           </li>
           <li>
@@ -189,7 +189,7 @@ describe('pharos-footer', () => {
               target="_blank"
               label="facebook - This link opens in a new window"
             >
-              <test-pharos-icon name="facebook"></test-pharos-icon>
+              <test-pharos-icon name="facebook" a11y-hidden="true"></test-pharos-icon>
             </test-pharos-link>
           </li>
           <li>
@@ -198,7 +198,7 @@ describe('pharos-footer', () => {
               target="_blank"
               label="instagram - This link opens in a new window"
             >
-              <test-pharos-icon name="instagram"></test-pharos-icon>
+              <test-pharos-icon name="instagram" a11y-hidden="true"></test-pharos-icon>
             </test-pharos-link>
           </li>
           <li>
@@ -207,7 +207,7 @@ describe('pharos-footer', () => {
               target="_blank"
               label="youtube - This link opens in a new window"
             >
-              <test-pharos-icon name="youtube"></test-pharos-icon>
+              <test-pharos-icon name="youtube" a11y-hidden="true"></test-pharos-icon>
             </test-pharos-link>
           </li>
           <li>
@@ -216,7 +216,7 @@ describe('pharos-footer', () => {
               target="_blank"
               label="linkedin - This link opens in a new window"
             >
-              <test-pharos-icon name="linkedin"></test-pharos-icon>
+              <test-pharos-icon name="linkedin" a11y-hidden="true"></test-pharos-icon>
             </test-pharos-link>
           </li>
           <li>
@@ -225,7 +225,7 @@ describe('pharos-footer', () => {
               target="_blank"
               label="tumblr - This link opens in a new window"
             >
-              <test-pharos-icon name="tumblr"></test-pharos-icon>
+              <test-pharos-icon name="tumblr" a11y-hidden="true"></test-pharos-icon>
             </test-pharos-link>
           </li>
         </ul>

--- a/packages/pharos/src/components/header/PharosHeader.react.stories.jsx
+++ b/packages/pharos/src/components/header/PharosHeader.react.stories.jsx
@@ -54,6 +54,7 @@ export const Base = {
             style={{
               marginLeft: '1rem',
             }}
+            a11yHidden="true"
           ></PharosIcon>
         </div>
         <span slot="top" className="show-for-small" style={{ display: 'none', fontWeight: 'bold' }}>

--- a/packages/pharos/src/components/header/pharos-header.wc.stories.jsx
+++ b/packages/pharos/src/components/header/pharos-header.wc.stories.jsx
@@ -67,7 +67,7 @@ export const Base = {
           >
             <span>Access provided by&nbsp;</span>
             <span style="font-weight: bold">JSTOR</span>
-            <storybook-pharos-icon name="chevron-down" style="margin-left: 1rem"></storybook-pharos-icon>
+            <storybook-pharos-icon name="chevron-down" style="margin-left: 1rem"  a11y-hidden="true"></storybook-pharos-icon>
           </div>
           <storybook-pharos-dropdown-menu id="pds-menu" placement="bottom">
             <div style="padding: 1rem">

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -231,7 +231,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
               [`card__link--collection--error`]: true,
             })}
           >
-            <pharos-icon name="exclamation-inverse"></pharos-icon>
+            <pharos-icon name="exclamation-inverse" a11y-hidden="true"></pharos-icon>
             <span class="unavailable-text">Image preview not available</span>
           </div>
         `
@@ -275,7 +275,7 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
             [`card__container--selectable-hover`]: this._isSelectableCardHover(),
           })}
         >
-          <pharos-icon name="exclamation-inverse"></pharos-icon>
+          <pharos-icon name="exclamation-inverse" a11y-hidden="true"></pharos-icon>
           <span class="unavailable-text">Image preview not available</span>
         </div>`
       : html`<slot name="image"></slot>`;

--- a/packages/pharos/src/components/input-group/PharosInputGroup.react.stories.jsx
+++ b/packages/pharos/src/components/input-group/PharosInputGroup.react.stories.jsx
@@ -109,7 +109,7 @@ export const Composition = {
     >
       <PharosInputGroup name="my-input-group-icon">
         <span slot="label">With icons</span>
-        <PharosIcon id="calendar" name="calendar"></PharosIcon>
+        <PharosIcon id="calendar" name="calendar" a11yHidden="true"></PharosIcon>
       </PharosInputGroup>
       <PharosInputGroup name="my-input-group-buttons">
         <span slot="label">Multiple buttons</span>

--- a/packages/pharos/src/components/input-group/pharos-input-group.wc.stories.jsx
+++ b/packages/pharos/src/components/input-group/pharos-input-group.wc.stories.jsx
@@ -118,7 +118,11 @@ export const Composition = {
       <div style="display: grid; grid-gap: 1rem; grid-template-columns: 524px;">
         <storybook-pharos-input-group name="my-input-group-icon">
           <span slot="label">With icons</span>
-          <storybook-pharos-icon id="calendar" name="calendar"></storybook-pharos-icon>
+          <storybook-pharos-icon
+            id="calendar"
+            name="calendar"
+            a11y-hidden="true"
+          ></storybook-pharos-icon>
         </storybook-pharos-input-group>
         <storybook-pharos-input-group name="my-input-group-buttons">
           <span slot="label">Multiple buttons</span>

--- a/packages/pharos/src/components/pagination/pharos-pagination.ts
+++ b/packages/pharos/src/components/pagination/pharos-pagination.ts
@@ -116,7 +116,7 @@ export class PharosPagination extends ScopedRegistryMixin(PharosElement) {
           href=""
           @click="${this._handleClick}"
         >
-          <pharos-icon name="chevron-left"></pharos-icon>
+          <pharos-icon name="chevron-left" a11y-hidden="true"></pharos-icon>
           Previous
         </pharos-link>
       `;
@@ -136,7 +136,7 @@ export class PharosPagination extends ScopedRegistryMixin(PharosElement) {
           @click="${this._handleClick}"
         >
           Next
-          <pharos-icon name="chevron-right"></pharos-icon>
+          <pharos-icon name="chevron-right" a11y-hidden="true"></pharos-icon>
         </pharos-link>
       `;
     }

--- a/packages/pharos/src/components/select/pharos-select.ts
+++ b/packages/pharos/src/components/select/pharos-select.ts
@@ -111,7 +111,7 @@ export class PharosSelect extends ScopedRegistryMixin(
               return html`${unsafeHTML(child.outerHTML)}`;
             })}
         </select>
-        <pharos-icon class="select__icon" name="chevron-down"></pharos-icon>
+        <pharos-icon class="select__icon" name="chevron-down" a11y-hidden="true"></pharos-icon>
       </div>
       ${this.messageContent}
     `;

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-link.ts
@@ -50,7 +50,11 @@ export class PharosSidenavLink extends ScopedRegistryMixin(PharosLink) {
 
   protected override get appendContent(): TemplateResult | typeof nothing {
     if (this.external) {
-      return html`<pharos-icon name="link-external" class="link__icon"></pharos-icon>`;
+      return html`<pharos-icon
+        name="link-external"
+        class="link__icon"
+        a11y-hidden="true"
+      ></pharos-icon>`;
     }
     return nothing;
   }

--- a/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
+++ b/packages/pharos/src/components/sidenav/pharos-sidenav-menu.ts
@@ -67,9 +67,13 @@ export class PharosSidenavMenu extends ScopedRegistryMixin(FocusMixin(PharosElem
 
   private _renderIcon(): TemplateResult {
     if (this.expanded) {
-      return html` <pharos-icon class="button__icon" name="chevron-up"></pharos-icon> `;
+      return html`
+        <pharos-icon class="button__icon" name="chevron-up" a11y-hidden="true"></pharos-icon>
+      `;
     }
-    return html` <pharos-icon class="button__icon" name="chevron-down"></pharos-icon> `;
+    return html`
+      <pharos-icon class="button__icon" name="chevron-down" a11y-hidden="true"></pharos-icon>
+    `;
   }
 
   private _renderMenu(): TemplateResult {

--- a/packages/pharos/src/components/text-input/pharos-text-input.test.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.test.ts
@@ -198,6 +198,7 @@ describe('pharos-text-input', () => {
         <pharos-icon
           class="input__icon"
           data-pharos-component="PharosIcon"
+          a11y-hidden="true"
           description=""
           name="exclamation"
         >
@@ -232,6 +233,7 @@ describe('pharos-text-input', () => {
         <pharos-icon
           class="input__icon"
           data-pharos-component="PharosIcon"
+          a11y-hidden="true"
           description=""
           name="checkmark"
         >

--- a/packages/pharos/src/components/text-input/pharos-text-input.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.ts
@@ -195,9 +195,13 @@ export class PharosTextInput extends ScopedRegistryMixin(FormMixin(FormElement))
 
   private _renderIcons(): TemplateResult | typeof nothing {
     if (this.invalidated) {
-      return html` <pharos-icon class="input__icon" name="exclamation"></pharos-icon> `;
+      return html`
+        <pharos-icon class="input__icon" name="exclamation" a11y-hidden="true"></pharos-icon>
+      `;
     } else if (this.validated) {
-      return html` <pharos-icon class="input__icon" name="checkmark"></pharos-icon> `;
+      return html`
+        <pharos-icon class="input__icon" name="checkmark" a11y-hidden="true"></pharos-icon>
+      `;
     }
     return nothing;
   }

--- a/packages/pharos/src/components/toast/pharos-toast.ts
+++ b/packages/pharos/src/components/toast/pharos-toast.ts
@@ -136,7 +136,7 @@ export class PharosToast extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
         })}"
         tabindex="0"
       >
-        <pharos-icon class="toast__icon" name="${this._getIcon()}"></pharos-icon>
+        <pharos-icon class="toast__icon" name="${this._getIcon()}" a11y-hidden="true"></pharos-icon>
         <div class="toast__body">
           <slot></slot>
         </div>

--- a/packages/pharos/src/pages/home/react/HeroSearch.tsx
+++ b/packages/pharos/src/pages/home/react/HeroSearch.tsx
@@ -4,7 +4,7 @@ import { PharosIcon } from '../../../react-components/icon/pharos-icon';
 
 export const HeroSearch: FC = () => (
   <div className="home-page__container--input">
-    <PharosIcon name="search" className="home-page__icon--search"></PharosIcon>
+    <PharosIcon name="search" className="home-page__icon--search" a11yHidden="true"></PharosIcon>
     <input className="home-page__input" placeholder="Search JSTOR..." />
   </div>
 );

--- a/packages/pharos/src/pages/home/wc/hero-search.ts
+++ b/packages/pharos/src/pages/home/wc/hero-search.ts
@@ -3,7 +3,11 @@ import type { TemplateResult } from 'lit';
 
 export const HeroSearch = (): TemplateResult => html`
   <div class="home-page__container--input">
-    <storybook-pharos-icon name="search" class="home-page__icon--search"></storybook-pharos-icon>
+    <storybook-pharos-icon
+      name="search"
+      class="home-page__icon--search"
+      a11y-hidden="true"
+    ></storybook-pharos-icon>
     <input class="home-page__input" placeholder="Search JSTOR..." />
   </div>
 `;

--- a/packages/pharos/src/pages/item-detail/react/item-detail.pages.stories.tsx
+++ b/packages/pharos/src/pages/item-detail/react/item-detail.pages.stories.tsx
@@ -43,6 +43,7 @@ export const ItemDetail = {
               <PharosIcon
                 name="arrow-left"
                 style={{ marginRight: 'var(--pharos-spacing-one-quarter-x)' }}
+                a11yHidden="true"
               ></PharosIcon>
               Back to results
             </PharosLink>

--- a/packages/pharos/src/pages/item-detail/wc/item-detail.pages.stories.ts
+++ b/packages/pharos/src/pages/item-detail/wc/item-detail.pages.stories.ts
@@ -35,6 +35,7 @@ export const ItemDetail = {
               <storybook-pharos-icon
                 name="arrow-left"
                 style="margin-right: var(--pharos-spacing-one-quarter-x)"
+                a11y-hidden="true"
               ></storybook-pharos-icon>
               Back to results
             </storybook-pharos-link>

--- a/packages/pharos/src/pages/shared/react/Footer.tsx
+++ b/packages/pharos/src/pages/shared/react/Footer.tsx
@@ -246,7 +246,7 @@ export const Footer: FC = () => {
             target="_blank"
             label="twitter - This link opens in a new window"
           >
-            <PharosIcon name="twitter"></PharosIcon>
+            <PharosIcon name="twitter" a11yHidden="true"></PharosIcon>
           </PharosLink>
         </li>
         <li>
@@ -256,7 +256,7 @@ export const Footer: FC = () => {
             target="_blank"
             label="facebook - This link opens in a new window"
           >
-            <PharosIcon name="facebook"></PharosIcon>
+            <PharosIcon name="facebook" a11yHidden="true"></PharosIcon>
           </PharosLink>
         </li>
         <li>
@@ -266,7 +266,7 @@ export const Footer: FC = () => {
             target="_blank"
             label="instagram - This link opens in a new window"
           >
-            <PharosIcon name="instagram"></PharosIcon>
+            <PharosIcon name="instagram" a11yHidden="true"></PharosIcon>
           </PharosLink>
         </li>
         <li>
@@ -276,7 +276,7 @@ export const Footer: FC = () => {
             target="_blank"
             label="youtube - This link opens in a new window"
           >
-            <PharosIcon name="youtube"></PharosIcon>
+            <PharosIcon name="youtube" a11yHidden="true"></PharosIcon>
           </PharosLink>
         </li>
         <li>
@@ -286,7 +286,7 @@ export const Footer: FC = () => {
             target="_blank"
             label="linkedin - This link opens in a new window"
           >
-            <PharosIcon name="linkedin"></PharosIcon>
+            <PharosIcon name="linkedin" a11yHidden="true"></PharosIcon>
           </PharosLink>
         </li>
         <li>
@@ -296,7 +296,7 @@ export const Footer: FC = () => {
             target="_blank"
             label="tumblr - This link opens in a new window"
           >
-            <PharosIcon name="tumblr"></PharosIcon>
+            <PharosIcon name="tumblr" a11yHidden="true"></PharosIcon>
           </PharosLink>
         </li>
       </ul>

--- a/packages/pharos/src/pages/shared/react/Header.tsx
+++ b/packages/pharos/src/pages/shared/react/Header.tsx
@@ -62,6 +62,7 @@ export const Header: FC = () => (
           style={{
             marginLeft: '1rem',
           }}
+          a11yHidden="true"
         ></PharosIcon>
       </div>
       <span slot="top" className="show-for-small" style={{ display: 'none', fontWeight: 'bold' }}>

--- a/packages/pharos/src/pages/shared/wc/footer.ts
+++ b/packages/pharos/src/pages/shared/wc/footer.ts
@@ -240,7 +240,7 @@ export const Footer = (): TemplateResult => {
             target="_blank"
             label="twitter - This link opens in a new window"
           >
-            <storybook-pharos-icon name="twitter"></storybook-pharos-icon>
+            <storybook-pharos-icon name="twitter" a11y-hidden="true"></storybook-pharos-icon>
           </storybook-pharos-link>
         </li>
         <li>
@@ -250,7 +250,7 @@ export const Footer = (): TemplateResult => {
             target="_blank"
             label="facebook - This link opens in a new window"
           >
-            <storybook-pharos-icon name="facebook"></storybook-pharos-icon>
+            <storybook-pharos-icon name="facebook" a11y-hidden="true"></storybook-pharos-icon>
           </storybook-pharos-link>
         </li>
         <li>
@@ -260,7 +260,7 @@ export const Footer = (): TemplateResult => {
             target="_blank"
             label="instagram - This link opens in a new window"
           >
-            <storybook-pharos-icon name="instagram"></storybook-pharos-icon>
+            <storybook-pharos-icon name="instagram" a11y-hidden="true"></storybook-pharos-icon>
           </storybook-pharos-link>
         </li>
         <li>
@@ -270,7 +270,7 @@ export const Footer = (): TemplateResult => {
             target="_blank"
             label="youtube - This link opens in a new window"
           >
-            <storybook-pharos-icon name="youtube"></storybook-pharos-icon>
+            <storybook-pharos-icon name="youtube" a11y-hidden="true"></storybook-pharos-icon>
           </storybook-pharos-link>
         </li>
         <li>
@@ -280,7 +280,7 @@ export const Footer = (): TemplateResult => {
             target="_blank"
             label="linkedin - This link opens in a new window"
           >
-            <storybook-pharos-icon name="linkedin"></storybook-pharos-icon>
+            <storybook-pharos-icon name="linkedin" a11y-hidden="true"></storybook-pharos-icon>
           </storybook-pharos-link>
         </li>
         <li>
@@ -290,7 +290,7 @@ export const Footer = (): TemplateResult => {
             target="_blank"
             label="tumblr - This link opens in a new window"
           >
-            <storybook-pharos-icon name="tumblr"></storybook-pharos-icon>
+            <storybook-pharos-icon name="tumblr" a11y-hidden="true"></storybook-pharos-icon>
           </storybook-pharos-link>
         </li>
       </ul>

--- a/packages/pharos/src/pages/shared/wc/header.ts
+++ b/packages/pharos/src/pages/shared/wc/header.ts
@@ -51,6 +51,7 @@ export const Header = (): TemplateResult => html`
         <storybook-pharos-icon
           name="chevron-down"
           style="margin-left: 1rem"
+          a11y-hidden="true"
         ></storybook-pharos-icon>
       </div>
       <storybook-pharos-dropdown-menu id="pds-menu" placement="bottom">

--- a/packages/pharos/src/styles/tokens.react.stories.jsx
+++ b/packages/pharos/src/styles/tokens.react.stories.jsx
@@ -603,7 +603,7 @@ const TypeTokens = () => (
                     GT America
                   </span>
                 ) : (
-                  <PharosIcon name="dash-small"></PharosIcon>
+                  <PharosIcon name="dash-small" a11yHidden="true"></PharosIcon>
                 )}
               </td>
               <td>
@@ -615,7 +615,7 @@ const TypeTokens = () => (
                     Ivar Headline
                   </span>
                 ) : (
-                  <PharosIcon name="dash-small"></PharosIcon>
+                  <PharosIcon name="dash-small" a11yHidden="true"></PharosIcon>
                 )}
               </td>
             </tr>

--- a/packages/pharos/src/styles/tokens.wc.stories.jsx
+++ b/packages/pharos/src/styles/tokens.wc.stories.jsx
@@ -551,7 +551,10 @@ const TypeTokens = () => html`
                       style="font-size:${tokens.type.scale[key].comment};"
                       >GT America</span
                     >`
-                  : html`<storybook-pharos-icon name="dash-small"></storybook-pharos-icon>`}
+                  : html`<storybook-pharos-icon
+                      name="dash-small"
+                      a11y-hidden="true"
+                    ></storybook-pharos-icon>`}
               </td>
               <td>
                 ${tokens.type.scale[key].value > 5
@@ -560,7 +563,10 @@ const TypeTokens = () => html`
                       style="font-size:${tokens.type.scale[key].comment};"
                       >Ivar Headline</span
                     >`
-                  : html`<storybook-pharos-icon name="dash-small"></storybook-pharos-icon>`}
+                  : html`<storybook-pharos-icon
+                      name="dash-small"
+                      a11y-hidden="true"
+                    ></storybook-pharos-icon>`}
               </td>
             </tr>
           `


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Fixes #659. Recent updates to the icon component (#646) were made which emit a
console log when deprecated attributes are used. This updates
all the internal usages of the icon component in other Pharos
components, storybook stories, and the pharos site to use the new
syntax so that the console log is no longer emitted in places that
would confuse our end users.

**How does this change work?**
Updates all internal instances of pharos-icon to either include an `a11y-hidden` or an `a11y-title` attribute as needed. In most cases this was done in such a way as to match the intended outcome of the previous iteration. So if there was a blank or no description, I added a `a11y-hidden` and only if there was an existing description that was updated to be a `a11y-title`. However, there were a few exceptions to this where it seemed pretty clear it should have a label and not be hidden so I added a title to those.

**Additional context**
You may see in some of the tests it is still expecting a `description=""` to be rendered. This is because until v14 is released there is a default description of "" added to all icons. 
