### PR TITLE
feat(dropdown-menu): Removing dropdown menu yOffset

### DIFF
--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu.ts
@@ -243,7 +243,6 @@ export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayEl
   }
 
   private _setupMenu(): void {
-    const yOffset = this._navMenu ? 0 : 8;
     const placement = this.placement === 'auto' ? 'bottom-start' : this.placement;
     if (this._currentTrigger) {
       this._cleanup = autoUpdate(this._currentTrigger, this, () => {
@@ -252,7 +251,6 @@ export class PharosDropdownMenu extends ScopedRegistryMixin(FocusMixin(OverlayEl
             placement: this._navMenu ? 'bottom-start' : placement,
             strategy: this.strategy,
             middleware: [
-              offset(yOffset),
               flip({
                 fallbackPlacements: this._filteredFallbackPlacements,
               }),


### PR DESCRIPTION
**This change:** (check at least one)

- [x] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Removing the offset for dropdown menu for aesthetics and if your mouse hovers the gap, it also can close the menu.

**How does this change work?**
Removes the offset.
