### PR TITLE
Add DOM cleanup to tooltip test suite

### DIFF
--- a/packages/pharos/package.json
+++ b/packages/pharos/package.json
@@ -79,7 +79,7 @@
     "chokidar": "^5.0.0",
     "globby": "^16.2.2",
     "minify-html-literals": "^1.3.5",
-    "playwright": "^1.61.1",
+    "playwright": "^1.62.1",
     "postcss": "^8.5.25",
     "prettier": "^3.9.6",
     "react": "^18.3.1",

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.test.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.test.ts
@@ -16,6 +16,9 @@ describe('pharos-tooltip', () => {
     trigger.setAttribute('id', id);
     trigger.setAttribute('data-tooltip-id', tooltipId);
     trigger.textContent = 'I am a button';
+    // Keep the trigger clear of the headless cursor at (0, 0), which would
+    // otherwise fire an unwanted mouseenter.
+    trigger.style.margin = '50px';
     document.body.appendChild(trigger);
     return trigger;
   };

--- a/packages/pharos/src/components/tooltip/pharos-tooltip.test.ts
+++ b/packages/pharos/src/components/tooltip/pharos-tooltip.test.ts
@@ -32,9 +32,8 @@ describe('pharos-tooltip', () => {
     `);
   });
 
-  afterEach(async () => {
-    trigger.remove();
-    secondTrigger.remove();
+  afterEach(() => {
+    document.body.replaceChildren();
   });
 
   it('is accessible', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4922,7 +4922,7 @@ __metadata:
     globby: "npm:^16.2.2"
     lit: "npm:^3.3.3"
     minify-html-literals: "npm:^1.3.5"
-    playwright: "npm:^1.61.1"
+    playwright: "npm:^1.62.1"
     postcss: "npm:^8.5.25"
     prettier: "npm:^3.9.6"
     react: "npm:^18.3.1"
@@ -22030,7 +22030,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.14.0, playwright@npm:^1.61.1":
+"playwright-core@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright-core@npm:1.62.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/a37d0f03bb73364cfd0eba704c4b3359b609c4779ae2649a88d8e2b3a29c7357dfcc58bdcf0cb68ddffdef7687abf78902c8356e89f189682c7e19be38e108f0
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.14.0":
   version: 1.61.1
   resolution: "playwright@npm:1.61.1"
   dependencies:
@@ -22042,6 +22051,21 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/cea1bc4d2a64ec3ef683891606774029da7b8a8036ed98332565cec2f8e89549ca1fab9a89fbfba4e08e27e0d7e7d148031e965af66d5ff97bb3c34058cfcad0
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.62.1":
+  version: 1.62.1
+  resolution: "playwright@npm:1.62.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.62.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/4d3522cd46325f50c46f8874d31f70d036f6983228a9f8b9d68fc249e4c17464edcd97cc4adfbb24e712d1829c1386d3bc24e17f58a1ced94e7c423300c21845
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**This change:** (check at least one)

- [ ] Adds a new feature
- [ ] Fixes a bug
- [X] Improves maintainability
- [ ] Improves documentation
- [ ] Is a release activity

**Is this a breaking change?** (check one)

- [ ] Yes
- [X] No

**Is the:** (complete all)

- [X] Title of this pull request clear, concise, and indicative of the issue number it addresses, if any?
- [X] Test suite(s) passing?
- [X] Code coverage maximal?
- [ ] Changeset added?

**What does this change address?**
Closes #1382 

**How does this change work?**
This updates the `afterEach` block to clean up the document body after each test, to prevent lingering DOM elements from causing issues with later tests.

