### PR TITLE
Tune Github Actions performance settings

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,6 +17,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic:
     name: Chromatic

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -21,6 +21,7 @@ jobs:
   chromatic:
     name: Chromatic
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout Repo (Push)
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     if: github.repository == 'ithaka/pharos'
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   size:
     runs-on: ubuntu-latest

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   size:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       CI_JOB_NUMBER: 1
     steps:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,6 +10,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
 
@@ -41,6 +42,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,11 +72,15 @@ jobs:
       - name: Install Dependencies
         run: yarn --check-cache --immutable
 
-      - name: Install Browsers
-        run: npx playwright install
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Install Browsers Dependencies
-        run: npx playwright install-deps
+      - name: Install Browsers
+        run: npx playwright install --with-deps chromium firefox webkit # --with-deps needed as OS libs aren't cached just the browsers
 
       - name: Test
         run: yarn test

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [X] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [ ] Test suite(s) passing?
- [ ] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Closes #1292 

**How does this change work?**
This makes three changes to our configuration:

**Sets timeout-minutes**
This is probably the most important one, it updates the jobs from the default timeout of 6 hours to something more resonable.

I wasn't too picky here, since it is just to prevent things spinning for longer then makes sense:
- I grabbed some run history, calculate the p90, then doubled it and rounded to the nearest 5 minutes.
- I excluded our recent 6 hour long jobs so they didn't skew the results.
- I also made the release job 30 minutes, just as a safe guard since that would be more detrimental if it timeout out half-way through a release.

| Workflow | Job | Data Range | Runs | Excluded (>60m) | p90 Duration | Current `timeout-minutes` |
|----------|-----|------------|------|-----------------|--------------|---------------------------|
| `verify.yml` | Lint | 2026-04-27 → 2026-06-05 | 36 | 0 | 1.8m | 5 |
| `verify.yml` | Test | 2026-04-27 → 2026-06-05 | 28 | 8 | 10.5m | 20 |
| `chromatic.yml` | Chromatic | 2026-04-27 → 2026-06-05 | 35 | 0 | 2.0m | 5 |
| `size-limit.yml` | size | 2026-04-27 → 2026-06-05 | 31 | 0 | 2.6m | 5 |
| `release.yml` | Release | 2025-06-09 → 2026-04-22 | 43 | 0 | 1.7m | 30 |

**Sets concurrency limits**
I also added concurrency control to the verify, chromatic, and size-limit workflows. It's grouped per `ref`, so if someone pushes up a commit, kicks off the pipelines, and then before they complete pushes up another commit, it'll cancel the previous run. This should save us some resources because we only really care about the latest run in these cases.

**Caches playwright browsers**
I also added a cache for the Playwright browsers. This way instead of re-downloading the browsers every time it runs, it will cache them based on the version. So subsequent runs can use the cached versions. Honestly this only saves ~10 seconds in the run I tested it with because it looks to take almost as long to pull them from the cache as download them, but I thought we could try it for a while and see.


