### PR TITLE
Multiselect-dropdown: align token names with compnent name

### DIFF
--- a/.changeset/lazy-files-hang.md
+++ b/.changeset/lazy-files-hang.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix multiselect dropdown token names to match component name

--- a/packages/pharos/src/components/multiselect-dropdown/pharos-multiselect-dropdown.scss
+++ b/packages/pharos/src/components/multiselect-dropdown/pharos-multiselect-dropdown.scss
@@ -1,7 +1,7 @@
 @use '../../utils/scss/mixins';
 
 @mixin selected-text {
-  color: var(--pharos-dropdown-multiselect-color-text-selected);
+  color: var(--pharos-multiselect-dropdown-color-text-selected);
   font-weight: var(--pharos-font-weight-bold);
 }
 
@@ -15,7 +15,7 @@
 }
 
 .multiselect-dropdown__icon {
-  fill: var(--pharos-dropdown-multiselect-color-icon-dropdown);
+  fill: var(--pharos-multiselect-dropdown-color-icon-dropdown);
 }
 
 .multiselect-dropdown__button {
@@ -82,14 +82,14 @@
   &:hover,
   &[highlighted] {
     background-color: var(--pharos-color-ui-20);
-    color: var(--pharos-dropdown-multiselect-color-text-hover);
+    color: var(--pharos-multiselect-dropdown-color-text-hover);
 
     .multiselect-dropdown__option-label {
-      color: var(--pharos-dropdown-multiselect-color-text-hover);
+      color: var(--pharos-multiselect-dropdown-color-text-hover);
     }
 
     .multiselect-dropdown__mark {
-      color: var(--pharos-dropdown-multiselect-color-text-hover);
+      color: var(--pharos-multiselect-dropdown-color-text-hover);
     }
   }
 }
@@ -118,7 +118,7 @@
 .multiselect-dropdown__list {
   @include mixins.font-base;
 
-  max-height: var(--pharos-dropdown-multiselect-size-height-list);
+  max-height: var(--pharos-multiselect-dropdown-size-height-list);
   overflow-y: scroll;
   z-index: 1;
   box-sizing: content-box;

--- a/packages/pharos/tokens/components/dropdown-multiselect.json
+++ b/packages/pharos/tokens/components/dropdown-multiselect.json
@@ -1,5 +1,5 @@
 {
-  "dropdown-multiselect": {
+  "multiselect-dropdown": {
     "color": {
       "text": {
         "hover": {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?
- [x] Component status page up to date?

**What does this change address?**
I noticed while working on something else the tokens for the multiselect dropdown
are named `dropdown-multiselect` instead of `multiselect-dropdown` like they should be, making them harder to find when you are looking for them

**How does this change work?**
Updates the token names and corresponding scss to use the correct component name

