### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pharos
+  description: Auto-generated catalog-info.yaml.
+  tags:
+  - typescript
+  - javascript
+  - scss
+  - css
+  - html
+  - mdx
+  - shell
+spec:
+  type: unknown
+  owner: group:ui-engineering
+  lifecycle: unknown


### PR DESCRIPTION
This PR adds a `catalog-info.yaml` file to Backstage when merged. If your repo is GitHub Only, this will not be picked up Backstage presently.