### PR TITLE
fix(icon): add media query style for WHCM

### DIFF
--- a/.changeset/gold-seas-end.md
+++ b/.changeset/gold-seas-end.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Added media query for icons to appear on Windows High Contrast Mode

--- a/packages/pharos/src/components/icon/pharos-icon.scss
+++ b/packages/pharos/src/components/icon/pharos-icon.scss
@@ -6,3 +6,10 @@
 .icon {
   display: block;
 }
+
+@media screen and (forced-colors: active) {
+  .icon {
+    fill: currentcolor;
+    stroke: currentcolor;
+  }
+}


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [ ] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
This addresses issue #688 where Pharos icons were not visually appearing while navigating screens with Windows High Contrast Mode.

**How does this change work?**
Added a media query that targets the `forced-colors` user preference and sets the SVG attributes `fill` and `stroke` to the `currentColor`.

**Additional context**
Resolves #688 

**References:**
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
https://www.smashingmagazine.com/2022/06/guide-windows-high-contrast-mode/
https://css-tricks.com/accessible-svgs-high-contrast-mode/
https://www.digitalocean.com/community/tutorials/css-currentcolor