### PR TITLE
fix(tests): update browser start timeout to 60s

### DIFF
--- a/packages/pharos/web-test-runner.config.mjs
+++ b/packages/pharos/web-test-runner.config.mjs
@@ -7,6 +7,7 @@ export default {
   nodeResolve: true,
   concurrentBrowsers: 3,
   coverage: true,
+  browserStartTimeout: 60000,
   testsStartTimeout: 45000,
   coverageConfig: {
     threshold: {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

On Actions runs for tests, WTR will frequently fail to start a browser in the given default 30s. Even though the tests all pass, the overall run fails due to this timeout.