### PR TITLE
Remove browser styled scrollbar from Tabs component

### DIFF
--- a/.changeset/eight-cows-bake.md
+++ b/.changeset/eight-cows-bake.md
@@ -1,0 +1,5 @@
+---
+"@ithaka/pharos": patch
+---
+
+Remove scrollbar for tabs

--- a/packages/pharos/src/components/tabs/pharos-tabs.scss
+++ b/packages/pharos/src/components/tabs/pharos-tabs.scss
@@ -31,6 +31,7 @@
   display: flex;
   overflow-x: scroll;
   scroll-behavior: smooth;
+  scrollbar-width: none; // removes the scrollbar browser style
   margin-bottom: var(--pharos-spacing-one-half-x);
   padding: var(--pharos-spacing-one-quarter-x) var(--pharos-spacing-one-quarter-x)
     var(--pharos-spacing-1-x);


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [ ] Code coverage maximal?
- [x] Changeset added?
- [x] Component status page up to date?

**What does this change address?**
The update for the Tabs that allowed for horizontal scrolling causes a scroll bar to appear, even when there isn't a need for one. This added unnecessary padding just below the tabs to all instances of this pattern. These are styled slightly different in each browser as the browser applies its own styles. Below is an example from a Chromium browser.
<img width="240" alt="Screenshot of Tab with scrollbar highlighted" src="https://github.com/ithaka/pharos/assets/6874453/cfd33681-9d1b-4ed7-8655-2ec38ae26b5b">

**How does this change work?**
Adding a style for the `.tab__list` element that sets the `scrollbar-width` to `none`.

![Screenshot 2024-03-28 at 5 47 03 PM](https://github.com/ithaka/pharos/assets/6874453/39db8f1a-89db-4534-9a7c-ac82f09be616)

**Additional context**
I confirmed that touch (mobile) users are still be able to tap and drag to scroll, mouse users will be required to scroll horizontally (either by the scroll wheel moving left/right or by holding down Shift and using the mouse scrollwheel) but won’t be able to click and drag, and keyboard-only users will still be able to tab through without hassle.