### PR TITLE
Remove console.log from multiselect-dropdown click handler

### DIFF
--- a/.changeset/plenty-grapes-remain.md
+++ b/.changeset/plenty-grapes-remain.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Remove console log from multiselect-dropdown on click handler

--- a/packages/pharos/src/components/multiselect-dropdown/pharos-multiselect-dropdown.ts
+++ b/packages/pharos/src/components/multiselect-dropdown/pharos-multiselect-dropdown.ts
@@ -215,7 +215,6 @@ export class PharosMultiselectDropdown extends ScopedRegistryMixin(FormMixin(For
   }
 
   private _handleOptionClick(option: HTMLOptionElement, event: Event): void {
-    console.log('Option clicked:', option);
     if (option.disabled) {
       event.preventDefault();
       return;


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?
- [X] Component status page up to date?

**What does this change address?**
There is currently a console.log logging what option was clicked in the click handler of the multiselect-dropdown component

**How does this change work?**
It removes the console.log

**Additional context**
It's me, hi, I'm the problem, it's me