### PR TITLE
Update the table caption warning to recommend correct attribute to visually hide the caption

### DIFF
--- a/.changeset/nice-cows-shave.md
+++ b/.changeset/nice-cows-shave.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix error message when no table caption is provided to recommend correct attribute to visually hide it

--- a/packages/pharos/src/components/table/pharos-table.test.ts
+++ b/packages/pharos/src/components/table/pharos-table.test.ts
@@ -200,7 +200,7 @@ it('throws an error if caption is not provided', async () => {
     if (error instanceof Error) {
       errorThrown = true;
       expect(error?.message).to.be.equal(
-        'Table must have an accessible name. Please provide a caption for the table using the `caption` attribute. You can hide the caption visually by setting the `hide-caption-visually` property.'
+        'Table must have an accessible name. Please provide a caption for the table using the `caption` attribute. You can hide the caption visually by setting the `hide-caption` property.'
       );
     }
   }

--- a/packages/pharos/src/components/table/pharos-table.ts
+++ b/packages/pharos/src/components/table/pharos-table.ts
@@ -98,7 +98,7 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
   protected override updated(): void {
     if (!this.caption) {
       throw new Error(
-        'Table must have an accessible name. Please provide a caption for the table using the `caption` attribute. You can hide the caption visually by setting the `hide-caption-visually` property.'
+        'Table must have an accessible name. Please provide a caption for the table using the `caption` attribute. You can hide the caption visually by setting the `hide-caption` property.'
       );
     }
     this._pageSize = !this.showPagination ? this.rowData.length : this._pageSize;


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
If you don't provide a table caption, there is an error thrown with directions how to fix it:

> Table must have an accessible name. Please provide a caption for the table using the `caption` attribute. You can hide the caption visually by setting the `hide-caption-visually` property.


However, the correct property to visually hide it is actually just `hide-caption` not `hide-caption-visually`

**How does this change work?**
Updates the error message to include the correct property in the error message
