### PR TITLE
Fix broken storybook link from the pharos site homepage

### DIFF
--- a/.changeset/soft-cobras-live.md
+++ b/.changeset/soft-cobras-live.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos-site': patch
+---
+
+Add redirect to fix link to hosted storybook instance

--- a/packages/pharos-site/gatsby-node.js
+++ b/packages/pharos-site/gatsby-node.js
@@ -1,3 +1,14 @@
+exports.createPages = async ({ actions }) => {
+  const { createRedirect } = actions;
+
+  createRedirect({
+    fromPath: '/storybook',
+    toPath: '/storybook/',
+    isPermanent: true,
+    redirectInBrowser: true,
+  });
+};
+
 exports.onCreateWebpackConfig = ({ getConfig, stage, actions, plugins }) => {
   if (stage === 'build-javascript') {
     const currentConfig = getConfig();


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [X] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?

**What does this change address?**
Currently the link to storybook from the pharos.jstor.org site is broken - it goes to https://pharos.jstor.org/storybook instead of https://pharos.jstor.org/storybook/ (missing trailing slash). This adds a redirect from `/storybook` to `/storybook/` so the link will work.

**How does this change work?**
We are linking to it using the Gatsby navigate command, which was stripping the trailing slash. Stripping the trailing slash is a global setting in Gatsby, this adds a redirect in gatsby-node.js to handle this specific case while still stripping the other trailing slashes as desired.

**Additional context**

