### PR TITLE
chore: add homepage URL to package.json

### DIFF
--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -54,6 +54,7 @@
   },
   "author": "ITHAKA",
   "license": "MIT",
+  "homepage": "https://pharos.jstor.org",
   "dependencies": {
     "@floating-ui/dom": "^1.7.2",
     "@ithaka/focus-trap": "2.0.1",


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [x] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?
- [ ] Component status page up to date?

**What does this change address?**

Systems like NPM and other peripheral sites can display the URL for a package. In the absence of `homepage`, systems usually choose something like a direct link to the README on GitHub.

**How does this change work?**

Add a `homepage` key whose value points at [the Pharos site](https://pharos.jstor.org).