### PR TITLE
Table: Add design tokens and update default header background

### DIFF
--- a/.changeset/metal-cougars-taste.md
+++ b/.changeset/metal-cougars-taste.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add component tokens to table and change default header background

--- a/packages/pharos/src/components/table/pharos-table.scss
+++ b/packages/pharos/src/components/table/pharos-table.scss
@@ -9,14 +9,18 @@
   border-collapse: collapse;
 
   th {
-    border: 1px solid var(--pharos-color-marble-gray-base);
+    border: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
     padding: var(--pharos-spacing-1-x);
   }
 
   td {
-    border: 1px solid var(--pharos-color-marble-gray-base);
+    border: 1px solid var(--pharos-table-body-color-border, var(--pharos-color-ui-30));
     padding: var(--pharos-spacing-1-x);
   }
+}
+
+.table-header {
+  background-color: var(--pharos-table-header-color-background, var(--pharos-color-ui-20));
 }
 
 .table-controls {

--- a/packages/pharos/src/components/table/pharos-table.ts
+++ b/packages/pharos/src/components/table/pharos-table.ts
@@ -204,7 +204,7 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
         >
           ${this.caption}
         </caption>
-        <thead>
+        <thead class="table-header">
           <tr>
             ${this._renderTableHeader()}
           </tr>

--- a/packages/pharos/tokens/components/table.json
+++ b/packages/pharos/tokens/components/table.json
@@ -1,0 +1,22 @@
+{
+	"table": {
+	  "header": {	
+		"color": {
+			"background": {
+				"value": "{color.ui.20.value}"
+			},
+			"border": {
+				"value": "{color.ui.30.value}"
+			}
+		}
+	  },
+	  "body": {
+	  	"color": {
+			"border": {
+				"value": "{color.ui.30.value}"
+			}
+		}
+	  }
+	}
+  }
+  


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Close #806 

**How does this change work?**
Adds new component level tokens for that table and updates the header to have a light gray background by default.

**Additional context**
New Default Header:

<img width="691" alt="Screenshot 2024-08-30 at 2 42 49 PM" src="https://github.com/user-attachments/assets/6e5ad7c7-5487-4237-b0fb-cf174d345ebc">
