### PR TITLE
chore(infra): add dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      non-major:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    ignore:
+      # ithaka/pharos#745
+      - dependency-name: '@lit-labs/scoped-registry-mixin'
+      - dependency-name: '@webcomponents/scoped-custom-element-registry'
+
+      # ithaka/pharos#634
+      - dependency-name: 'lit'
+        update-types:
+          - 'version-update:semver-major'
+
+      # ithaka/pharos#780
+      - dependency-name: 'style-dictionary'
+        update-types:
+          - 'version-update:semver-major'


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Resolves #751

We have been manually and sporadically updating dependencies, which is tedious and time consuming. This will reduce effort by presenting sets of package changes that will automatically be checked, which make them easy enough to accept or deny. I've included a few known challenging packages in the `ignore` though I suspect there might be others occasionally. We should prefer to fix the PR up so that the code meets the dependency updates, rather than excluding updates, when possible.