### PR TITLE
Add shared utitlity to centralize highlighting logic

### DIFF
--- a/.changeset/petite-doodles-happen.md
+++ b/.changeset/petite-doodles-happen.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Add shared helper to centralize text highlighting logic across components

--- a/packages/pharos/src/components/combobox/pharos-combobox.ts
+++ b/packages/pharos/src/components/combobox/pharos-combobox.ts
@@ -3,9 +3,9 @@ import { property, query, state } from 'lit/decorators.js';
 import type { PropertyValues, TemplateResult, CSSResultArray } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { comboboxStyles } from './pharos-combobox.css';
 import debounce from '../../utils/debounce';
+import { highlightTextMatches } from '../../utils/highlightTextMatches';
 
 import { FormElement } from '../base/form-element';
 import FormMixin from '../../utils/mixins/form';
@@ -186,16 +186,14 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
             ? matchingOptions.map((child, index) => {
                 const option = child as HTMLOptionElement;
                 const exactMatch = this.value === option.value;
+                const highlightClass = exactMatch
+                  ? 'combobox__mark combobox__mark--selected'
+                  : 'combobox__mark';
 
-                const optionText = this._query
-                  ? option.text.replace(regex, (str) => {
-                      const classes = exactMatch
-                        ? 'combobox__mark combobox__mark--selected'
-                        : 'combobox__mark';
-
-                      return this.searchMode ? `${str}` : `<mark class=${classes}>${str}</mark>`;
-                    })
-                  : option.text;
+                const optionText =
+                  this._query && !this.searchMode
+                    ? highlightTextMatches(option.text, regex, highlightClass)
+                    : document.createTextNode(option.text);
 
                 return html`
                   <li
@@ -214,7 +212,7 @@ export class PharosCombobox extends ScopedRegistryMixin(FormMixin(FormElement)) 
                       event.preventDefault();
                     }}
                   >
-                    ${unsafeHTML(optionText)}
+                    ${optionText}
                     ${exactMatch && !this.searchMode
                       ? html`
                           <pharos-icon

--- a/packages/pharos/src/components/multiselect-dropdown/pharos-multiselect-dropdown.ts
+++ b/packages/pharos/src/components/multiselect-dropdown/pharos-multiselect-dropdown.ts
@@ -3,9 +3,9 @@ import { property, query, state } from 'lit/decorators.js';
 import type { TemplateResult, CSSResultArray } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import { multiselectDropdownStyles } from './pharos-multiselect-dropdown.css';
+import { highlightTextMatches } from '../../utils/highlightTextMatches';
 
 import { FormElement } from '../base/form-element';
 import FormMixin from '../../utils/mixins/form';
@@ -544,16 +544,13 @@ export class PharosMultiselectDropdown extends ScopedRegistryMixin(FormMixin(For
               ? this._matchingOptions.map((child, index) => {
                   const option = child as HTMLOptionElement;
                   const exactMatch = this._searchValue === option.value;
+                  const highlightClass = exactMatch
+                    ? 'multiselect-dropdown__mark multiselect-dropdown__mark--selected'
+                    : 'multiselect-dropdown__mark';
 
                   const optionText = this._searchValue
-                    ? option.text.replace(regex, (str) => {
-                        const classes = exactMatch
-                          ? 'multiselect-dropdown__mark multiselect-dropdown__mark--selected'
-                          : 'multiselect-dropdown__mark';
-
-                        return `<mark class="${classes}">${str}</mark>`;
-                      })
-                    : option.text;
+                    ? highlightTextMatches(option.text, regex, highlightClass)
+                    : document.createTextNode(option.text);
 
                   const isSelected = this._pendingOptions.includes(option);
                   return html`
@@ -582,9 +579,7 @@ export class PharosMultiselectDropdown extends ScopedRegistryMixin(FormMixin(For
                       >
                         ${this._renderCheckboxIcon(isSelected)}
                       </div>
-                      <div class="multiselect-dropdown__option-label">
-                        ${unsafeHTML(optionText)}
-                      </div>
+                      <div class="multiselect-dropdown__option-label">${optionText}</div>
                     </li>
                   `;
                 })

--- a/packages/pharos/src/utils/highlightTextMatches.ts
+++ b/packages/pharos/src/utils/highlightTextMatches.ts
@@ -1,0 +1,39 @@
+/**
+ * Highlights text matches in a string by wrapping them in mark elements
+ *
+ * @param text - The text to search
+ * @param regex - The pattern to match and highlight
+ * @param markClassName - CSS class(es) to apply to the mark elements
+ * @returns DocumentFragment with text nodes and optionally mark elements for matches
+ */
+export function highlightTextMatches(
+  text: string,
+  regex: RegExp,
+  className: string
+): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  let lastIndex = 0;
+
+  text.replace(regex, (match, offset) => {
+    // Add text before match
+    if (offset > lastIndex) {
+      fragment.appendChild(document.createTextNode(text.slice(lastIndex, offset)));
+    }
+
+    // Add mark element around matches
+    const mark = document.createElement('mark');
+    mark.className = className;
+    mark.textContent = match;
+    fragment.appendChild(mark);
+
+    lastIndex = offset + match.length;
+    return match;
+  });
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+  }
+
+  return fragment;
+}


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [X] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?

**What does this change address?**
Streamlines some duplicated code.

**How does this change work?**
Extracts the text highlighting logic that was previously duplicated between the combobox and multi-select dropdown components into a shared helper


