### PR TITLE
chore(infra): bump Chromatic action version

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -65,7 +65,7 @@ jobs:
         run: yarn storybook:wc:build
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@v13
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**

We appear to be quite behind on the Chromatic action version. I was made aware of this as a recent build in Chromatic started displaying the following warning message:

> This build was created using Chromatic CLI version 11.27.0, which is
> significantly outdated. Please upgrade your chromatic dependency.

**How does this change work?**

This change should start using a newer version of the Chromatic CLI by using a new Actions version. To be clear, it seems we're bumping from v11.27.0 to v13.X.Y, despite the Actions tag being just `v1`.

I opted not to use `latest` for some buffer against breaking changes.
