### PR TITLE
fix(tabs): ensure that parent tabs don't handle nested child tab clicked accidentally

### DIFF
--- a/.changeset/fresh-bars-talk.md
+++ b/.changeset/fresh-bars-talk.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Ensure that parent tabs don't handle nested child tab clicks accidentally

--- a/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
+++ b/packages/pharos/src/components/tabs/PharosTabs.react.stories.jsx
@@ -37,7 +37,20 @@ export const Base = {
         Panel 1
       </PharosTabPanel>
       <PharosTabPanel id="panel-2" slot="panel">
-        Panel 2
+        <PharosTabs>
+          <PharosTab id="tab-2-1" data-panel-id="panel-2-1">
+            Nested tab 1
+          </PharosTab>
+          <PharosTab id="tab-2-2" data-panel-id="panel-2-2">
+            Nested tab 2
+          </PharosTab>
+          <PharosTabPanel id="panel-2-1" slot="panel">
+            Nested panel 1
+          </PharosTabPanel>
+          <PharosTabPanel id="panel-2-2" slot="panel">
+            Nested panel 2
+          </PharosTabPanel>
+        </PharosTabs>
       </PharosTabPanel>
       <PharosTabPanel id="panel-3" slot="panel">
         Panel 3

--- a/packages/pharos/src/components/tabs/pharos-tabs.test.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.test.ts
@@ -6,7 +6,9 @@ import type { PharosTab } from './pharos-tab';
 import type { PharosTabPanel } from './pharos-tab-panel';
 
 describe('pharos-tabs', () => {
-  let component: PharosTabs, componentLastTabSelected: PharosTabs;
+  let component: PharosTabs,
+    componentLastTabSelected: PharosTabs,
+    componentWithNestedTabs: PharosTabs;
 
   beforeEach(async () => {
     component = await fixture(html`
@@ -28,6 +30,28 @@ describe('pharos-tabs', () => {
         <test-pharos-tab-panel id="panel-4" slot="panel">Panel 1</test-pharos-tab-panel>
         <test-pharos-tab-panel id="panel-5" slot="panel">Panel 2</test-pharos-tab-panel>
         <test-pharos-tab-panel id="panel-6" slot="panel">Panel 3</test-pharos-tab-panel>
+      </test-pharos-tabs>
+    `);
+
+    componentWithNestedTabs = await fixture(html`
+      <test-pharos-tabs>
+        <test-pharos-tab id="tab-1" data-panel-id="panel-1">Tab 1</test-pharos-tab>
+        <test-pharos-tab id="tab-2" data-panel-id="panel-2">
+          <test-pharos-tabs>
+            <test-pharos-tab id="tab-2-1" data-panel-id="panel-2-1">Nested tab 1</test-pharos-tab>
+            <test-pharos-tab id="tab-2-2" data-panel-id="panel-2-2">Nested tab 2</test-pharos-tab>
+            <test-pharos-tab-panel id="panel-2-1" slot="panel"
+              >Nested panel 1</test-pharos-tab-panel
+            >
+            <test-pharos-tab-panel id="panel-2-2" slot="panel"
+              >Nested panel 2</test-pharos-tab-panel
+            >
+          </test-pharos-tabs>
+        </test-pharos-tab>
+        <test-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</test-pharos-tab>
+        <test-pharos-tab-panel id="panel-1" slot="panel">Panel 1</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-2" slot="panel">Panel 2</test-pharos-tab-panel>
+        <test-pharos-tab-panel id="panel-3" slot="panel">Panel 3</test-pharos-tab-panel>
       </test-pharos-tabs>
     `);
   });
@@ -175,6 +199,27 @@ describe('pharos-tabs', () => {
     expect(tabs[0].selected).to.be.false;
     expect(tabs[1].selected).to.be.true;
     expect(tabs[2].selected).to.be.false;
+  });
+
+  it('changes only the selected nested tab on click', async () => {
+    const topLevelTabs = Array.prototype.slice.call(
+      componentWithNestedTabs.querySelectorAll(`test-pharos-tab`)
+    ) as PharosTab[];
+
+    const nestedTabs = Array.prototype.slice.call(
+      topLevelTabs[1].querySelectorAll(`test-pharos-tab`)
+    ) as PharosTab[];
+
+    topLevelTabs[1].click();
+    nestedTabs[1].click();
+    await component.updateComplete;
+    await aTimeout(1);
+
+    expect(topLevelTabs[0].selected).to.be.false;
+    expect(topLevelTabs[1].selected).to.be.true;
+    expect(topLevelTabs[2].selected).to.be.false;
+    expect(nestedTabs[0].selected).to.be.false;
+    expect(nestedTabs[1].selected).to.be.true;
   });
 
   it('shows the first panel by default', async () => {

--- a/packages/pharos/src/components/tabs/pharos-tabs.ts
+++ b/packages/pharos/src/components/tabs/pharos-tabs.ts
@@ -55,9 +55,11 @@ export class PharosTabs extends PharosElement {
   }
 
   protected override async firstUpdated(): Promise<void> {
-    this.addEventListener('pharos-tab-selected', (e) =>
-      this._handleTabSelected(e.target as PharosTab)
-    );
+    this.addEventListener('pharos-tab-selected', (e) => {
+      if (Array.from(this._tabs).includes(e.target as PharosTab)) {
+        this._handleTabSelected(e.target as PharosTab);
+      }
+    });
     this.addEventListener('keydown', this._handleKeydown);
     this.addEventListener('focusout', this._handleFocusout);
 

--- a/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
+++ b/packages/pharos/src/components/tabs/pharos-tabs.wc.stories.jsx
@@ -20,7 +20,22 @@ export const Base = {
       <storybook-pharos-tab id="tab-2" data-panel-id="panel-2">Tab 2</storybook-pharos-tab>
       <storybook-pharos-tab id="tab-3" data-panel-id="panel-3">Tab 3</storybook-pharos-tab>
       <storybook-pharos-tab-panel id="panel-1" slot="panel">Panel 1</storybook-pharos-tab-panel>
-      <storybook-pharos-tab-panel id="panel-2" slot="panel">Panel 2</storybook-pharos-tab-panel>
+      <storybook-pharos-tab-panel id="panel-2" slot="panel">
+        <storybook-pharos-tabs>
+          <storybook-pharos-tab id="tab-2-1" data-panel-id="panel-2-1"
+            >Nested tab 1</storybook-pharos-tab
+          >
+          <storybook-pharos-tab id="tab-2-2" data-panel-id="panel-2-2"
+            >Nested tab 2</storybook-pharos-tab
+          >
+          <storybook-pharos-tab-panel id="panel-2-1" slot="panel"
+            >Nested panel 1</storybook-pharos-tab-panel
+          >
+          <storybook-pharos-tab-panel id="panel-2-2" slot="panel"
+            >Nested panel 2</storybook-pharos-tab-panel
+          >
+        </storybook-pharos-tabs>
+      </storybook-pharos-tab-panel>
       <storybook-pharos-tab-panel id="panel-3" slot="panel">Panel 3</storybook-pharos-tab-panel>
     </storybook-pharos-tabs>
   `,


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

When a tab panel itself contained a set of tabs, clicks on any of the nested tabs would result in the parent set of tabs trying to handle the click in addition to the nested tabs trying to handle the click, resulting in an empty display due to the parent not being able to find the clicked tab in its set of tabs.

**How does this change work?**

When setting up event listeners in `firstUpdated`, ensure that tabs being listened to are in `this`'s set of tabs.