### PR TITLE
Remove old onBackground attribute from sidenav storybook story

### DIFF
--- a/.changeset/eleven-spoons-shop.md
+++ b/.changeset/eleven-spoons-shop.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Remove deprecated onBackground attribute from sidenav storybook story

--- a/packages/pharos/src/components/sidenav/PharosSidenav.react.stories.jsx
+++ b/packages/pharos/src/components/sidenav/PharosSidenav.react.stories.jsx
@@ -62,7 +62,6 @@ export const Base = {
             variant="subtle"
             isOnBackground
             a11yLabel="search"
-            onBackground
           ></PharosButton>
         </PharosInputGroup>
         <PharosSidenavSection showDivider>


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [ ] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
When merging the latest develop into this release branch the sidenav component ended up with both the old onBackground and new isOnBackground versions of the attribute in its storybook story. This removes the old version so it is correct.

**How does this change work?**
Removes the deprecated `onBackground` attribute from the storybook story.

