### PR TITLE
Add context7 validation key to claim library

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/ithaka/pharos",
+  "public_key": "pk_1tsHCvoY9ljabfypPOHK0"
+}


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [X] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
[Context7](https://context7.com/) is a service that helps provide current documentation for LLMs and AI code editors. Pharos is currently available as its open source, but there are some things we could do to improve the experience. To do that ITHAKA needs to "Claim ownership" of the library, by adding a small verification key to the project.

**How does this change work?**
Adds a public key to a configuration file, allowing ITHAKA to claim ownership of the library in the context7 UI.

**Additional context**
It looks like we will also be able to use this file to maintain an IAC configuration moving forward, which is nice
