### PR TITLE
Replace image card error state icon with new svg

### DIFF
--- a/.changeset/petite-beers-punch.md
+++ b/.changeset/petite-beers-punch.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Replace exclamation icon on image card error state with a new svg, removed associated error state text

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -360,15 +360,13 @@ describe('pharos-image-card', () => {
     expect(sourceType).not.to.be.null;
   });
 
-  it('renders an exclamation icon in the error state for collection variant', async () => {
+  it('renders an svg in the error state for collection variant', async () => {
     component.variant = 'collection';
     component.error = true;
     await component.updateComplete;
 
-    const icon = component.renderRoot.querySelector(
-      '[data-pharos-component="PharosIcon"][name="exclamation-inverse"]'
-    );
-    expect(icon).not.to.be.null;
+    const svg = component.renderRoot.querySelector('svg');
+    expect(svg).not.to.be.null;
   });
 
   it('renders a checkbox for the selectable variant', async () => {

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -233,8 +233,47 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       ? html`
           <div class="card__image--collection-container">
             <div class="card__image--collection--error">
-              <pharos-icon name="exclamation-inverse" a11y-hidden="true"></pharos-icon>
-              <span class="unavailable-text">Image preview not available</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="73"
+                height="65"
+                viewBox="0 0 73 65"
+                fill="none"
+              >
+                <title>Image preview not available</title>
+                <rect
+                  y="24.882"
+                  width="42"
+                  height="42"
+                  transform="rotate(-19.9519 0 24.882)"
+                  fill="#D1CFC7"
+                />
+                <rect
+                  x="30.5576"
+                  y="4"
+                  width="39.6944"
+                  height="40.8625"
+                  transform="rotate(20.871 30.5576 4)"
+                  fill="white"
+                />
+                <rect
+                  x="29"
+                  width="46.235"
+                  height="45.5793"
+                  transform="rotate(20.871 29 0)"
+                  fill="white"
+                />
+                <path
+                  d="M50.9424 44.2752L46.6176 25.4893L39.0461 30.6573L37.9063 27.3458L26.0366 34.7459L50.9424 44.2752Z"
+                  fill="#D1CFC7"
+                />
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M69.8494 17.2469L30 2L14.7531 41.8494L54.6025 57.0963L69.8494 17.2469ZM21.6401 38.7741L33.0753 8.88704L62.9624 20.3222L51.5272 50.2093L21.6401 38.7741Z"
+                  fill="#D1CFC7"
+                />
+              </svg>
             </div>
           </div>
         `


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Is the:** (complete all)

- [ ] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
closes #774 

Replaces the exclamation icon and associated text for a new placeholder svg.

**How does this change work?**
Replaces the exclamation icon and associated text for a new placeholder svg.
