### PR TITLE
Set Content-Security-Policy in Gatsby to allow loading content in Storybook

### DIFF
--- a/.changeset/weak-scissors-vanish.md
+++ b/.changeset/weak-scissors-vanish.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+Set Content-Security-Policy to allow iframes in storybook

--- a/packages/pharos-site/gatsby-config.js
+++ b/packages/pharos-site/gatsby-config.js
@@ -12,6 +12,17 @@ module.exports = {
     siteUrl: 'https://pharos.jstor.org',
   },
   trailingSlash: 'never',
+  headers: [
+    {
+      source: 'pharos.jstor.org',
+      headers: [
+        {
+          key: 'Content-Security-Policy',
+          value: "default-src 'self' jstor.org *.jstor.org",
+        },
+      ],
+    },
+  ],
   plugins: [
     `gatsby-plugin-react-helmet`,
     {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
When updating to Gatsby 5 we inadvertently broke some storybook pages. It will no longer load any content for the stories, returning a 404 with an error like `Refused to display 'https://pharos.jstor.org/' in a frame because it set 'X-Frame-Options' to 'deny'.`

**How does this change work?**
Sets the `Content-Security-Policy` of `pharos.jstor.org` to all content from any jstor page. It appears that in Gatsby 5 Netlify automatically injects it's adapter, which sets the headers to deny. ([thread](https://answers.netlify.com/t/breaking-change-x-frame-options-set-to-deny/102220), [documentation](https://www.netlify.com/blog/gatsby-adapters-realize-the-full-potential-of-gatsby-on-your-platform/))

**Additional context**
I used this [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#example_2) to create the header value, but I'm not overly familiar with this header, so let me know if there is a better option!
