### PR TITLE
Tabs: Remove overflow-y from pharos-tabs' tab__panels class

### DIFF
--- a/.changeset/weak-berries-hunt.md
+++ b/.changeset/weak-berries-hunt.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': major
+---
+
+Remove overflow-y from pharos-tabs tab panels

--- a/packages/pharos/src/components/tabs/pharos-tabs.scss
+++ b/packages/pharos/src/components/tabs/pharos-tabs.scss
@@ -39,7 +39,6 @@
 .tab__panels {
   display: flex;
   flex-direction: column;
-  overflow-y: hidden;
   padding: var(--pharos-spacing-one-quarter-x);
 }
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [x] Yes
- [ ] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
This change is removing the overflow-y from the panel of the tab component. This change is being made because child nodes of the panel are being confined to that area (see in screenshot). This will allow some flexibility and will let the consumer choose how/if to apply overflow.
<img width="1217" alt="Screenshot 2024-02-21 at 8 55 55 AM" src="https://github.com/ithaka/pharos/assets/64924035/4141e61a-e951-435e-9c09-54aa4c935937">

**How does this change work?**
Remove overflow-y attribute.

**Additional context**
As mentioned above this is a breaking change. Any app/page that is using the tabs component should verify that the UI is working as expected.
