### PR TITLE
Revert to targeting es2021 when compiling TypeScript

### DIFF
--- a/.changeset/public-teeth-hope.md
+++ b/.changeset/public-teeth-hope.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Revert update to target es2022 when compiling

--- a/packages/pharos-cli/tsconfig.json
+++ b/packages/pharos-cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "es2022",
+    "target": "es2021",
     "module": "commonjs",
     "strict": true,
     "allowJs": true,

--- a/packages/pharos-site/babel.config.js
+++ b/packages/pharos-site/babel.config.js
@@ -3,7 +3,6 @@ module.exports = {
   plugins: [
     '@babel/plugin-transform-shorthand-properties',
     '@babel/plugin-transform-block-scoping',
-    '@babel/plugin-transform-class-static-block',
     ['@babel/plugin-proposal-decorators', { decoratorsBeforeExport: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-transform-private-methods', { loose: true }],

--- a/packages/pharos-site/tsconfig.json
+++ b/packages/pharos-site/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2021",
     "module": "es2022",
-    "lib": ["es2022", "dom", "dom.iterable", "esnext.array"],
+    "lib": ["es2021", "dom", "dom.iterable", "esnext.array"],
     "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,

--- a/packages/pharos/tsconfig.json
+++ b/packages/pharos/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "es2021",
     "module": "es2022",
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": ["es2021", "dom", "dom.iterable"],
     "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [x] Component status page up to date?

**What does this change address?**
In #925 we updated TypeScript to compile to `es2022` instead of `es2021`. While global support suggested this was a safe switch we are finding we are getting more error reports than we had hoped for, specifically users on older safari versions. So we are rolling it back for now, we can revisit it again after some time has passed. 

**How does this change work?**
Reverts the changes to tsconfig to bump the build version

