### PR TITLE
Table: Add sticky header option

### DIFF
--- a/.changeset/fifty-icons-pretend.md
+++ b/.changeset/fifty-icons-pretend.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add sticky header option to table component. Fix bug preventing hideCaption from correctly hiding a table caption.

--- a/packages/pharos/src/components/table/PharosTable.react.stories.jsx
+++ b/packages/pharos/src/components/table/PharosTable.react.stories.jsx
@@ -50,3 +50,37 @@ export const WithPagination = {
     showPagination: true,
   },
 };
+
+export const WithHiddenCaption = {
+  render: (args) => (
+    <PharosTable
+      columns={args.columns}
+      rowData={args.rowData}
+      showPagination={args.showPagination}
+      totalResults={5}
+      pageSizeOptions={[2, 4]}
+      caption={'An example table'}
+      hideCaption={args.hideCaption}
+    ></PharosTable>
+  ),
+  args: {
+    ...defaultArgs,
+    hideCaption: true,
+  },
+};
+
+export const WithStickyHeader = {
+  render: (args) => (
+    <PharosTable
+      columns={args.columns}
+      rowData={[...args.rowData, ...args.rowData, ...args.rowData, ...args.rowData]}
+      showPagination={args.showPagination}
+      caption={'An example sticky header table'}
+      hasStickyHeader={args.hasStickyHeader}
+    ></PharosTable>
+  ),
+  args: {
+    ...defaultArgs,
+    hasStickyHeader: true,
+  },
+};

--- a/packages/pharos/src/components/table/pharos-table.scss
+++ b/packages/pharos/src/components/table/pharos-table.scss
@@ -7,20 +7,25 @@
 
 .table {
   border-collapse: collapse;
-
-  th {
-    border: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
-    padding: var(--pharos-spacing-1-x);
-  }
-
-  td {
-    border: 1px solid var(--pharos-table-body-color-border, var(--pharos-color-ui-30));
-    padding: var(--pharos-spacing-1-x);
-  }
 }
 
 .table-header {
   background-color: var(--pharos-table-header-color-background, var(--pharos-color-ui-20));
+}
+
+.table-header--has-sticky-header {
+  position: sticky;
+  top: 0;
+}
+
+.table-header__cell {
+  border: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
+  padding: var(--pharos-spacing-1-x);
+}
+
+.table-body__cell {
+  border: 1px solid var(--pharos-table-body-color-border, var(--pharos-color-ui-30));
+  padding: var(--pharos-spacing-1-x);
 }
 
 .table-controls {

--- a/packages/pharos/src/components/table/pharos-table.scss
+++ b/packages/pharos/src/components/table/pharos-table.scss
@@ -18,27 +18,27 @@
   padding: var(--pharos-spacing-1-x);
 }
 
-.table-header--has-sticky-header {
+.table-body__cell {
+  border: 1px solid var(--pharos-table-body-color-border, var(--pharos-color-ui-30));
+  padding: var(--pharos-spacing-1-x);
+}
+
+.table-sticky-header {
   position: sticky;
   top: 0;
 }
 
-.table-header--has-active-sticky-header {
+.table-sticky-header--is-active {
   box-shadow: var(--pharos-elevation-level-2);
-
-  .table-header__cell {
-    border: none;
-    border-right: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
-
-    &:last-child {
-      border-right: none;
-    }
-  }
 }
 
-.table-body__cell {
-  border: 1px solid var(--pharos-table-body-color-border, var(--pharos-color-ui-30));
-  padding: var(--pharos-spacing-1-x);
+.table-sticky-header__cell--is-active {
+  border: none;
+  border-right: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
+
+  &:last-child {
+    border-right: none;
+  }
 }
 
 .table-controls {

--- a/packages/pharos/src/components/table/pharos-table.scss
+++ b/packages/pharos/src/components/table/pharos-table.scss
@@ -13,14 +13,27 @@
   background-color: var(--pharos-table-header-color-background, var(--pharos-color-ui-20));
 }
 
+.table-header__cell {
+  border: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
+  padding: var(--pharos-spacing-1-x);
+}
+
 .table-header--has-sticky-header {
   position: sticky;
   top: 0;
 }
 
-.table-header__cell {
-  border: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
-  padding: var(--pharos-spacing-1-x);
+.table-header--has-active-sticky-header {
+  box-shadow: var(--pharos-elevation-level-2);
+
+  .table-header__cell {
+    border: none;
+    border-right: 1px solid var(--pharos-table-header-color-border, var(--pharos-color-ui-30));
+
+    &:last-child {
+      border-right: none;
+    }
+  }
 }
 
 .table-body__cell {

--- a/packages/pharos/src/components/table/pharos-table.test.ts
+++ b/packages/pharos/src/components/table/pharos-table.test.ts
@@ -181,6 +181,14 @@ describe('pharos-table', () => {
     await expect(tableCell[0].innerHTML).is.empty;
     await expect(componentWithEmptyHeaderCell).to.be.accessible();
   });
+
+  it('renders a sticky table header when has-sticky-header is set', async () => {
+    component.hasStickyHeader = true;
+    await component.updateComplete;
+
+    const headerRow = component.renderRoot.querySelector(`thead`);
+    await expect(headerRow).to.have.style('position', 'sticky');
+  });
 });
 
 it('throws an error if caption is not provided', async () => {

--- a/packages/pharos/src/components/table/pharos-table.test.ts
+++ b/packages/pharos/src/components/table/pharos-table.test.ts
@@ -185,9 +185,36 @@ describe('pharos-table', () => {
   it('renders a sticky table header when has-sticky-header is set', async () => {
     component.hasStickyHeader = true;
     await component.updateComplete;
-
     const headerRow = component.renderRoot.querySelector(`thead`);
     await expect(headerRow).to.have.style('position', 'sticky');
+  });
+
+  it('sets an active state on a sticky header when the header intersects with the table', async () => {
+    component.hasStickyHeader = true;
+    component['_toggleActiveStickyHeader'](true);
+    await component.updateComplete;
+
+    const headerRow = component.renderRoot.querySelector(`.table-sticky-header`);
+    expect(headerRow).to.have.class('table-sticky-header--is-active');
+
+    const headerCells = component.querySelectorAll('.table-sticky-header__cell');
+    headerCells.forEach((cell) => {
+      expect(cell).to.have.class('table-sticky-header__cell--is-active');
+    });
+  });
+  it('removes the active state on a sticky header when the header no longer intersects with the table', async () => {
+    component.hasStickyHeader = true;
+    component['_toggleActiveStickyHeader'](true);
+    component['_toggleActiveStickyHeader'](false);
+    await component.updateComplete;
+
+    const headerRow = component.renderRoot.querySelector(`.table-sticky-header`);
+    expect(headerRow).not.to.have.class('table-sticky-header--is-active');
+
+    const headerCells = component.querySelectorAll('.table-sticky-header__cell');
+    headerCells.forEach((cell) => {
+      expect(cell).to.have.class('table-sticky-header__cell--is-active');
+    });
   });
 });
 

--- a/packages/pharos/src/components/table/pharos-table.ts
+++ b/packages/pharos/src/components/table/pharos-table.ts
@@ -118,24 +118,38 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
     this.totalResults = !this.totalResults ? this.rowData.length : this.totalResults;
   }
 
+  private _toggleActiveStickyHeader = (active: boolean) => {
+    const ACTIVE_HEADER_CLASS = 'table-sticky-header--is-active';
+    const ACTIVE_HEADER_CELL_CLASS = 'table-sticky-header__cell--is-active';
+    const headerCells = this.header?.querySelectorAll('.table-header__cell');
+
+    if (active) {
+      this.header?.classList.add(ACTIVE_HEADER_CLASS);
+      headerCells?.forEach((cell) => {
+        cell.classList.add(ACTIVE_HEADER_CELL_CLASS);
+      });
+    } else {
+      this.header?.classList.remove(ACTIVE_HEADER_CLASS);
+      headerCells?.forEach((cell) => {
+        cell.classList.remove(ACTIVE_HEADER_CELL_CLASS);
+      });
+    }
+  };
+
   private _initHeaderObserver(): void {
-    const ACTIVE_HEADER_CLASS = 'table-header--has-active-sticky-header';
     if (!this.header) {
       throw new Error('No table header found, cannot initialize observer');
     }
+
     this.observer = new IntersectionObserver(
       (entries: IntersectionObserverEntry[]) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            this.header?.classList.add(ACTIVE_HEADER_CLASS);
-          } else {
-            this.header?.classList.remove(ACTIVE_HEADER_CLASS);
-          }
+          this._toggleActiveStickyHeader(entry.isIntersecting);
         });
       },
       {
         root: this.shadowRoot?.querySelector('.table'),
-        // Negative top rootMargin to offset the viewbox used for intersection calculations by the hight of the current header
+        // Negative top rootMargin to offset the viewbox used for intersection calculations by the height of the current header
         rootMargin: `-${this.header.getBoundingClientRect().height}px 0px 0px 0px`,
         threshold: [0.5],
       }
@@ -244,7 +258,7 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
       <table class="table">
         <caption
           class=${classMap({
-            [`visually-hidden`]: this.hideCaption,
+            ['visually-hidden']: this.hideCaption,
           })}
         >
           ${this.caption}
@@ -252,7 +266,7 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
         <thead
           class=${classMap({
             'table-header': true,
-            [`table-header--has-sticky-header`]: this.hasStickyHeader,
+            ['table-sticky-header']: this.hasStickyHeader,
           })}
         >
           <tr>

--- a/packages/pharos/src/components/table/pharos-table.ts
+++ b/packages/pharos/src/components/table/pharos-table.ts
@@ -120,9 +120,6 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
 
   private _initHeaderObserver(): void {
     const ACTIVE_HEADER_CLASS = 'table-header--has-active-sticky-header';
-    if (!this.hasStickyHeader) {
-      throw new Error('Sticky header is not enabled, cannot initialize observer');
-    }
     if (!this.header) {
       throw new Error('No table header found, cannot initialize observer');
     }

--- a/packages/pharos/src/components/table/pharos-table.ts
+++ b/packages/pharos/src/components/table/pharos-table.ts
@@ -198,9 +198,9 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
     return html`
       <table class="table">
         <caption
-          class="${classMap({
+          class=${classMap({
             [`visually-hidden`]: this.hideCaption,
-          })}"
+          })}
         >
           ${this.caption}
         </caption>

--- a/packages/pharos/src/components/table/pharos-table.ts
+++ b/packages/pharos/src/components/table/pharos-table.ts
@@ -81,8 +81,11 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
   @property({ type: String, reflect: true, attribute: 'caption' })
   public caption: string = '';
 
-  @property({ type: String, reflect: true, attribute: 'hide-caption' })
+  @property({ type: Boolean, reflect: true, attribute: 'hide-caption' })
   public hideCaption: boolean = false;
+
+  @property({ type: Boolean, reflect: true, attribute: 'has-sticky-header' })
+  public hasStickyHeader: boolean = false;
 
   @state()
   private _pageSize = 50;
@@ -134,9 +137,9 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
   private _renderTableHeader(): (TemplateResult | undefined)[] {
     return this.columns.map((column: ColumnSpecification) => {
       if (column.name) {
-        return html`<th scope="col">${column.name}</th>`;
+        return html`<th scope="col" class="table-header__cell">${column.name}</th>`;
       } else {
-        return html`<td></td>`;
+        return html`<td class="table-header__cell"></td>`;
       }
     });
   }
@@ -149,7 +152,7 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
     return currentDisplayingData.map((row: RowData) => {
       const arr: TemplateResult[] = [];
       this.columns.forEach((column: ColumnSpecification) => {
-        arr.push(html`<td>${row[column.field]}</td>`);
+        arr.push(html`<td class="table-body__cell">${row[column.field]}</td>`);
       });
       return html`<tr>
         ${arr}
@@ -204,7 +207,12 @@ export class PharosTable extends ScopedRegistryMixin(PharosElement) {
         >
           ${this.caption}
         </caption>
-        <thead class="table-header">
+        <thead
+          class=${classMap({
+            'table-header': true,
+            [`table-header--has-sticky-header`]: this.hasStickyHeader,
+          })}
+        >
           <tr>
             ${this._renderTableHeader()}
           </tr>

--- a/packages/pharos/src/components/table/pharos-table.wc.stories.jsx
+++ b/packages/pharos/src/components/table/pharos-table.wc.stories.jsx
@@ -27,6 +27,23 @@ export const Base = {
   },
 };
 
+export const WithPagination = {
+  render: ({ columns, rowData, showPagination }) => html`
+    <storybook-pharos-table
+      .columns="${columns}"
+      .rowData="${rowData}"
+      .showPagination="${showPagination}"
+      .totalResults="${5}"
+      .pageSizeOptions="${[2, 4]}"
+      caption="An example table"
+    />
+  `,
+  args: {
+    ...defaultArgs,
+    showPagination: true,
+  },
+};
+
 export const WithHiddenCaption = {
   render: ({ columns, rowData, showPagination }) => html`
     <storybook-pharos-table
@@ -43,15 +60,13 @@ export const WithHiddenCaption = {
   },
 };
 
-export const WithPagination = {
-  render: ({ columns, rowData, showPagination }) => html`
+export const WithStickyHeader = {
+  render: ({ columns, rowData }) => html`
     <storybook-pharos-table
       .columns="${columns}"
-      .rowData="${rowData}"
-      .showPagination="${showPagination}"
-      .totalResults="${5}"
-      .pageSizeOptions="${[2, 4]}"
-      caption="An example table"
+      .rowData="${[...rowData, ...rowData, ...rowData, ...rowData]}"
+      .hasStickyHeader="${true}"
+      caption="A sticky header example"
     />
   `,
   args: {

--- a/packages/pharos/src/components/table/pharos-table.wc.stories.jsx
+++ b/packages/pharos/src/components/table/pharos-table.wc.stories.jsx
@@ -27,6 +27,22 @@ export const Base = {
   },
 };
 
+export const WithHiddenCaption = {
+  render: ({ columns, rowData, showPagination }) => html`
+    <storybook-pharos-table
+      .columns="${columns}"
+      .rowData="${rowData}"
+      .showPagination="${showPagination}"
+      caption="An example table"
+      .hideCaption="${true}"
+    />
+  `,
+  args: {
+    ...defaultArgs,
+    showPagination: false,
+  },
+};
+
 export const WithPagination = {
   render: ({ columns, rowData, showPagination }) => html`
     <storybook-pharos-table


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [x] Component status page up to date?

**What does this change address?**
Closes #805 
Also closes #802 

**How does this change work?**
Adds a `hasStickyHeader` property to the table component which sets `position:sticky` on the `thead` element and keeps it visible when the table is scrolled. 

Once the table is scrolled past the header (so the stickiness will display it over the table) a `table-header--has-active-sticky-header` class will toggle from an IntersectionObserver to set an elevation so it is more visually evident is it displaying over the content. 

**Additional context**
❤️  Shoutout to @daneah @elisa-vargas @jialin-he for working together on this at the working session last week!

Because it needed to use similar logic to conditionally set a class name as `hideCaption` we updated that logic to close #802 once we got it working. (classMap shouldn't be inside quotes)

I also updated the property annotation of the `hideCaption` to be a Boolean instead of a string (it is actually a boolean) - I don't think this should cause any problems, but want to call it out to verify my understanding of that.

