### PR TITLE
Add ability to manually trigger Chromatic jobs for any PR

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,16 +10,30 @@ on:
       - '.github/workflows/chromatic.yml'
     branches-ignore:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to run Chromatic on'
+        required: true
+        type: string
 
 jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
+      - name: Checkout Repo (Push)
+        if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout Repo (Manual Dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [X] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [ ] Changeset added?
- [] Component status page up to date?

**What does this change address?**
When a PR is opened from a fork, the Chromatic jobs are not triggered. They are currently configured to only run on push events. We don't really want to open it up for running on every PR since anyone can create one at any time and there is some possibility for malicious intent. However, for legitimate contributions (#1028)  it would be nice to manually trigger a run.

**How does this change work?**
This adds the ability to manually trigger a Chromatic build via the GitHub Actions tab by inputting the PR number.

**Additional context**
Open to other thoughts/ideas, I'm not the GitHub Actions expert, so just trying something out 😄 
