### PR TITLE
Modal: Add default elevation

### DIFF
--- a/.changeset/calm-weeks-own.md
+++ b/.changeset/calm-weeks-own.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add elevation style to modal component

--- a/packages/pharos/src/components/modal/pharos-modal.scss
+++ b/packages/pharos/src/components/modal/pharos-modal.scss
@@ -31,7 +31,6 @@
   pointer-events: none;
   z-index: 9001;
   visibility: hidden;
-  box-shadow: var(--pharos-elevation-level-5);
 
   @at-root #{&}--small {
     width: 28rem;
@@ -95,9 +94,9 @@
   overflow-y: scroll;
   background-color: var(--pharos-modal-color-background-content);
   background-clip: padding-box;
-  border: 1px solid var(--pharos-modal-color-border-content);
   border-radius: var(--pharos-radius-base-standard);
   outline: 0;
+  box-shadow: var(--pharos-elevation-level-5);
 }
 
 .modal__body {

--- a/packages/pharos/src/components/modal/pharos-modal.scss
+++ b/packages/pharos/src/components/modal/pharos-modal.scss
@@ -31,6 +31,7 @@
   pointer-events: none;
   z-index: 9001;
   visibility: hidden;
+  box-shadow: var(--pharos-elevation-level-5);
 
   @at-root #{&}--small {
     width: 28rem;


### PR DESCRIPTION

**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Closes #665.
Adds default elevation to the modal component.

**How does this change work?**
Adds a `box-shadow` set to the `pharos-elevation-level-5` design token to the modal component

**Screenshot**
<img width="1000" alt="Screenshot 2024-02-09 at 8 50 10 AM" src="https://github.com/ithaka/pharos/assets/6653970/f5c9d984-4711-4cea-b071-4b2dd2b69b4b">
