### PR TITLE
Require icon accessibility attributes

### DIFF
--- a/.changeset/thirty-carrots-suffer.md
+++ b/.changeset/thirty-carrots-suffer.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Require all icons to have a label or be explicitly hidden

--- a/packages/pharos/src/components/alert/pharos-alert.test.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.test.ts
@@ -39,7 +39,6 @@ describe('pharos-alert', () => {
           class="alert__icon"
           data-pharos-component="PharosIcon"
           a11y-hidden="true"
-          description=""
           name="info-inverse"
         >
         </pharos-icon>

--- a/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-category.ts
+++ b/packages/pharos/src/components/dropdown-menu-nav/pharos-dropdown-menu-nav-category.ts
@@ -52,7 +52,7 @@ export class PharosDropdownMenuNavCategory extends ScopedRegistryMixin(FocusMixi
       })}"
     >
       <slot name="category"></slot>
-      <pharos-icon name="chevron-down"></pharos-icon>
+      <pharos-icon name="chevron-down" a11y-hidden="true"></pharos-icon>
     </button>`;
   }
 }

--- a/packages/pharos/src/components/icon/pharos-icon.test.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.test.ts
@@ -7,7 +7,9 @@ describe('pharos-icon', () => {
   let component: PharosIcon;
 
   beforeEach(async () => {
-    component = await fixture(html`<test-pharos-icon name="base"></test-pharos-icon>`);
+    component = await fixture(
+      html`<test-pharos-icon name="base" a11y-title="base-icon"></test-pharos-icon>`
+    );
   });
 
   it('is accessible', async () => {
@@ -15,9 +17,9 @@ describe('pharos-icon', () => {
   });
 
   it('throws an error for an invalid icon name', async () => {
-    component = await fixture(html` <test-pharos-icon name="fake"></test-pharos-icon> `).catch(
-      (e) => e
-    );
+    component = await fixture(
+      html` <test-pharos-icon name="fake" a11y-title="fake-icon"></test-pharos-icon> `
+    ).catch((e) => e);
     expect('Could not get icon named "fake"').to.be.thrown;
   });
 
@@ -46,26 +48,6 @@ describe('pharos-icon', () => {
     expect(svg?.getAttribute('aria-hidden')).to.equal('true');
   });
 
-  it('adds aria-hidden when a11y-hidden is not provided and there is no title or description', async () => {
-    await component.updateComplete;
-    const svg = component.renderRoot.querySelector('svg');
-    expect(svg?.getAttribute('aria-hidden')).to.equal('true');
-  });
-
-  it('does not add aria-hidden if there is a title', async () => {
-    component.a11yTitle = 'some-label';
-    await component.updateComplete;
-    const svg = component.renderRoot.querySelector('svg');
-    expect(svg?.getAttribute('aria-hidden')).not.to.exist;
-  });
-
-  it('does not add aria-hidden if there is a description', async () => {
-    component.description = 'some-label';
-    await component.updateComplete;
-    const svg = component.renderRoot.querySelector('svg');
-    expect(svg?.getAttribute('aria-hidden')).not.to.exist;
-  });
-
   it('sets the svg title properly when a11y-title is set', async () => {
     const labelText = 'This is a test title';
     component.a11yTitle = labelText;
@@ -74,11 +56,12 @@ describe('pharos-icon', () => {
     expect(title).to.contain.text(labelText);
   });
 
-  it('sets the svg title properly when description is set', async () => {
-    const labelText = 'This is a test title';
-    component.description = labelText;
-    await component.updateComplete;
-    const title = component.renderRoot.querySelector('svg>title');
-    expect(title).to.contain.text(labelText);
+  it('throws an erorr when neither a11y-title or a11y-hidden are set', async () => {
+    component = await fixture(html` <test-pharos-icon name="base"></test-pharos-icon> `).catch(
+      (e) => e
+    );
+    expect(
+      'All icons must have an accessible title (a11y-title) or be marked as hidden to assistive technology (a11y-hidden).'
+    ).to.be.thrown;
   });
 });

--- a/packages/pharos/src/components/icon/pharos-icon.ts
+++ b/packages/pharos/src/components/icon/pharos-icon.ts
@@ -28,14 +28,6 @@ export class PharosIcon extends PharosElement {
   public name?: IconName;
 
   /**
-   * A description of what the icon represents
-   * @attr description
-   * @deprecated Please use a11yTitle instead.
-   */
-  @property({ type: String, reflect: true })
-  public description = '';
-
-  /**
    * Indicates the title to apply as the accessible name of the icon.
    * @attr a11y-title
    */
@@ -55,9 +47,10 @@ export class PharosIcon extends PharosElement {
 
   protected override update(changedProperties: PropertyValues): void {
     super.update && super.update(changedProperties);
-    if (this.description.length) {
-      console.warn(
-        "The 'description' attribute of pharos-icon is deprecated and will be removed in the next major release. Please use a11y-title or mark the icon as decorative by using a11y-hidden instead."
+
+    if (!this.a11yHidden && !this.a11yTitle) {
+      throw new Error(
+        `All icons must have an accessible title (a11y-title) or be marked as hidden to assistive technology (a11y-hidden).`
       );
     }
   }
@@ -84,12 +77,6 @@ export class PharosIcon extends PharosElement {
 
   protected override render(): TemplateResult {
     const size = this._getIconSize();
-    const accessibilityLabel = this.a11yTitle || this.description;
-    let hideIcon = this.a11yHidden;
-    // Check accessibilityLabel length for backwards compatibility until description is removed
-    if (hideIcon !== 'true' && accessibilityLabel.length === 0) {
-      hideIcon = 'true';
-    }
     return html`
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -97,12 +84,12 @@ export class PharosIcon extends PharosElement {
         viewBox="0 0 ${size} ${size}"
         class="icon"
         role="img"
-        aria-hidden=${hideIcon || nothing}
+        aria-hidden=${this.a11yHidden || nothing}
         height="${size}"
         width="${size}"
         focusable="false"
       >
-        <title>${accessibilityLabel}</title>
+        <title>${this.a11yTitle}</title>
         ${unsafeSVG(this._svg)}
       </svg>
     `;

--- a/packages/pharos/src/components/text-input/pharos-text-input.test.ts
+++ b/packages/pharos/src/components/text-input/pharos-text-input.test.ts
@@ -199,7 +199,6 @@ describe('pharos-text-input', () => {
           class="input__icon"
           data-pharos-component="PharosIcon"
           a11y-hidden="true"
-          description=""
           name="exclamation"
         >
         </pharos-icon>
@@ -234,7 +233,6 @@ describe('pharos-text-input', () => {
           class="input__icon"
           data-pharos-component="PharosIcon"
           a11y-hidden="true"
-          description=""
           name="checkmark"
         >
         </pharos-icon>


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [X] Yes
- [ ] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Fixes #467. 
This is the breaking change followup to #646, removing the icon description and requiring an icon to be correctly annotated for screen readers by providing a title or being marked as hidden.

**How does this change work?**
It does the following for the icon component:
- Removes the deprecated `description` attribute entirely
- No longer defaults to hiding the icon if there is no accessible title provided
- Throws an error if an icon is added without being provided a title or being explicitly marked as hidden

**Additional context**
- See [this diagram](https://github.com/ithaka/pharos/pull/646#discussion_r1420728515) for a better understanding of what has changed between v13/v14. This PR represents the end state of that diagram.
- I also updated several downstream tests which were expecting the default for description to be present in their checks.
- There was an icon I missed in #660 in the dropdown navigation so I fixed that too. (Some nice proof this will prevent inaccessible icons from making it to users 🎉)
