### PR TITLE
Update github actions permission settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
   release:


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
This fixes some permission errors in the release workflow by granting the workflow write access to the repository contents and pull requests. Without it the GitHub Actions bot was unable to push commits and branches, resulting in 403 errors during releases: https://github.com/ithaka/pharos/actions/runs/22102014749/job/63873988832

**How does this change work?**
It adds `contents: write` and `pull-requests: write` to the workflow’s permissions, enabling GITHUB_TOKEN to push commits, create branches, update files, and open PRs as needed for the release process.

**Additional context**
This follows up #1171