### PR TITLE
Dropdown Menu: Add default elevation

### DIFF
--- a/.changeset/quiet-garlics-compete.md
+++ b/.changeset/quiet-garlics-compete.md
@@ -2,4 +2,4 @@
 '@ithaka/pharos': minor
 ---
 
-Add default elevation to dropdown-menu
+Add default elevation and remove border from dropdown-menu

--- a/.changeset/quiet-garlics-compete.md
+++ b/.changeset/quiet-garlics-compete.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add default elevation to dropdown-menu

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.scss
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.scss
@@ -19,7 +19,6 @@
   list-style-type: none;
   padding-left: 0;
   padding-inline-start: 0;
-  border: 1px solid var(--pharos-dropdown-menu-color-border-base);
   border-radius: 2px;
   box-shadow: var(--pharos-elevation-level-3);
   visibility: hidden;
@@ -28,10 +27,6 @@
   transform: translate3d(0, 0, 0);
   transition: visibility 0s var(--pharos-transition-duration-short),
     opacity var(--pharos-transition-duration-short) linear;
-}
-
-:host([is-on-background]) .dropdown-menu__list {
-  border: none;
 }
 
 :host([open]) .dropdown-menu__list {

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.scss
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.scss
@@ -21,6 +21,7 @@
   padding-inline-start: 0;
   border: 1px solid var(--pharos-dropdown-menu-color-border-base);
   border-radius: 2px;
+  box-shadow: var(--pharos-elevation-level-3);
   visibility: hidden;
   pointer-events: none;
   opacity: 0;


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Closes #662.
Adds default elevation to the dropdown-menu component.

**How does this change work?**
Adds a `box-shadow` set to the `pharos-elevation-level-3` design token to the dropdown-menu component

**Screenshot**
Before:
<img width="236" alt="Screenshot 2024-02-09 at 9 29 24 AM" src="https://github.com/ithaka/pharos/assets/6653970/d21e68d6-deb8-4c80-9f5c-8d7431318200">

After:
<img width="236" alt="Screenshot 2024-02-09 at 9 32 39 AM" src="https://github.com/ithaka/pharos/assets/6653970/1d3d76ad-acd0-438b-bfc4-9fa887343e20">
