### PR TITLE
Remove tabindex from Alert component

### DIFF
--- a/.changeset/dark-mails-joke.md
+++ b/.changeset/dark-mails-joke.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Remove tabindex from alert component

--- a/packages/pharos/src/components/alert/pharos-alert.test.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.test.ts
@@ -33,7 +33,6 @@ describe('pharos-alert', () => {
       <div
         class="alert alert--info"
         role="alert"
-        tabindex="0"
       >
         <pharos-icon
           class="alert__icon"
@@ -56,20 +55,6 @@ describe('pharos-alert', () => {
     `).catch((e) => e);
     expect('fake is not a valid status. Valid statuses are: info, success, warning, error').to.be
       .thrown;
-  });
-
-  it('is able to delegate focus', async () => {
-    let activeElement = null;
-    const onFocusIn = (event: Event): void => {
-      activeElement = event.composedPath()[0];
-    };
-    document.addEventListener('focusin', onFocusIn);
-    const alert = component.renderRoot.querySelector('.alert');
-
-    component.focus();
-
-    expect(activeElement === alert).to.be.true;
-    document.removeEventListener('focusin', onFocusIn);
   });
 
   it('adds a class to slotted links', async () => {

--- a/packages/pharos/src/components/alert/pharos-alert.ts
+++ b/packages/pharos/src/components/alert/pharos-alert.ts
@@ -130,7 +130,6 @@ export class PharosAlert extends ScopedRegistryMixin(FocusMixin(PharosElement)) 
           [`alert--${this.status}`]: this.status || '',
           [`alert--closable`]: this.closable,
         })}"
-        tabindex="0"
       >
         <pharos-icon class="alert__icon" name="${this._getIcon()}" a11y-hidden="true"></pharos-icon>
         <div class="alert__body">


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [ ] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**
This is referenced in #900 that we don't need to have the alert container be in the keyboard focus order, only interactive elements should. This adds an extra tab stop to the page and could confuse assistive tech users thinking that what they've tabbed to is something interactive and attempt to activate it. When nothing happens, this could lead to confusion and increased cognitive load.

**How does this change work?**
Removed `tabindex="0"` from the alert component.

**Additional context**
[How to Use ARIA Alert Effectively](https://www.a11y-collective.com/blog/aria-alert/)
