### PR TITLE
Correctly throw error when un-selectable image card is marked as selected

### DIFF
--- a/.changeset/thirty-poems-cough.md
+++ b/.changeset/thirty-poems-cough.md
@@ -2,4 +2,4 @@
 '@ithaka/pharos': patch
 ---
 
-Corretly throw an error when a non-selectable image card is marked as selected
+Correctly throw an error when a non-selectable image card is marked as selected

--- a/.changeset/thirty-poems-cough.md
+++ b/.changeset/thirty-poems-cough.md
@@ -1,0 +1,5 @@
+---
+'@ithaka/pharos': patch
+---
+
+Corretly throw an error when a non-selectable image card is marked as selected

--- a/packages/pharos/src/components/image-card/pharos-image-card.test.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.test.ts
@@ -177,10 +177,7 @@ describe('pharos-image-card', () => {
     );
   });
 
-  // This test was discovered to be silently failing as part of https://github.com/ithaka/pharos/issues/1009
-  // Bug filed here https://github.com/ithaka/pharos/issues/1331
-  // We can un-skip this once that is resolved
-  it.skip('throws an error when using the selected prop is used with a non-selectable variant', async () => {
+  it('throws an error when using the selected prop is used with a non-selectable variant', async () => {
     const error = await errorFixture(html`
       <test-pharos-image-card
         title="Card Title"

--- a/packages/pharos/src/components/image-card/pharos-image-card.ts
+++ b/packages/pharos/src/components/image-card/pharos-image-card.ts
@@ -20,11 +20,7 @@ import { PharosButton } from '../button/pharos-button';
 import { PharosCheckbox } from '../checkbox/pharos-checkbox';
 
 export type ImageCardVariant =
-  | 'base'
-  | 'collection'
-  | 'promotional'
-  | 'selectable'
-  | 'selectable-collection';
+  'base' | 'collection' | 'promotional' | 'selectable' | 'selectable-collection';
 
 const VARIANTS = [
   'base',
@@ -178,9 +174,9 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
       );
     }
 
-    if (this.selected && this._isSelectable()) {
+    if (this._isSelected && !this._isSelectable()) {
       throw new Error(
-        `Image card with variant type ${this.variant} cannot be selected. Only the selectable variants can be selected.}`
+        `Image card with variant type ${this.variant} cannot be selected. Only the selectable variants can be selected.`
       );
     }
   }
@@ -439,15 +435,17 @@ export class PharosImageCard extends ScopedRegistryMixin(FocusMixin(PharosElemen
           ?indicate-visited=${this.indicateLinkVisited}
           @click=${this._cardToggleSelect}
           a11y-label=${ifDefined(this.imageLinkLabel)}
-          >${this.title && this.title.trim() !== ''
-            ? html`<pharos-heading
-                class="card__heading"
-                preset=${this._chooseHeadingPreset()}
-                level=${this.headingLevel || DEFAULT_HEADING_LEVEL}
-                no-margin
-                >${this.title}</pharos-heading
-              >`
-            : html`<slot name="title"></slot>`}
+          >${
+            this.title && this.title.trim() !== ''
+              ? html`<pharos-heading
+                  class="card__heading"
+                  preset=${this._chooseHeadingPreset()}
+                  level=${this.headingLevel || DEFAULT_HEADING_LEVEL}
+                  no-margin
+                  >${this.title}</pharos-heading
+                >`
+              : html`<slot name="title"></slot>`
+          }
         </pharos-link>`
       : nothing;
   }


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [x] Fixes a bug
- [ ] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [x] Changeset added?

**What does this change address?**
Fixes #1331 

**How does this change work?**
The image card has several variants which can be selected: (https://pharos.jstor.org/storybook/?path=/story/web-components_components-image-card--selectable)

This can be set programmatically by passing a `selected` attribute to the web component. The component has some logic that if `selected` was set on an image card but it was not one of the variants which allowed for selection, it should throw an error.

There was a bug in the logic, while the HTML attribute is `selected`, the Lit property that maps to it is  `_isSelected`, and the code was checking the wrong thing. In addition, the logic was inverse so if it was working it would have thrown errors for selectable variants when they were selected 🙃 .

This fixes the logic so the error will be thrown as originally intended, and re-enables the test that exercises this logic.
