### PR TITLE
Popover: Update default elevation to use token

### DIFF
--- a/.changeset/pink-ties-tell.md
+++ b/.changeset/pink-ties-tell.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Update popover component elevation to use design token

--- a/packages/pharos/src/components/popover/pharos-popover.scss
+++ b/packages/pharos/src/components/popover/pharos-popover.scss
@@ -14,7 +14,7 @@
 
   position: relative;
   margin: 0;
-  box-shadow: 0 1px 2px rgb(18 18 18 / 0.3), 0 4px 8px 3px rgb(18 18 18 / 0.15);
+  box-shadow: var(--pharos-elevation-level-4);
   border-radius: var(--pharos-radius-base-standard);
   visibility: hidden;
   pointer-events: none;


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Closes #664.
Updates the default elevation of the popover component to use a design token

**How does this change work?**
Updates the `box-shadow` set on the popver component to use the `pharos-elevation-level-4` design token.

**Screenshots**
<img width="269" alt="Screenshot 2024-02-09 at 8 56 30 AM" src="https://github.com/ithaka/pharos/assets/6653970/ee92b8e6-c2a0-42a7-b286-5344581fdd5f">


<img width="269" alt="Screenshot 2024-02-09 at 8 58 24 AM" src="https://github.com/ithaka/pharos/assets/6653970/a17f5a48-9209-4b02-b650-8a6fd6b5a637">
