### PR TITLE
chore(infra): group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      non-major-security:
+        applies-to: 'security-updates'
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     ignore:
       # ithaka/pharos#856
       - dependency-name: 'react'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,6 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-      non-major-security:
-        applies-to: 'security-updates'
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
     ignore:
       # ithaka/pharos#856
       - dependency-name: 'react'
@@ -32,3 +25,15 @@ updates:
       - dependency-name: '@types/react-dom'
         update-types:
           - 'version-update:semver-major'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    groups:
+      non-major-security:
+        applies-to: 'security-updates'
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      non-major-security:
+        applies-to: 'security-updates'
+        patterns:
+          - '*'
     ignore:
       # ithaka/pharos#856
       - dependency-name: 'react'
@@ -25,15 +29,3 @@ updates:
       - dependency-name: '@types/react-dom'
         update-types:
           - 'version-update:semver-major'
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    groups:
-      non-major-security:
-        applies-to: 'security-updates'
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [x] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [x] No

**Is the:** (complete all)

- [x] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [x] Test suite(s) passing?
- [x] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**

Dependabot groups minor and patch updates for dependencies with regular version updates. It doesn't do the same for security updates. Occasionally, after merging a pull request that either pulls in new dependency versions or loosens a prior constraint on the compatible dependency version ranges, a flurry of pull requests opens in quick succession. These are somewhat tedious to manage and each use up infrastructure time as well.

**How does this change work?**

Tell Dependabot to also group security updates that are minor and patch versions.

**Additional context**

This does require both rulesets; one ruleset can't apply to both regular and security updates.
