### PR TITLE
Fix the global colors design token page

### DIFF
--- a/.changeset/ten-pigs-train.md
+++ b/.changeset/ten-pigs-train.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+Fix global color token page not displaying all tokens

--- a/packages/pharos-site/src/pages/design-tokens/global-colors.tsx
+++ b/packages/pharos-site/src/pages/design-tokens/global-colors.tsx
@@ -5,23 +5,17 @@ import { ColorHead } from '../../components/statics/design-token/ColorHead';
 import PageSection from '../../components/statics/PageSection';
 import { FC } from 'react';
 
-{
-  /* TODO: doess this work? */
-}
 export let colorTokens = Object.keys(tokens.color)
   .filter((key) => key !== 'brand' && key !== 'base')
-  .map((key) => {
-    const currentToken = tokens.color[key];
+  .flatMap((key) => {
+    const currentToken = tokens.color[key] as Record<string, any>;
     if (currentToken.value) {
-      return currentToken;
+      return [currentToken];
     } else {
-      let childTokens = [];
-      Object.keys(currentToken).map((k) => {
-        if (currentToken[k].value) {
-          childTokens.push(currentToken[k]);
-        }
-      });
-      return childTokens;
+      return Object.keys(currentToken)
+        .filter((k) => k !== 'brand' && k !== 'base')
+        .map((k) => currentToken[k])
+        .filter((token) => token.value);
     }
   });
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
Fixes #980 

**How does this change work?**
The `grayscale` `tint` and `feedback` color tokens were not being displayed in the global colors page. The issue was that the array that was being made from the tokens wasn't being flattened properly, making those groups return an empty array.