### PR TITLE
Combobox: Add default elevation

### DIFF
--- a/.changeset/flat-clocks-brush.md
+++ b/.changeset/flat-clocks-brush.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add default elevation to combobox component

--- a/.changeset/flat-clocks-brush.md
+++ b/.changeset/flat-clocks-brush.md
@@ -2,4 +2,4 @@
 '@ithaka/pharos': minor
 ---
 
-Add default elevation to combobox component
+Add default elevation and remove border from combobox component

--- a/packages/pharos/src/components/combobox/pharos-combobox.scss
+++ b/packages/pharos/src/components/combobox/pharos-combobox.scss
@@ -114,6 +114,7 @@
   z-index: 1;
   width: 100%;
   box-sizing: border-box;
+  box-shadow: var(--pharos-elevation-level-3);
   border-radius: var(--pharos-radius-base-standard);
   background-color: var(--pharos-color-ui-10);
   border: 1px solid var(--pharos-form-element-color-border-base);

--- a/packages/pharos/src/components/combobox/pharos-combobox.scss
+++ b/packages/pharos/src/components/combobox/pharos-combobox.scss
@@ -117,7 +117,6 @@
   box-shadow: var(--pharos-elevation-level-3);
   border-radius: var(--pharos-radius-base-standard);
   background-color: var(--pharos-color-ui-10);
-  border: 1px solid var(--pharos-form-element-color-border-base);
   margin-block-start: var(--pharos-spacing-one-half-x);
   margin-block-end: var(--pharos-spacing-one-half-x);
   list-style-type: none;


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Closes #663.
Adds default elevation to the combobox component.

**How does this change work?**
Adds a `box-shadow` set to the `pharos-elevation-level-3` design token to the combobox component

**Screenshots**
Before:
<img width="338" alt="Screenshot 2024-02-09 at 9 17 02 AM" src="https://github.com/ithaka/pharos/assets/6653970/cf325f44-e2f3-4da4-8333-56e3ef48cb08">

After:
<img width="338" alt="Screenshot 2024-02-09 at 9 17 50 AM" src="https://github.com/ithaka/pharos/assets/6653970/c0dd6dbc-6abf-4e23-8358-7b8fa3981c24">

