### PR TITLE
fix(dropdown-menu): remove curly braces around a11y-hidden attribute value

### DIFF
--- a/.changeset/true-tools-deny.md
+++ b/.changeset/true-tools-deny.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Fix `a11y-hidden` attribute for icons within dropdown menu items

--- a/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
+++ b/packages/pharos/src/components/dropdown-menu/pharos-dropdown-menu-item.ts
@@ -129,7 +129,7 @@ export class PharosDropdownMenuItem extends ScopedRegistryMixin(FocusMixin(Pharo
         <pharos-icon
           class="dropdown-menu-item__icon"
           name=${this.icon}
-          a11y-hidden="{true}"
+          a11y-hidden="true"
         ></pharos-icon>
       `;
     }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [X] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
We were seeing many noisy Sentry alerts because of the pharos error message
> All icons must have an accessible title (a11y-title) or be marked as hidden to assistive technology (a11y-hidden)

**How does this change work?**
Remove curly braces that likely were causing this error message to be emitted

**Additional context**
