### PR TITLE
Prevent error state for collection variant image card from overflowing its container

### DIFF
--- a/.changeset/short-days-arrive.md
+++ b/.changeset/short-days-arrive.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix display issue with error placeholder in collection image cards

--- a/packages/pharos/src/components/image-card/pharos-image-card.scss
+++ b/packages/pharos/src/components/image-card/pharos-image-card.scss
@@ -166,6 +166,8 @@ slot[name='image']::slotted(img) {
 
 .card__image--collection {
   cursor: pointer;
+  display: grid;
+  align-self: end;
 }
 
 .card__image--collection-container {
@@ -224,8 +226,8 @@ slot[name='image']::slotted(img) {
 
 .card__svg {
   display: block;
-  height: 100%;
   width: 100%;
+  grid-area: 1 / 1;
 }
 
 .card__checkbox--subtle {


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [X] Changeset added?

**What does this change address?**
Closes #1150 

**How does this change work?**
In #1145 we removed the `display:grid` from the image card component to fix issues with images displaying in Firefox. However, this caused the collection image card error to overflow its container. This update restores the `display:grid` to the collection image card variant, and fixes the original Firefox issue with an alternative fix by setting `grid-area` on the svg element.

**Additional context**
For some reason  the original Firefox PR didn't flag the UI changes in Chromatic, so I we should will be sure to examine it manually to verify the fix