### PR TITLE
Updating yarn.lock with latest release version of Pharos for Pharos site

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3591,7 +3591,7 @@ __metadata:
     "@babel/core": "npm:^7.28.0"
     "@babel/plugin-proposal-object-rest-spread": "npm:^7.20.7"
     "@babel/plugin-transform-private-methods": "npm:^7.27.1"
-    "@ithaka/pharos": "npm:^14.16.1"
+    "@ithaka/pharos": "npm:^14.17.0"
     "@reach/router": "npm:^1.3.4"
     "@types/babel__core": "npm:^7.20.5"
     "@types/culori": "npm:^4"
@@ -3624,7 +3624,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ithaka/pharos@npm:^14.16.1, @ithaka/pharos@workspace:packages/pharos":
+"@ithaka/pharos@npm:^14.17.0, @ithaka/pharos@workspace:packages/pharos":
   version: 0.0.0-use.local
   resolution: "@ithaka/pharos@workspace:packages/pharos"
   dependencies:


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [x] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Running into issues with release when Pharos site is trying to update to new release of Pharos but yarn.lock does not like that, see https://github.com/ithaka/pharos/issues/709#issuecomment-2450627968 

**How does this change work?**
Ran `yarn install` locally and pushing changes to `yarn.lock` file.

**Additional context**
Add any other context here.
