### PR TITLE
Add full width option to radio and checkbox components

### DIFF
--- a/.changeset/tiny-clubs-behave.md
+++ b/.changeset/tiny-clubs-behave.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': minor
+---
+
+Add full-width attribute to radio and checkbox components, which makes them fill their parent container. Default radio-group and checkbox-group width to 100%

--- a/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.scss
+++ b/packages/pharos/src/components/checkbox-group/pharos-checkbox-group.scss
@@ -6,6 +6,7 @@
 .checkbox-group {
   border: 0;
   padding: 0;
+  width: 100%;
 }
 
 .checkbox-group__checkboxes {

--- a/packages/pharos/src/components/checkbox/PharosCheckbox.react.stories.tsx
+++ b/packages/pharos/src/components/checkbox/PharosCheckbox.react.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from 'storybook/actions';
 
-import { PharosCheckbox, PharosLink } from '../../react-components';
+import { PharosCheckbox, PharosCheckboxGroup, PharosLink } from '../../react-components';
 import { defaultArgs, type ComponentArgs, type StoryArgs } from './storyArgs';
 import { configureDocsPage } from '../../utils/_storybook/docsPageConfig';
 import { PharosContext } from '../../utils/PharosContext';
@@ -120,6 +120,65 @@ export const Validity: Story = {
     invalidated: true,
     message: 'This field is required, please make a selection',
   },
+};
+
+export const FullWidth: Story = {
+  render: () => (
+    <>
+      <style>{`
+        .full-width-styled-example [data-pharos-component='PharosCheckbox'] {
+          box-sizing: border-box;
+          padding: var(--pharos-spacing-one-half-x, 0.5rem);
+          border: 1px solid var(--pharos-color-marble-gray-80, #c3c5c8);
+          border-radius: var(--pharos-radius-base, 4px);
+        }
+        /* When a checkbox is checked, style it like an info alert */
+        .full-width-styled-example [data-pharos-component='PharosCheckbox'][checked] {
+          background-color: var(--pharos-alert-color-background-info);
+          border-color: var(--pharos-alert-color-border-info);
+        }
+      `}</style>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '3rem' }}>
+        <PharosCheckboxGroup
+          style={{
+            width: '480px',
+            border: '1px solid var(--pharos-color-marble-gray-80, #c3c5c8)',
+            padding: 'var(--pharos-spacing-one, 1rem)',
+            borderRadius: 'var(--pharos-radius-base, 4px)',
+          }}
+        >
+          <span slot="legend">Full Width</span>
+          <PharosCheckbox value="email" fullWidth checked>
+            <span slot="label">This is the first choice</span>
+          </PharosCheckbox>
+          <PharosCheckbox value="product" fullWidth>
+            <span slot="label">This is the second choice</span>
+          </PharosCheckbox>
+          <PharosCheckbox value="research" fullWidth>
+            <span slot="label">
+              This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users
+            </span>
+          </PharosCheckbox>
+        </PharosCheckboxGroup>
+        <PharosCheckboxGroup className="full-width-styled-example" style={{ width: '480px' }}>
+          <span slot="legend">Full Width with styles</span>
+          <PharosCheckbox value="email" fullWidth checked>
+            <span slot="label">This is the first choice</span>
+          </PharosCheckbox>
+          <PharosCheckbox value="product" fullWidth>
+            <span slot="label">This is the second choice</span>
+          </PharosCheckbox>
+          <PharosCheckbox value="research" fullWidth>
+            <span slot="label">
+              This is the third choice with a label that is really, really entirely too long and
+              someone should have said something before shipping this to to users
+            </span>
+          </PharosCheckbox>
+        </PharosCheckboxGroup>
+      </div>
+    </>
+  ),
 };
 
 export const IsOnBackground: Story = {

--- a/packages/pharos/src/components/checkbox/PharosCheckbox.react.stories.tsx
+++ b/packages/pharos/src/components/checkbox/PharosCheckbox.react.stories.tsx
@@ -171,8 +171,8 @@ export const FullWidth: Story = {
           </PharosCheckbox>
           <PharosCheckbox value="research" fullWidth>
             <span slot="label">
-              This is the third choice with a label that is really, really entirely too long and
-              someone should have said something before shipping this to to users
+              This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users
             </span>
           </PharosCheckbox>
         </PharosCheckboxGroup>

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.scss
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.scss
@@ -10,6 +10,15 @@
   @include mixins.option-wrapper;
 }
 
+:host([full-width]) {
+  width: 100%;
+}
+
+// Grow the label to fill the row so the entire width is clickable, not just the text
+:host([full-width]) label {
+  flex: 1;
+}
+
 .input__icon {
   display: block;
   cursor: pointer;

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.test.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.test.ts
@@ -284,6 +284,28 @@ describe('pharos-checkbox', () => {
     expect(clickSpy.callCount).to.equal(1);
   });
 
+  it('stretches to fill its container when full-width is set', async () => {
+    const parentNode = document.createElement('div');
+    parentNode.style.width = '400px';
+    component = await fixture(
+      html`<test-pharos-checkbox full-width
+        ><span slot="label">test checkbox</span></test-pharos-checkbox
+      >`,
+      { parentNode }
+    );
+    expect(getComputedStyle(component).width).to.equal('400px');
+  });
+
+  it('does not stretch to fill its container by default', async () => {
+    const parentNode = document.createElement('div');
+    parentNode.style.width = '400px';
+    component = await fixture(
+      html`<test-pharos-checkbox><span slot="label">test checkbox</span></test-pharos-checkbox>`,
+      { parentNode }
+    );
+    expect(getComputedStyle(component).width).to.not.equal('400px');
+  });
+
   it('resets checked when the form is reset', async () => {
     const parentNode = document.createElement('form');
     parentNode.setAttribute('name', 'my-form');

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.ts
@@ -52,6 +52,13 @@ export class PharosCheckbox extends FormMixin(FormElement) {
   @property({ type: Boolean, reflect: true })
   public isOnBackground = false;
 
+  /**
+   * Stretches the checkbox to fill the width of its container
+   * @attr full-width
+   */
+  @property({ type: Boolean, reflect: true })
+  public fullWidth = false;
+
   @query('#checkbox-element')
   private _checkbox!: HTMLInputElement;
 

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.wc.stories.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.wc.stories.ts
@@ -109,6 +109,57 @@ export const Validity: Story = {
   },
 };
 
+export const FullWidth: Story = {
+  render: () =>
+    html` <style>
+        .full-width-styled-example storybook-pharos-checkbox {
+          box-sizing: border-box;
+          padding: var(--pharos-spacing-one-half-x, 0.5rem);
+          border: 1px solid var(--pharos-color-marble-gray-80, #c3c5c8);
+          border-radius: var(--pharos-radius-base, 4px);
+        }
+        /* When a checkbox is checked, style it like an info alert */
+        .full-width-styled-example storybook-pharos-checkbox[checked] {
+          background-color: var(--pharos-alert-color-background-info);
+          border-color: var(--pharos-alert-color-border-info);
+        }
+      </style>
+      <div style="display: flex; flex-direction: column; gap: 3rem;">
+        <storybook-pharos-checkbox-group
+          style="width: 480px; border: 1px solid var(--pharos-color-marble-gray-80, #c3c5c8); padding: var(--pharos-spacing-one, 1rem); border-radius: var(--pharos-radius-base, 4px);"
+        >
+          <span slot="legend">Full Width</span>
+          <storybook-pharos-checkbox value="email" full-width checked
+            ><span slot="label">This is the first choice</span></storybook-pharos-checkbox
+          >
+          <storybook-pharos-checkbox value="product" full-width
+            ><span slot="label">This is the second choice</span></storybook-pharos-checkbox
+          >
+          <storybook-pharos-checkbox value="research" full-width
+            ><span slot="label"
+              >This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users</span
+            ></storybook-pharos-checkbox
+          >
+        </storybook-pharos-checkbox-group>
+        <storybook-pharos-checkbox-group class="full-width-styled-example" style="width: 480px;">
+          <span slot="legend">Full Width with styles</span>
+          <storybook-pharos-checkbox value="email" full-width checked
+            ><span slot="label">This is the first choice</span></storybook-pharos-checkbox
+          >
+          <storybook-pharos-checkbox value="product" full-width
+            ><span slot="label">This is the second choice</span></storybook-pharos-checkbox
+          >
+          <storybook-pharos-checkbox value="research" full-width
+            ><span slot="label"
+              >This is the third choice with a label that is really, really entirely too long and
+              someone should have said something before shipping this to to users</span
+            ></storybook-pharos-checkbox
+          >
+        </storybook-pharos-checkbox-group>
+      </div>`,
+};
+
 export const IsOnBackground: Story = {
   name: 'On background',
   render: () => html`

--- a/packages/pharos/src/components/checkbox/pharos-checkbox.wc.stories.ts
+++ b/packages/pharos/src/components/checkbox/pharos-checkbox.wc.stories.ts
@@ -152,8 +152,8 @@ export const FullWidth: Story = {
           >
           <storybook-pharos-checkbox value="research" full-width
             ><span slot="label"
-              >This is the third choice with a label that is really, really entirely too long and
-              someone should have said something before shipping this to to users</span
+              >This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users</span
             ></storybook-pharos-checkbox
           >
         </storybook-pharos-checkbox-group>

--- a/packages/pharos/src/components/radio-button/PharosRadioButton.react.stories.tsx
+++ b/packages/pharos/src/components/radio-button/PharosRadioButton.react.stories.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { action } from 'storybook/actions';
 
-import { PharosRadioButton, PharosLink } from '../../react-components';
+import { PharosRadioButton, PharosRadioGroup, PharosLink } from '../../react-components';
 import { configureDocsPage } from '../../utils/_storybook/docsPageConfig';
 import { defaultArgs, type ComponentArgs, type StoryArgs } from './storyArgs';
 import { PharosContext } from '../../utils/PharosContext';
@@ -122,4 +122,68 @@ export const Validity: Story = {
     required: true,
     message: 'This field is required, please make a selection',
   },
+};
+
+export const FullWidth: Story = {
+  render: () => (
+    <>
+      <style>{`
+        .full-width-styled-example [data-pharos-component='PharosRadioButton'] {
+          box-sizing: border-box;
+          padding: var(--pharos-spacing-one-half-x, 0.5rem);
+          border: 1px solid var(--pharos-color-marble-gray-80, #c3c5c8);
+          border-radius: var(--pharos-radius-base, 4px);
+        }
+        /* When a radio button is checked, style it like an info alert */
+        .full-width-styled-example [data-pharos-component='PharosRadioButton'][checked] {
+          background-color: var(--pharos-alert-color-background-info);
+          border-color: var(--pharos-alert-color-border-info);
+        }
+      `}</style>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '3rem' }}>
+        <PharosRadioGroup
+          name="full-width-example"
+          style={{
+            width: '480px',
+            border: '1px solid var(--pharos-color-marble-gray-80, #c3c5c8)',
+            padding: 'var(--pharos-spacing-one, 1rem)',
+            borderRadius: 'var(--pharos-radius-base, 4px)',
+          }}
+        >
+          <span slot="legend">Full Width</span>
+          <PharosRadioButton value="first" fullWidth checked>
+            <span slot="label">This is the first choice</span>
+          </PharosRadioButton>
+          <PharosRadioButton value="second" fullWidth>
+            <span slot="label">This is the second choice</span>
+          </PharosRadioButton>
+          <PharosRadioButton value="third" fullWidth>
+            <span slot="label">
+              This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users
+            </span>
+          </PharosRadioButton>
+        </PharosRadioGroup>
+        <PharosRadioGroup
+          name="full-width-styled-example"
+          className="full-width-styled-example"
+          style={{ width: '480px' }}
+        >
+          <span slot="legend">Full Width with styles</span>
+          <PharosRadioButton value="first" fullWidth checked>
+            <span slot="label">This is the first choice</span>
+          </PharosRadioButton>
+          <PharosRadioButton value="second" fullWidth>
+            <span slot="label">This is the second choice</span>
+          </PharosRadioButton>
+          <PharosRadioButton value="third" fullWidth>
+            <span slot="label">
+              This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users
+            </span>
+          </PharosRadioButton>
+        </PharosRadioGroup>
+      </div>
+    </>
+  ),
 };

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.scss
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.scss
@@ -10,6 +10,15 @@
   @include mixins.option-wrapper;
 }
 
+:host([full-width]) {
+  width: 100%;
+}
+
+// Grow the label to fill the row so the entire width is clickable, not just the text
+:host([full-width]) label {
+  flex: 1;
+}
+
 .input__icon {
   display: block;
   cursor: pointer;

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.test.ts
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.test.ts
@@ -239,6 +239,30 @@ describe('pharos-radio-button', () => {
     expect(count).to.equal(1);
   });
 
+  it('stretches to fill its container when full-width is set', async () => {
+    const parentNode = document.createElement('div');
+    parentNode.style.width = '400px';
+    component = await fixture(
+      html`<test-pharos-radio-button full-width
+        ><span slot="label">test radio</span></test-pharos-radio-button
+      >`,
+      { parentNode }
+    );
+    expect(getComputedStyle(component).width).to.equal('400px');
+  });
+
+  it('does not stretch to fill its container by default', async () => {
+    const parentNode = document.createElement('div');
+    parentNode.style.width = '400px';
+    component = await fixture(
+      html`<test-pharos-radio-button
+        ><span slot="label">test radio</span></test-pharos-radio-button
+      >`,
+      { parentNode }
+    );
+    expect(getComputedStyle(component).width).to.not.equal('400px');
+  });
+
   it('resets checked when the form is reset', async () => {
     const parentNode = document.createElement('form');
     parentNode.setAttribute('name', 'my-form');

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.ts
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.ts
@@ -33,6 +33,13 @@ export class PharosRadioButton extends FormMixin(FormElement) {
   @property({ type: String, reflect: true })
   public value = '';
 
+  /**
+   * Stretches the radio button to fill the width of its container
+   * @attr full-width
+   */
+  @property({ type: Boolean, reflect: true })
+  public fullWidth = false;
+
   @query('#radio-element')
   private _radio!: HTMLInputElement;
 

--- a/packages/pharos/src/components/radio-button/pharos-radio-button.wc.stories.ts
+++ b/packages/pharos/src/components/radio-button/pharos-radio-button.wc.stories.ts
@@ -102,3 +102,59 @@ export const Validity: Story = {
     message: 'This field is required, please make a selection',
   },
 };
+
+export const FullWidth: Story = {
+  render: () =>
+    html` <style>
+        .full-width-styled-example storybook-pharos-radio-button {
+          box-sizing: border-box;
+          padding: var(--pharos-spacing-one-half-x, 0.5rem);
+          border: 1px solid var(--pharos-color-marble-gray-80, #c3c5c8);
+          border-radius: var(--pharos-radius-base, 4px);
+        }
+        /* When a radio button is checked, style it like an info alert */
+        .full-width-styled-example storybook-pharos-radio-button[checked] {
+          background-color: var(--pharos-alert-color-background-info);
+          border-color: var(--pharos-alert-color-border-info);
+        }
+      </style>
+      <div style="display: flex; flex-direction: column; gap: 3rem;">
+        <storybook-pharos-radio-group
+          name="full-width-example"
+          style="width: 480px; border: 1px solid var(--pharos-color-marble-gray-80, #c3c5c8); padding: var(--pharos-spacing-one, 1rem); border-radius: var(--pharos-radius-base, 4px);"
+        >
+          <span slot="legend">Full Width</span>
+          <storybook-pharos-radio-button value="first" full-width checked
+            ><span slot="label">This is the first choice</span></storybook-pharos-radio-button
+          >
+          <storybook-pharos-radio-button value="second" full-width
+            ><span slot="label">This is the second choice</span></storybook-pharos-radio-button
+          >
+          <storybook-pharos-radio-button value="third" full-width
+            ><span slot="label"
+              >This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users</span
+            ></storybook-pharos-radio-button
+          >
+        </storybook-pharos-radio-group>
+        <storybook-pharos-radio-group
+          name="full-width-styled-example"
+          class="full-width-styled-example"
+          style="width: 480px;"
+        >
+          <span slot="legend">Full Width with styles</span>
+          <storybook-pharos-radio-button value="first" full-width checked
+            ><span slot="label">This is the first choice</span></storybook-pharos-radio-button
+          >
+          <storybook-pharos-radio-button value="second" full-width
+            ><span slot="label">This is the second choice</span></storybook-pharos-radio-button
+          >
+          <storybook-pharos-radio-button value="third" full-width
+            ><span slot="label"
+              >This is the third choice with a label that is just entirely too long and someone
+              should have said something before shipping this to users</span
+            ></storybook-pharos-radio-button
+          >
+        </storybook-pharos-radio-group>
+      </div>`,
+};

--- a/packages/pharos/src/components/radio-group/pharos-radio-group.scss
+++ b/packages/pharos/src/components/radio-group/pharos-radio-group.scss
@@ -6,6 +6,7 @@
 .radio-group {
   border: 0;
   padding: 0;
+  width: 100%;
 }
 
 .radio-group__radios {


### PR DESCRIPTION
**This change:** (check at least one)

- [X] Adds a new feature
- [ ] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Closes #1281 

**How does this change work?**
This adds a new `full-width` attribute to the radio and checkbox components, which causes their labels to expand the full width of their container when provided. This allows adding additional styling to the checkbox host elements themselves, to denote selected state with additional visual changes.

**Additional context**
One side effect of this change I want to call out is it changes the default for the checkbox group and radio group inner containers to have a full width of 100%. There's a slight chance this could cause downstream issues, although since they don't provide any styling, I think it should be okay, but I wanted to call it out in case anyone has concerns. We could add "full-width" attributes to those components as well if there are concerns, but I wondered if that might be overkill

**Sceenshot**
<img width="528" height="250" alt="Screenshot 2026-05-29 at 3 48 11 PM" src="https://github.com/user-attachments/assets/f944d7e7-f430-4065-9626-8631bebcf301" />

