### PR TITLE
Revert "docs: fix storybook link from pharos site (#1086)"

### DIFF
--- a/.changeset/soft-cobras-live.md
+++ b/.changeset/soft-cobras-live.md
@@ -1,5 +1,0 @@
----
-'@ithaka/pharos-site': patch
----
-
-Add redirect to fix link to hosted storybook instance

--- a/packages/pharos-site/gatsby-node.js
+++ b/packages/pharos-site/gatsby-node.js
@@ -1,14 +1,3 @@
-exports.createPages = async ({ actions }) => {
-  const { createRedirect } = actions;
-
-  createRedirect({
-    fromPath: '/storybook',
-    toPath: '/storybook/',
-    isPermanent: true,
-    redirectInBrowser: true,
-  });
-};
-
 exports.onCreateWebpackConfig = ({ getConfig, stage, actions, plugins }) => {
   if (stage === 'build-javascript') {
     const currentConfig = getConfig();


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?

**What does this change address?**
Revert #1086

**How does this change work?**
Reverts a recent change meant to fix a link in the Pharos docs actually broke it more, making storybook totally unavailable. Reverting for now so I can take a look at it again, but have storybook up in the meantime.
