### PR TITLE
Fix the all-contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href=".github/CODE_OF_CONDUCT.md"><img src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg" alt="Contributor Covenant" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Pharos is released under the MIT license" /></a>
-  <a href="#contributors-"><img src="https://img.shields.io/badge/all_contributors-20-orange.svg?style=flat-square" alt="All Contributors" /></a>
+  <a href="#contributors-"><img src="https://img.shields.io/github/all-contributors/ithaka/pharos" alt="All Contributors" /></a>
   <a href="https://bundlephobia.com/package/@ithaka/pharos"><img src="https://img.shields.io/bundlephobia/min/@ithaka/pharos" alt="Bundlephobia stats" /></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href=".github/CODE_OF_CONDUCT.md"><img src="https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg" alt="Contributor Covenant" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Pharos is released under the MIT license" /></a>
-  <a href="#contributors-"><img src="https://img.shields.io/github/all-contributors/ithaka/pharos" alt="All Contributors" /></a>
+  <a href="#contributors-"><img src="https://img.shields.io/github/all-contributors/ithaka/pharos?color=orange" alt="All Contributors" /></a>
   <a href="https://bundlephobia.com/package/@ithaka/pharos"><img src="https://img.shields.io/bundlephobia/min/@ithaka/pharos" alt="Bundlephobia stats" /></a>
 </p>
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

The all-contributors badge was stuck at a count of 20, as we seem to have been using a hard-coded image.

**How does this change work?**

This updates the badge to a proper dynamic badge with the right count.
