### PR TITLE
chore: update build target to es2022

### DIFF
--- a/.changeset/funny-hotels-fold.md
+++ b/.changeset/funny-hotels-fold.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Update build target to es2022

--- a/packages/pharos-cli/tsconfig.json
+++ b/packages/pharos-cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "es2021",
+    "target": "es2022",
     "module": "commonjs",
     "strict": true,
     "allowJs": true,

--- a/packages/pharos-site/babel.config.js
+++ b/packages/pharos-site/babel.config.js
@@ -3,6 +3,7 @@ module.exports = {
   plugins: [
     '@babel/plugin-transform-shorthand-properties',
     '@babel/plugin-transform-block-scoping',
+    '@babel/plugin-transform-class-static-block',
     ['@babel/plugin-proposal-decorators', { decoratorsBeforeExport: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-transform-private-methods', { loose: true }],

--- a/packages/pharos-site/tsconfig.json
+++ b/packages/pharos-site/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2021",
+    "target": "es2022",
     "module": "es2022",
-    "lib": ["es2021", "dom", "dom.iterable", "esnext.array"],
+    "lib": ["es2022", "dom", "dom.iterable", "esnext.array"],
     "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,

--- a/packages/pharos/tsconfig.json
+++ b/packages/pharos/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2021",
+    "target": "es2022",
     "module": "es2022",
     "lib": ["es2021", "dom", "dom.iterable"],
     "jsx": "react-jsx",

--- a/packages/pharos/tsconfig.json
+++ b/packages/pharos/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "es2022",
-    "lib": ["es2021", "dom", "dom.iterable"],
+    "lib": ["es2022", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No (it may break JavaScript behavior in some older browsers, but not any APIs)

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**Additional context**

See [caniuse](https://caniuse.com/?feats=mdn-javascript_builtins_array_at,mdn-javascript_builtins_regexp_hasindices,mdn-javascript_builtins_object_hasown,mdn-javascript_builtins_error_cause,mdn-javascript_operators_await_top_level,mdn-javascript_classes_private_class_fields,mdn-javascript_classes_private_class_methods,mdn-javascript_classes_static_class_fields,mdn-javascript_classes_static_initialization_blocks)