### PR TITLE
Require an accessible label be present for icon-only buttons

### DIFF
--- a/.changeset/tough-buckets-press.md
+++ b/.changeset/tough-buckets-press.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': major
+---
+
+Require an a11y-label for icon buttons

--- a/packages/pharos/src/components/button/pharos-button.test.ts
+++ b/packages/pharos/src/components/button/pharos-button.test.ts
@@ -182,8 +182,24 @@ describe('pharos-button', () => {
         .thrown;
     });
 
+    it('throws an error for an icon only button with no accessible label', async () => {
+      let errorThrown = false;
+      try {
+        await fixture(html` <test-pharos-button icon="download"></test-pharos-button> `);
+      } catch (error) {
+        if (error instanceof Error) {
+          errorThrown = true;
+          expect(error?.message).to.be.equal(
+            "Icon only buttons must have an accessible name. Please provide an 'a11y-label' attribute for the button using the 'download' icon."
+          );
+        }
+      }
+      expect(errorThrown).to.be.true;
+    });
+
     it('allows for an icon to be shown as the content of the button', async () => {
       component.icon = 'download';
+      component.a11yLabel = 'Download';
       await component.updateComplete;
 
       const icon = component.renderRoot.querySelector(

--- a/packages/pharos/src/components/button/pharos-button.ts
+++ b/packages/pharos/src/components/button/pharos-button.ts
@@ -196,7 +196,11 @@ export class PharosButton extends ScopedRegistryMixin(FocusMixin(AnchorElement))
         `${this.variant} is not a valid variant. Valid variants are: ${VARIANTS.join(', ')}`
       );
     }
-
+    if (this.icon && !this.a11yLabel) {
+      throw new Error(
+        `Icon only buttons must have an accessible name. Please provide an 'a11y-label' attribute for the button using the '${this.icon}' icon.`
+      );
+    }
     if (this.label) {
       console.warn("The 'label' attribute is deprecated. Use 'a11y-label' instead.");
     }

--- a/packages/pharos/src/components/input-group/pharos-input-group.test.ts
+++ b/packages/pharos/src/components/input-group/pharos-input-group.test.ts
@@ -101,6 +101,7 @@ describe('pharos-input-group', () => {
   it('adjusts the validated icon position when elements are dynamically appended to the group', async () => {
     const button = document.createElement('test-pharos-button');
     button.icon = 'close';
+    button.a11yLabel = 'close';
     component.appendChild(button);
     component.validated = true;
 

--- a/packages/pharos/src/components/toggle-button-group/PharosToggleButtonGroup.react.stories.jsx
+++ b/packages/pharos/src/components/toggle-button-group/PharosToggleButtonGroup.react.stories.jsx
@@ -87,13 +87,13 @@ export const Events = {
 export const IconsOnly = {
   render: () => (
     <PharosToggleButtonGroup>
-      <PharosToggleButton icon="view-list" id="view-list-button">
+      <PharosToggleButton icon="view-list" a11yLabel="view list" id="view-list-button">
         List
       </PharosToggleButton>
-      <PharosToggleButton icon="view-gallery" id="view-gallery-button">
+      <PharosToggleButton icon="view-gallery" a11yLabel="view gallery" id="view-gallery-button">
         Gallery
       </PharosToggleButton>
-      <PharosToggleButton icon="image" id="view-presentation-button">
+      <PharosToggleButton icon="image" a11yLabel="view presentation" id="view-presentation-button">
         Presentation
       </PharosToggleButton>
     </PharosToggleButtonGroup>

--- a/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.wc.stories.jsx
+++ b/packages/pharos/src/components/toggle-button-group/pharos-toggle-button-group.wc.stories.jsx
@@ -77,14 +77,17 @@ export const IconsOnly = {
       <storybook-pharos-toggle-button-group>
         <storybook-pharos-toggle-button
           icon="view-list"
+          a11y-label="view list"
           id="view-list-button"
         ></storybook-pharos-toggle-button
         ><storybook-pharos-toggle-button
           icon="view-gallery"
+          a11y-label="view gallery"
           id="view-gallery-button"
         ></storybook-pharos-toggle-button
         ><storybook-pharos-toggle-button
           icon="image"
+          a11y-label="view presentation"
           id="view-presentation-button"
         ></storybook-pharos-toggle-button>
       </storybook-pharos-toggle-button-group>


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [X] Yes
- [ ] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
Closes #698 

**How does this change work?**
Because the icon in an icon button is set to aria-hidden="true", it is not visible to screen readers. This change requires an `a11y-label` for icon-only buttons to ensure that the button is accessible.

If a button is created with an `icon` attribute but is not given a `a11y-label` attribute, the component will throw an error.

Note this is only checking the `icon` attribute and not the `icon-right` and `icon-left` attributes, as those are commonly used with additional text, which would also make them accessible.

**Additional context**

The test looks a little different as our existing error tests don't actually function - they always pass, this method seems to work better. 
